### PR TITLE
Feat(graphs): reorganized the building process of networks

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,6 +28,8 @@ jobs:
           - python-version: "3.13"
             os: windows-latest
     runs-on: ${{ matrix.os }}
+    env:
+      CI_ENV: "true"
 
     steps:
       - uses: actions/checkout@v4

--- a/paibox/backend/mapper.py
+++ b/paibox/backend/mapper.py
@@ -169,7 +169,7 @@ class Mapper:
         elif isinstance(multicast_optim, Sequence):
             _mul_optim_nodes = tuple(node.name for node in multicast_optim)
 
-            if any(node not in self.graph._raw_nodes for node in _mul_optim_nodes):
+            if any(node not in self.graph.nodes for node in _mul_optim_nodes):
                 raise ValueError("not all specified nodes are in the graph.")
 
             set_cflag(multicast_optim=True)

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -1593,3 +1593,73 @@ class TestData:
             ),
         ],
     )
+
+    prune_disconn_graph_test_data = ParametrizedTestData(
+        args="graph, start_nodes, expected_graph, disconn_nodes",
+        data=[
+            (
+                {1: [2, 3], 2: [4], 3: [5], 4: [], 5: []},
+                [1],
+                {1: [2, 3], 2: [4], 3: [5], 4: [], 5: []},
+                set(),
+            ),
+            (
+                {
+                    "A": ["B", "C"],
+                    "B": ["C", "D"],
+                    "C": [],
+                    "D": [],
+                    "E": [],
+                    "F": ["G"],
+                    "G": ["F", "H"],
+                    "H": [],
+                    "I": [],
+                },
+                ["A"],
+                {"A": ["B", "C"], "B": ["C", "D"], "C": [], "D": []},
+                {"E", "F", "G", "H", "I"},
+            ),
+            (
+                {
+                    "A": ["B", "C"],
+                    "B": ["C", "D"],
+                    "C": [],
+                    "D": [],
+                    "E": [],
+                    "F": ["G"],
+                    "G": ["F", "H"],
+                    "H": [],
+                    "I": [],
+                },
+                ["A", "G"],
+                {
+                    "A": ["B", "C"],
+                    "B": ["C", "D"],
+                    "C": [],
+                    "D": [],
+                    "F": ["G"],
+                    "G": ["F", "H"],
+                    "H": [],
+                },
+                {"E", "I"},
+            ),
+            (
+                {
+                    "A": ["B", "C"],
+                    "B": ["C", "D"],
+                    "C": [],
+                    "D": [],
+                    "E": [],
+                    "F": ["G"],
+                    "G": ["F", "H"],
+                    "H": [],
+                    "I": [],
+                },
+                # Even if starting from node B, A is connected to B.
+                ["B"],
+                {"A": ["B", "C"], "B": ["C", "D"], "C": [], "D": []},
+                {"E", "F", "G", "H", "I"},
+            ),
+        ],
+        ids=["all_connected", "1_start_node", "2_start_nodes", "start_from_middle"],
+    )

--- a/tests/backend/test_graph_utils.py
+++ b/tests/backend/test_graph_utils.py
@@ -168,6 +168,47 @@ class TestTopoSort:
                 list(iter_toposort(graph))
 
 
+@pytest.mark.parametrize(
+    TestData.prune_disconn_graph_test_data["args"],
+    TestData.prune_disconn_graph_test_data["data"],
+    ids=TestData.prune_disconn_graph_test_data["ids"],  # type: ignore
+)
+def test_prune_disconn_graph(graph, start_nodes, expected_graph, disconn_nodes):
+    new_graph, disconn = prune_disconn_graph(graph, start_nodes, forward_only=False)
+
+    assert set(new_graph.keys()) == set(expected_graph.keys())
+    for node in new_graph:
+        assert set(new_graph[node]) == set(expected_graph[node])
+
+    assert disconn == disconn_nodes
+
+
+def test_prune_disconn_graph_forward_only():
+    graph = {
+        "A": ["B", "C"],
+        "B": ["C", "D"],
+        "C": [],
+        "D": [],
+        "E": [],
+        "F": ["G"],
+        "G": ["F", "H"],
+        "H": [],
+        "I": [],
+    }
+    # If starting from node B with `forward_only=True`, A is dismissed.
+    start_nodes = ["B"]
+    expected_graph = {"B": ["C", "D"], "C": [], "D": []}
+    disconn_nodes = {"A", "E", "F", "G", "H", "I"}
+
+    new_graph, disconn = prune_disconn_graph(graph, start_nodes, forward_only=True)
+
+    assert set(new_graph.keys()) == set(expected_graph.keys())
+    for node in new_graph:
+        assert set(new_graph[node]) == set(expected_graph[node])
+
+    assert disconn == disconn_nodes
+
+
 class TestDAGPathDistance:
     @staticmethod
     def get_longest_path_proto(

--- a/tests/backend/test_graphs.py
+++ b/tests/backend/test_graphs.py
@@ -4,7 +4,6 @@ import pytest
 from paicorelib import HwConfig
 
 import paibox as pb
-from paibox.backend.graphs import PAIGraph
 from paibox.backend.graph_utils import *
 from paibox.backend.graphs import PAIGraph
 from paibox.backend.types import *

--- a/tests/backend/test_mapper.py
+++ b/tests/backend/test_mapper.py
@@ -204,10 +204,11 @@ class TestMapperDeployment:
         net: pb.Network = build_Network_with_container
         mapper: pb.Mapper = get_mapper
         mapper.build(net)
+        assert len(mapper.graph.nodes) == 4
+
         mapper.compile()
 
-        assert len(mapper.graph.nodes.keys()) == 4
-        # Input projectioon is discnnected!
+        # The input node is isolated
         assert len(mapper.graph_info["input"]) == 0
         assert len(mapper.graph_info["output"]) == 1
 

--- a/tests/components/test_functional.py
+++ b/tests/components/test_functional.py
@@ -98,7 +98,7 @@ class TestFunctionalModules:
         mapper.build(net)
         mapper.compile()
 
-        assert len(mapper.graph._raw_nodes) == 4
+        assert len(mapper.graph.nodes) == 4
 
     def test_BitwiseAND(self):
         from tests.shared_networks import FunctionalModule_2to1_Net

--- a/tests/onboard/test_onboard.py
+++ b/tests/onboard/test_onboard.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import numpy as np
@@ -7,6 +8,10 @@ import paibox as pb
 from paibox.components.neuron.base import MetaNeuron
 from paibox.types import NEUOUT_U8_DTYPE, VOLTAGE_DTYPE, NeuOutType, VoltageType
 from tests.components.utils import conv1d_golden
+
+ci_env = os.environ.get("CI_ENV", None) is not None
+pytestmark = pytest.mark.skipif(ci_env, reason="Skipping in CI environment")
+
 
 TEST_DIR = Path(__file__).parent
 DATA_DIR = TEST_DIR / "data"


### PR DESCRIPTION
1. 主要修改了 `PAIGraph` 及 `PAIGraph.build()` 中根据用户输入的网络构建计算图的过程
2. 动了 `PAIGraph` 内几个变量存储数据的含义
3. 添加了针对“未与输入节点连通的子图”的判断与移除，可通过构建参数控制该检查是否开启。由于测试项目中例化的网络可能不是严格地都具有输入节点，因此默认关闭。在生产中可开启
4. 测试ci：在 Actions 中自动测试时，跳过 `onboard` 测试项目，因为这些项目通常手动进行了
