### PR TITLE
Bugfix(NodeSlice): Incorrectly used `is` for comparison

### DIFF
--- a/paibox/backend/placement.py
+++ b/paibox/backend/placement.py
@@ -162,7 +162,7 @@ class CoreBlock(CoreAbstract):
         self, src: SourceSliceType, dest: DestSliceType
     ) -> Optional[EdgeSlice]:
         for syn in self.obj:
-            if syn.source is src and syn.dest is dest:
+            if syn.source == src and syn.dest == dest:
                 return syn
 
         return None


### PR DESCRIPTION
这里修复了一个很严重的bug，在获取coreplacement权重时，需要获取coreblock中指定dest对应的权重。在获取dest对应的权重时，需要通过这块权重的dest和source来寻找对应的edge，在这个过程中的比较不应该使用is而应该使用==，从而调用自定义的nodeslice的__equal__()。
修复前可能无法获取到任何权重信息。