### PR TITLE
make tick relative in range

### DIFF
--- a/paibox/backend/segment_utils.py
+++ b/paibox/backend/segment_utils.py
@@ -334,13 +334,13 @@ def aligned_coords(
 
     if tr_offset_stop == tr_offset_start:
         axon_coords = [
-            AxonCoord(tr_base + tr_offset_start, (addr_offset + addr) * _addr_interval)
+            AxonCoord.build(tr_base + tr_offset_start, (addr_offset + addr) * _addr_interval)
             for addr in range(addr_start, addr_stop)
         ]
     else:
         # First row: addr_start -> end
         acoords_first = [
-            AxonCoord(tr_base + tr_offset_start, (addr_offset + addr) * _addr_interval)
+            AxonCoord.build(tr_base + tr_offset_start, (addr_offset + addr) * _addr_interval)
             for addr in range(addr_start, addr_width)
         ]
 
@@ -348,13 +348,13 @@ def aligned_coords(
         acoords_mid = []
         for tr in range(tr_offset_start + 1, tr_offset_stop):
             acoords_mid.extend(
-                AxonCoord(tr_base + tr, (addr_offset + addr) * _addr_interval)
+                AxonCoord.build(tr_base + tr, (addr_offset + addr) * _addr_interval)
                 for addr in range(addr_width)
             )
 
         # Last row: start -> addr_stop
         acoords_last = [
-            AxonCoord(tr_base + tr_offset_stop, (addr_offset + addr) * _addr_interval)
+            AxonCoord.build(tr_base + tr_offset_stop, (addr_offset + addr) * _addr_interval)
             for addr in range(addr_stop)
         ]
 

--- a/paibox/backend/segment_utils.py
+++ b/paibox/backend/segment_utils.py
@@ -334,13 +334,17 @@ def aligned_coords(
 
     if tr_offset_stop == tr_offset_start:
         axon_coords = [
-            AxonCoord.build(tr_base + tr_offset_start, (addr_offset + addr) * _addr_interval)
+            AxonCoord.build(
+                tr_base + tr_offset_start, (addr_offset + addr) * _addr_interval
+            )
             for addr in range(addr_start, addr_stop)
         ]
     else:
         # First row: addr_start -> end
         acoords_first = [
-            AxonCoord.build(tr_base + tr_offset_start, (addr_offset + addr) * _addr_interval)
+            AxonCoord.build(
+                tr_base + tr_offset_start, (addr_offset + addr) * _addr_interval
+            )
             for addr in range(addr_start, addr_width)
         ]
 
@@ -354,7 +358,9 @@ def aligned_coords(
 
         # Last row: start -> addr_stop
         acoords_last = [
-            AxonCoord.build(tr_base + tr_offset_stop, (addr_offset + addr) * _addr_interval)
+            AxonCoord.build(
+                tr_base + tr_offset_stop, (addr_offset + addr) * _addr_interval
+            )
             for addr in range(addr_stop)
         ]
 

--- a/paibox/backend/types.py
+++ b/paibox/backend/types.py
@@ -13,7 +13,7 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-from paicorelib import Coord, CoreMode
+from paicorelib import Coord, CoreMode, HwConfig
 from paicorelib import ReplicationId as RId
 
 from paibox.base import PAIBoxObject
@@ -242,6 +242,10 @@ class AxonCoord(NamedTuple):
     tick_relative: int
     addr_axon: int
 
+    @classmethod
+    def build(cls, tick_relative: int, addr_axon: int) -> "AxonCoord":
+        tick_relative = tick_relative % HwConfig.N_TIMESLOT_MAX
+        return cls(tick_relative, addr_axon)
 
 class AxonSegment(NamedTuple):
     n_axon: int

--- a/paibox/backend/types.py
+++ b/paibox/backend/types.py
@@ -247,6 +247,7 @@ class AxonCoord(NamedTuple):
         tick_relative = tick_relative % HwConfig.N_TIMESLOT_MAX
         return cls(tick_relative, addr_axon)
 
+
 class AxonSegment(NamedTuple):
     n_axon: int
     """#N of axons."""


### PR DESCRIPTION
我和郝昭阳讨论后，对tick relative循环设置的分工是，后端只需要按照delay和n_dest_timeslot设置正确的目标地址即可。由于timeslot循环放置带来的数据覆盖问题由前端来解决。