### PR TITLE
Revert(twe): revert pr#146 about twe

### DIFF
--- a/paibox/components/functional.py
+++ b/paibox/components/functional.py
@@ -942,7 +942,7 @@ class LinearSemiFolded(_LinearBase, _SemiFoldedModule):
                 shape=(ich, ih),
                 delay=incoming_flow_format.interval * i + 1,
                 tick_wait_start=self.tick_wait_start,
-                tick_wait_end=twe - incoming_flow_format.interval * i,
+                tick_wait_end=twe,
                 keep_shape=self.keep_shape,
                 name=f"n{i}_{self.name}",
             )
@@ -1088,7 +1088,7 @@ class Conv2dSemiFolded(_SemiFoldedModule):
                 (ic, ih),
                 delay=incoming_flow_format.interval * i + 1,
                 tick_wait_start=self.tick_wait_start,
-                tick_wait_end=twe - incoming_flow_format.interval * i,
+                tick_wait_end=twe,
                 name=f"n{i}_delay_{self.name}",
             )
             n_delays.append(neuron)
@@ -1259,7 +1259,7 @@ class MaxPool2dSemiFolded(_SemiFoldedModule):
                 (cin, ih),
                 delay=incoming_flow_format.interval * i + 1,
                 tick_wait_start=self.tick_wait_start,
-                tick_wait_end=twe - incoming_flow_format.interval * i,
+                tick_wait_end=twe,
                 keep_shape=self.keep_shape,
                 name=f"n{i}_{self.name}",
             )
@@ -1406,7 +1406,7 @@ class AvgPool2dSemiFolded(_SemiFoldedModule):
                 (cin, ih),
                 delay=incoming_flow_format.interval * i + 1,
                 tick_wait_start=self.tick_wait_start,
-                tick_wait_end=twe - incoming_flow_format.interval * i,
+                tick_wait_end=twe,
                 keep_shape=self.keep_shape,
                 name=f"n{i}_{self.name}",
             )


### PR DESCRIPTION
According to the onboard test results, restore the changes to `twe` parameter in #146. After that, after changing the padding of onboard tests 012, 013 & 014 to 0, 013 & 014 are correct but 012 is still wrong. 

> [!WARNING]
> Padding is not currently supported.