### PR TITLE
feat: implement get_raw_weights for conv, linear and pooling

### DIFF
--- a/docs/paiir_backend_guide.md
+++ b/docs/paiir_backend_guide.md
@@ -70,17 +70,17 @@ graph = compile_to_paiir(model, x, compile_config=cfg, strict=False)
 
 `compile_to_paiir` 完整参数：
 
-| 参数 | 类型 | 说明 |
-|---|---|---|
-| `model` | `nn.Module` | PyTorch 模型 |
-| `*sample_inputs` | `Tensor` | 示例输入（batch_size 必须为 1），用于推断形状和维度 |
-| `tick_duration` | `int \| None` | 全局工作时长，默认 0（常开） |
-| `auto_reset` | `bool \| None` | 工作周期结束后自动复位，默认 True |
-| `tick_overrides` | `dict[str, TickOverride] \| None` | 按节点名指定时序覆盖 |
-| `input_formats` | `dict[str, DataFormat] \| None` | 按 InputNode 名指定输入数据格式 |
-| `compile_config` | `CompileConfig \| None` | 配置对象（关键字参数优先级更高） |
-| `concrete_args` | `dict[str, Any] \| None` | 传递给 `fx.Tracer.trace` 的具体参数 |
-| `strict` | `bool` | True = 遇到不支持的算子时报错；False = 警告并跳过 |
+| 参数             | 类型                              | 说明                                                |
+| ---------------- | --------------------------------- | --------------------------------------------------- |
+| `model`          | `nn.Module`                       | PyTorch 模型                                        |
+| `*sample_inputs` | `Tensor`                          | 示例输入（batch_size 必须为 1），用于推断形状和维度 |
+| `tick_duration`  | `int \| None`                     | 全局工作时长，默认 0（常开）                        |
+| `auto_reset`     | `bool \| None`                    | 工作周期结束后自动复位，默认 True                   |
+| `tick_overrides` | `dict[str, TickOverride] \| None` | 按节点名指定时序覆盖                                |
+| `input_formats`  | `dict[str, DataFormat] \| None`   | 按 InputNode 名指定输入数据格式                     |
+| `compile_config` | `CompileConfig \| None`           | 配置对象（关键字参数优先级更高）                    |
+| `concrete_args`  | `dict[str, Any] \| None`          | 传递给 `fx.Tracer.trace` 的具体参数                 |
+| `strict`         | `bool`                            | True = 遇到不支持的算子时报错；False = 警告并跳过   |
 
 ### 分步编译
 
@@ -282,23 +282,23 @@ params: NeuronParams = op.neuron_params
 
 关键字段：
 
-| 字段 | 类型 | 说明 |
-|---|---|---|
-| `reset_mode` | `RM` | `MODE_NORMAL`（硬复位）/ `MODE_LINEAR`（软复位） |
-| `reset_v` | `float` | 复位电压 |
-| `thres_pos` | `float` | 正阈值 |
-| `thres_neg` | `float` | 负阈值 |
-| `thres_pos_mode` | `ThresholdPosMode` | `FIRE`（触发）/ `CEILING`（截断） |
-| `thres_neg_mode` | `ThresholdNegMode` | `FIRE`（触发）/ `FLOOR`（截断） |
-| `leak_tau` | `int` | 移位指数（正 = 左移放大，负 = 右移衰减） |
-| `leak_v` | `float` | 加性漏电压（含融合后的 bias） |
-| `init_v` | `float` | 初始膜电位 |
-| `output_type` | `OutputType` | 输出类型 |
-| `lateral_inhi` | `LateralInhibitionMode` | 侧抑制 |
-| `leak_multi_sequence` | `LeakMultiComparisonOrder` | 乘性漏执行顺序 |
-| `leak_multi_input` | `LeakMultiInputMode` | 输入是否参与乘性漏 |
-| `leak_multi_mode` | `LeakMultiMode` | 乘性漏模式 |
-| `leak_add_mode` | `LeakAddMode` | 加性漏方向 |
+| 字段                  | 类型                       | 说明                                             |
+| --------------------- | -------------------------- | ------------------------------------------------ |
+| `reset_mode`          | `RM`                       | `MODE_NORMAL`（硬复位）/ `MODE_LINEAR`（软复位） |
+| `reset_v`             | `float`                    | 复位电压                                         |
+| `thres_pos`           | `float`                    | 正阈值                                           |
+| `thres_neg`           | `float`                    | 负阈值                                           |
+| `thres_pos_mode`      | `ThresholdPosMode`         | `FIRE`（触发）/ `CEILING`（截断）                |
+| `thres_neg_mode`      | `ThresholdNegMode`         | `FIRE`（触发）/ `FLOOR`（截断）                  |
+| `leak_tau`            | `int`                      | 移位指数（正 = 左移放大，负 = 右移衰减）         |
+| `leak_v`              | `float`                    | 加性漏电压（含融合后的 bias）                    |
+| `init_v`              | `float`                    | 初始膜电位                                       |
+| `output_type`         | `OutputType`               | 输出类型                                         |
+| `lateral_inhi`        | `LateralInhibitionMode`    | 侧抑制                                           |
+| `leak_multi_sequence` | `LeakMultiComparisonOrder` | 乘性漏执行顺序                                   |
+| `leak_multi_input`    | `LeakMultiInputMode`       | 输入是否参与乘性漏                               |
+| `leak_multi_mode`     | `LeakMultiMode`            | 乘性漏模式                                       |
+| `leak_add_mode`       | `LeakAddMode`              | 加性漏方向                                       |
 
 > **bias 融合**：`SequentialOp` 和 `AccumulateOp` 的 `neuron_params` 已将 Conv/Linear 的 bias 融合到 `leak_v` 中，后端无需额外处理。
 
@@ -555,6 +555,7 @@ class OfflineCoreParams:
 ```
 
 时序参数的寄存器限制：
+
 - `tick_start`: 16-bit 无符号，[0, 65535]
 - `tick_duration`: 32-bit 无符号，[0, 4294967295]
 - `tick_initial`: 16-bit 无符号，[0, 65535]
@@ -595,12 +596,12 @@ class LutData:
 
 输出格式（由激活模块决定）：
 
-| 模式 | 条件 | 输出格式 |
-|---|---|---|
-| SNN | `thres_neg_mode == FIRE` | SIGNED, WIDTH_2BIT（{-1, 0, +1}） |
-| SNN | `thres_neg_mode == FLOOR` | UNSIGNED, WIDTH_1BIT（{0, 1}） |
-| ANN | `output_sign == 1` | SIGNED, WIDTH_8BIT（[-128, 127]） |
-| ANN | `output_sign == 0` | UNSIGNED, WIDTH_8BIT（[0, 255]） |
+| 模式 | 条件                      | 输出格式                          |
+| ---- | ------------------------- | --------------------------------- |
+| SNN  | `thres_neg_mode == FIRE`  | SIGNED, WIDTH_2BIT（{-1, 0, +1}） |
+| SNN  | `thres_neg_mode == FLOOR` | UNSIGNED, WIDTH_1BIT（{0, 1}）    |
+| ANN  | `output_sign == 1`        | SIGNED, WIDTH_8BIT（[-128, 127]） |
+| ANN  | `output_sign == 0`        | UNSIGNED, WIDTH_8BIT（[0, 255]）  |
 
 权重格式：从量化权重的实际值范围推断最窄的 `(DataSign, DataWidth)` 组合。
 

--- a/paibox/_logging/base.py
+++ b/paibox/_logging/base.py
@@ -172,9 +172,7 @@ class PAIBoxLogsFormatter(logging.Formatter):
         record.asctime = self.formatTime(record, "%H:%M:%S")
 
         shortlevel = log_level_to_abbr.get(record.levelname, record.levelname)
-        prefix = (
-            f"[{shortlevel} {record.asctime} {record.lineno}]{record.artifactprefix}"  # type: ignore[attr-defined]
-        )
+        prefix = f"[{shortlevel} {record.asctime} {record.lineno}]{record.artifactprefix}"  # type: ignore[attr-defined]
 
         lines = s.split("\n")
         return "\n".join(f"{prefix} {l}" for l in lines)

--- a/paibox/backendv2/core_config.py
+++ b/paibox/backendv2/core_config.py
@@ -73,7 +73,6 @@ def to_core_reg(
     frontend_conf: Frontend_Core_Config,
     coord: CoordXY,
 ) -> OfflineCoreRegV2:
-
     core_reg = OfflineCoreRegV2(
         name=f"core_reg_at_({coord.x},{coord.y})",
         snn_ann=frontend_conf.snn_ann,

--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -6,17 +6,12 @@ from typing import Optional
 import numpy as np
 from paicorelib import (
     FRAME_DTYPE,
-    LUT_ACTIVATION_DTYPE,
-    LUT_POTENTIAL_DTYPE,
     CoordXY,
     DataWidth,
     FrameArrayType,
-    LUTActivationType,
-    LUTPotentialType,
     NeuronType,
     OfflineCoreRegV2,
     OfflineFrameGenV2,
-    SNNMode,
     find_coordxy_shortest_path,
 )
 

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -4,7 +4,6 @@ import os
 from typing import TextIO
 
 from paicorelib import LCN_EX, AERPacketZXYCopy, CoordXY, FrameArrayType
-from torch.fx import GraphModule
 
 from paibox.paiir import PAIIRGraph
 
@@ -22,6 +21,7 @@ def export_single_framearray(
         hex_str = "_".join(hex_str[i : i + 4] for i in range(0, 16, 4))
         file.write(f"{prefix}{hex_str}\n")
 
+
 def export_framearray_to_bit(
     frame_array: FrameArrayType, file: TextIO, prefix: str = ""
 ) -> None:
@@ -33,8 +33,8 @@ def export_framearray_to_bit(
         high_bin = f"{high32:032b}"
         low_bin = f"{low32:032b}"
         # 每16位加下划线，可读性更好
-        high_bin = "_".join(high_bin[i:i+16] for i in range(0, 32, 16))
-        low_bin = "_".join(low_bin[i:i+16] for i in range(0, 32, 16))
+        high_bin = "_".join(high_bin[i : i + 16] for i in range(0, 32, 16))
+        low_bin = "_".join(low_bin[i : i + 16] for i in range(0, 32, 16))
         # 输出到一行
         file.write(f"{prefix}0b{high_bin},0b{low_bin},\n")
 
@@ -105,9 +105,15 @@ class Mapper:
             open(frame2_path, "w") as frame2_file,
             open(frame3_path, "w") as frame3_file,
         ):
-            frame1_file.write("volatile unsigned int config_frame1[] __attribute__((section(\".large_const_data\"))) ={\n")
-            frame2_file.write("volatile unsigned int config_frame2[] __attribute__((section(\".large_const_data\"))) ={\n")
-            frame3_file.write("volatile unsigned int config_frame3[] __attribute__((section(\".large_const_data\"))) ={\n")
+            frame1_file.write(
+                'volatile unsigned int config_frame1[] __attribute__((section(".large_const_data"))) ={\n'
+            )
+            frame2_file.write(
+                'volatile unsigned int config_frame2[] __attribute__((section(".large_const_data"))) ={\n'
+            )
+            frame3_file.write(
+                'volatile unsigned int config_frame3[] __attribute__((section(".large_const_data"))) ={\n'
+            )
             for rg in self.routing_groups:
                 for core_placement in rg.core_placements:
                     core_frame_type1, core_frame_type2, core_frame_type3 = (

--- a/paibox/backendv2/op_node.py
+++ b/paibox/backendv2/op_node.py
@@ -2,31 +2,24 @@ from typing import Optional
 
 import torch
 from paicorelib import (
-    DataSign,
-    DataWidth,
     OfflineNeuFullAttrsV2Part2,
     OutputType,
-    PoolingMode,
     SNNMode,
     WeightCompressType,
-    ZeroOutputMode,
 )
-from torch import nn, Tensor
+from torch import Tensor, nn
 
-from ..fx_converter.clac_params import NeuV2ClacParams, OfflineCoreV2CalcParams
-from ..fx_converter.core_op import BaseCoreOp
 from ..paiir import (
+    AccumulateOp,
     InputNode,
     LutData,
     OfflineCoreOp,
     OfflineCoreParams,
     OutputNode,
     PAIIRGraph,
-    PAIIRNode,
     SequentialOp,
-    AccumulateOp,
+    StandaloneActOp,
     StandaloneCompOp,
-    StandaloneActOp
 )
 from .core_config import Frontend_Core_Config
 
@@ -97,13 +90,12 @@ class CoreOpNode:
         self.predecessors: list[CoreOpNode | InNode] = []
         self.comps: list[Optional[nn.Module]] = []
         self.weights: list[Optional[Tensor]] = []
-        
+
         self.frontend_core_config: Frontend_Core_Config = get_frontend_core_conf(
             raw_node.core_params, raw_node.lut_data
         )
-        
-    
-    def set_comps_and_weights(self)-> None:
+
+    def set_comps_and_weights(self) -> None:
         """Set self.comps based on the type of raw_node."""
         if isinstance(self.raw_node, SequentialOp):
             self.comps = [self.raw_node.comp]
@@ -121,8 +113,6 @@ class CoreOpNode:
             self.weights = list(weights)
         else:
             self.weights = [None]
-        
-        
 
     def __hash__(self) -> int:
         return hash(id(self))

--- a/paibox/backendv2/route_solver.py
+++ b/paibox/backendv2/route_solver.py
@@ -123,14 +123,12 @@ MAX_AREA = max(SHAPES_BY_AREA.keys())
 def route_solve(
     areas=[1], next_area_id={}, io_target=(0, 0), input_area_ids=[], output_area_ids=[]
 ):
-
     num_areas = len(areas)
     placements = []
     placement_cells = []
     placement_area = []
 
     for area_id, area in enumerate(areas):
-
         shapes = []
         for selected_area in range(area, MAX_AREA + 1):
             if selected_area in SHAPES_BY_AREA:

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
+import torch
 from paicorelib import (
     LCN_EX,
     AERPacketZXYCopy,
@@ -18,6 +19,8 @@ from paicorelib import (
     WeightCompressType,
     find_coordxy_shortest_path,
 )
+from torch import Tensor, nn
+from torch.nn import functional as F
 
 from .core_config import Backend_Core_Config, Frontend_Core_Config
 from .coreplacement import (
@@ -28,68 +31,444 @@ from .coreplacement import (
 from .neuron import InputElem, Neuron, OfflineNeuronPlacement
 from .op_node import CoreOpNode, InNode
 from .weight import Weight
+from ..paiir import AccumulateOp, AddOp, SequentialOp, StandaloneActOp, StandaloneCompOp
 
 FANIN_BASE = 512
+
+
+def feature_shape(shape: torch.Size | tuple[int, ...]) -> tuple[int, ...]:
+    # Backend weight extraction works on feature dimensions only.
+    # The leading batch dimension is stripped and must stay equal to 1.
+    feature_shape = tuple(shape)
+    if len(feature_shape) > 1:
+        batch = feature_shape[0]
+        if batch != 1:
+            raise NotImplementedError(
+                f"Only batch size 1 is supported, but got shape {feature_shape}."
+            )
+        feature_shape = feature_shape[1:]
+
+    return feature_shape
+
+
+def to_nd_tuple(value: int | tuple[int, ...], ndim: int) -> tuple[int, ...]:
+    if isinstance(value, tuple):
+        if len(value) != ndim:
+            raise ValueError(f"Expected a tuple of length {ndim}, but got {value}.")
+        return value
+
+    return (value,) * ndim
+
+
+def ensure_target_components(target: CoreOpNode) -> None:
+    # Lazily reconstruct per-predecessor comps/weights so routing can
+    # query them even if node initialization did not populate them yet.
+    if not target.predecessors:
+        return
+
+    if len(target.comps) == len(target.predecessors) and len(target.weights) == len(
+        target.predecessors
+    ):
+        return
+
+    raw_node = target.raw_node
+    if isinstance(raw_node, SequentialOp):
+        target.comps = [raw_node.comp]
+    elif isinstance(raw_node, AccumulateOp):
+        target.comps = list(raw_node.comps)
+    elif isinstance(raw_node, StandaloneCompOp):
+        target.comps = [raw_node.comp]
+    elif isinstance(raw_node, StandaloneActOp):
+        target.comps = [None]
+    elif isinstance(raw_node, AddOp):
+        target.comps = [None] * len(raw_node.signs)
+    else:
+        raise NotImplementedError(f"Unsupported node type: {type(raw_node)}")
+
+    raw_weights = raw_node.weights
+    if raw_weights is None:
+        target.weights = [None] * len(target.comps)
+    else:
+        target.weights = list(raw_weights)
+
+
+def path_signs(target: CoreOpNode) -> list[int]:
+    # Accumulate/Add nodes may encode subtraction through per-path signs.
+    raw_node = target.raw_node
+    if isinstance(raw_node, (AccumulateOp, AddOp)):
+        return list(raw_node.signs)
+
+    return [1] * len(target.predecessors)
+
+
+def direct_weight_matrix(
+    weight: Tensor, input_shape: tuple[int, ...], output_shape: tuple[int, ...], sign: int
+) -> np.ndarray:
+    # Linear/identity-like paths already expose a dense [out, in] matrix.
+    matrix = np.asarray(weight.detach().cpu(), dtype=np.int32)
+    n_input = int(np.prod(input_shape))
+    n_output = int(np.prod(output_shape))
+
+    if matrix.shape != (n_output, n_input):
+        raise ValueError(
+            f"Direct weight shape mismatch: expected {(n_output, n_input)}, got {matrix.shape}."
+        )
+
+    if sign != 1:
+        matrix = sign * matrix
+
+    return matrix
+
+
+def unfold_input_indices_2d(
+    channels: int,
+    spatial_shape: tuple[int, int],
+    kernel_size: tuple[int, int],
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+) -> torch.Tensor:
+    # Build a lookup table from each sliding-window position back to the
+    # flattened input indices. Zero means "came from padding".
+    height, width = spatial_shape
+    n_input = channels * height * width
+    input_ids = torch.arange(1, n_input + 1, dtype=torch.float64).reshape(
+        1, channels, height, width
+    )
+    patches = F.unfold(
+        input_ids,
+        kernel_size=kernel_size,
+        dilation=dilation,
+        padding=padding,
+        stride=stride,
+    )
+    return patches.to(torch.int64).squeeze(0)
+
+
+def conv2d_weight_matrix(
+    weight: Tensor,
+    input_shape: tuple[int, int, int],
+    output_shape: tuple[int, int, int],
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+    groups: int,
+    sign: int,
+) -> np.ndarray:
+    # Expand a Conv2d kernel into a full dense matrix with shape [out, in],
+    # where rows are flattened output neurons and columns are flattened inputs.
+    in_channels, height, width = input_shape
+    out_channels, out_height, out_width = output_shape
+    kernel = np.asarray(weight.detach().cpu(), dtype=np.int32)
+    _, in_channels_per_group, kernel_height, kernel_width = kernel.shape
+
+    if in_channels != in_channels_per_group * groups:
+        raise ValueError(
+            f"Conv groups mismatch: input channels {in_channels}, kernel channels {in_channels_per_group}, groups {groups}."
+        )
+
+    out_channels_per_group = out_channels // groups
+    out_size = out_height * out_width
+    n_input = in_channels * height * width
+    matrix = np.zeros((out_channels * out_size, n_input), dtype=np.int32)
+
+    patches = unfold_input_indices_2d(
+        in_channels,
+        (height, width),
+        (kernel_height, kernel_width),
+        stride,
+        padding,
+        dilation,
+    ).cpu().numpy()
+
+    if patches.shape[1] != out_size:
+        raise ValueError(
+            f"Conv unfold mismatch: expected {out_size} output positions, got {patches.shape[1]}."
+        )
+
+    row_offsets = np.tile(
+        np.arange(out_size, dtype=np.int64),
+        in_channels_per_group * kernel_height * kernel_width,
+    )
+
+    for out_channel in range(out_channels):
+        group_idx = out_channel // out_channels_per_group
+        patch_start = group_idx * in_channels_per_group * kernel_height * kernel_width
+        patch_end = patch_start + in_channels_per_group * kernel_height * kernel_width
+
+        # Scatter each kernel coefficient to the input positions that feed the
+        # corresponding flattened output locations.
+        flat_cols = patches[patch_start:patch_end].reshape(-1)
+        valid = flat_cols > 0
+        flat_rows = row_offsets[valid]
+        flat_values = np.repeat(kernel[out_channel].reshape(-1), out_size)[valid]
+        matrix[out_channel * out_size + flat_rows, flat_cols[valid] - 1] = flat_values
+
+    if sign != 1:
+        matrix *= sign
+
+    return matrix
+
+
+def pool2d_weight_matrix(
+    channels: int,
+    input_shape: tuple[int, int, int],
+    output_shape: tuple[int, int, int],
+    kernel_size: tuple[int, int],
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+    sign: int,
+) -> np.ndarray:
+    # Pooling has no explicit weight tensor, but connectivity still forms a
+    # dense [out, in] matrix. Every valid input in the pooling window gets 1.
+    in_channels, height, width = input_shape
+    out_channels, out_height, out_width = output_shape
+    if in_channels != channels or out_channels != channels:
+        raise ValueError(
+            f"Pooling channel mismatch: input={in_channels}, output={out_channels}, channels={channels}."
+        )
+
+    out_size = out_height * out_width
+    n_input = in_channels * height * width
+    matrix = np.zeros((out_channels * out_size, n_input), dtype=np.int32)
+
+    patches = unfold_input_indices_2d(
+        in_channels,
+        (height, width),
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+    ).cpu().numpy()
+
+    if patches.shape[1] != out_size:
+        raise ValueError(
+            f"Pooling unfold mismatch: expected {out_size} output positions, got {patches.shape[1]}."
+        )
+
+    kernel_elems = int(np.prod(kernel_size))
+    row_offsets = np.tile(np.arange(out_size, dtype=np.int64), kernel_elems)
+
+    for channel in range(channels):
+        patch_start = channel * kernel_elems
+        patch_end = patch_start + kernel_elems
+
+        flat_cols = patches[patch_start:patch_end].reshape(-1)
+        valid = flat_cols > 0
+        matrix[channel * out_size + row_offsets[valid], flat_cols[valid] - 1] = sign
+
+    return matrix
+
+
+def conv1d_weight_matrix(
+    weight: Tensor,
+    input_shape: tuple[int, int],
+    output_shape: tuple[int, int],
+    stride: tuple[int],
+    padding: tuple[int],
+    dilation: tuple[int],
+    groups: int,
+    sign: int,
+) -> np.ndarray:
+    # Reuse the 2D expansion path by treating 1D signals as H=1 feature maps.
+    in_channels, in_length = input_shape
+    out_channels, out_length = output_shape
+    kernel = weight.reshape(weight.shape[0], weight.shape[1], 1, weight.shape[2])
+    return conv2d_weight_matrix(
+        kernel,
+        (in_channels, 1, in_length),
+        (out_channels, 1, out_length),
+        (1, stride[0]),
+        (0, padding[0]),
+        (1, dilation[0]),
+        groups,
+        sign,
+    )
+
+
+def pool1d_weight_matrix(
+    channels: int,
+    input_shape: tuple[int, int],
+    output_shape: tuple[int, int],
+    kernel_size: tuple[int],
+    stride: tuple[int],
+    padding: tuple[int],
+    dilation: tuple[int],
+    sign: int,
+) -> np.ndarray:
+    # Reuse the 2D pooling expansion path by treating 1D signals as H=1 maps.
+    in_channels, in_length = input_shape
+    out_channels, out_length = output_shape
+    return pool2d_weight_matrix(
+        channels,
+        (in_channels, 1, in_length),
+        (out_channels, 1, out_length),
+        (1, kernel_size[0]),
+        (1, stride[0]),
+        (0, padding[0]),
+        (1, dilation[0]),
+        sign,
+    )
+
+
+def expanded_path_weight_matrix(
+    predecessor: CoreOpNode | InNode,
+    target: CoreOpNode,
+    comp: Optional[nn.Module],
+    weight: Optional[Tensor],
+    sign: int,
+) -> np.ndarray:
+    # Convert one predecessor path into a dense [out, in] matrix, choosing
+    # the correct expansion strategy from the comp type.
+    input_shape = feature_shape(predecessor.shape)
+    output_shape = feature_shape(target.shape)
+
+    if weight is not None and (comp is None or isinstance(comp, nn.Linear) or weight.ndim == 2):
+        return direct_weight_matrix(weight, input_shape, output_shape, sign)
+
+    if isinstance(comp, nn.Conv1d):
+        return conv1d_weight_matrix(
+            weight,
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.stride, 1),
+            to_nd_tuple(comp.padding, 1),
+            to_nd_tuple(comp.dilation, 1),
+            comp.groups,
+            sign,
+        )
+
+    if isinstance(comp, nn.Conv2d):
+        return conv2d_weight_matrix(
+            weight,
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.stride, 2),
+            to_nd_tuple(comp.padding, 2),
+            to_nd_tuple(comp.dilation, 2),
+            comp.groups,
+            sign,
+        )
+
+    if isinstance(comp, nn.MaxPool1d):
+        if comp.ceil_mode:
+            raise NotImplementedError("MaxPool1d with ceil_mode=True is not supported.")
+
+        return pool1d_weight_matrix(
+            input_shape[0],
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.kernel_size, 1),
+            to_nd_tuple(comp.stride or comp.kernel_size, 1),
+            to_nd_tuple(comp.padding, 1),
+            to_nd_tuple(comp.dilation, 1),
+            sign,
+        )
+
+    if isinstance(comp, nn.AvgPool1d):
+        if comp.ceil_mode:
+            raise NotImplementedError("AvgPool1d with ceil_mode=True is not supported.")
+
+        return pool1d_weight_matrix(
+            input_shape[0],
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.kernel_size, 1),
+            to_nd_tuple(comp.stride or comp.kernel_size, 1),
+            to_nd_tuple(comp.padding, 1),
+            (1,),
+            sign,
+        )
+
+    if isinstance(comp, nn.MaxPool2d):
+        if comp.ceil_mode:
+            raise NotImplementedError("MaxPool2d with ceil_mode=True is not supported.")
+
+        return pool2d_weight_matrix(
+            input_shape[0],
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.kernel_size, 2),
+            to_nd_tuple(comp.stride or comp.kernel_size, 2),
+            to_nd_tuple(comp.padding, 2),
+            to_nd_tuple(comp.dilation, 2),
+            sign,
+        )
+
+    if isinstance(comp, nn.AvgPool2d):
+        if comp.ceil_mode:
+            raise NotImplementedError("AvgPool2d with ceil_mode=True is not supported.")
+
+        return pool2d_weight_matrix(
+            input_shape[0],
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.kernel_size, 2),
+            to_nd_tuple(comp.stride or comp.kernel_size, 2),
+            to_nd_tuple(comp.padding, 2),
+            (1, 1),
+            sign,
+        )
+
+    raise NotImplementedError(
+        f"Unsupported weight expansion for comp {type(comp)} with weight {type(weight)}."
+    )
 
 
 def get_raw_weights(
     raw_neus: list[Neuron], input_neus: list[Neuron | InputElem]
 ) -> np.ndarray:
-    # emplement your own weight retrieval logic here
-    # raw_neu and input_neu are both single neuron at an index of a CoreOpNode or InputNode
-    # the shape of the complete core op node or input node can be found in raw_neu.target.shape or input_neu.target.shape
-    # the index of the elem in flatten is neu.index.idx or elem.index.idx
-    for neu in raw_neus:
-        neu.target.shape
-        neu.index.idx
-    for elem in input_neus:
-        elem.target.shape
-        elem.index.idx
-
+    # Return a dense routing-group weight matrix with shape
+    # [number of output neurons, number of input elements].
     n_output = len(raw_neus)
     n_input = len(input_neus)
-
-    # weight's shape should be (n_output, n_input)
     weights = np.zeros((n_output, n_input), dtype=np.int32)
+
+    # Cache expanded matrices per target node and predecessor node because
+    # many raw neurons share the same source/target pair.
+    target_cache: dict[CoreOpNode, dict[CoreOpNode | InNode, np.ndarray]] = {}
+
+    for neu in raw_neus:
+        target = neu.target
+        if target in target_cache:
+            continue
+
+        ensure_target_components(target)
+        signs = path_signs(target)
+        path_matrices: dict[CoreOpNode | InNode, np.ndarray] = {}
+
+        for predecessor, comp, weight, sign in zip(
+            target.predecessors,
+            target.comps,
+            target.weights,
+            signs,
+        ):
+            # Each predecessor contributes one dense [target_out, pred_out] block.
+            matrix = expanded_path_weight_matrix(
+                predecessor,
+                target,
+                comp,
+                weight,
+                sign,
+            )
+            if predecessor in path_matrices:
+                path_matrices[predecessor] = path_matrices[predecessor] + matrix
+            else:
+                path_matrices[predecessor] = matrix
+
+        target_cache[target] = path_matrices
+
     for i, neu in enumerate(raw_neus):
+        path_matrices = target_cache[neu.target]
         for j, elem in enumerate(input_neus):
-            # set weight value according to your logic
-            # weights[i, j] should be the weight from input_neus[j] to raw_neus[i]
-            # which is the weight from elem.target to neu.target
-            # at the corresponding indices elem.index.idx and neu.index.idx
+            matrix = path_matrices.get(elem.target)
+            if matrix is None:
+                # No edge from this input node to the current output neuron.
+                continue
 
-            # if there is no weight connection, set weights[i, j] to 0
-            
-            # the weight of neu.target 
-            neu.target.weights 
-            # is the weights for 
-            neu.target.predecessors 
-            # to neu.target
-            # the order of weights corresponds to the order of predecessors, which can be CoreOpNode or InNode
-            
-            # you can get the nn.Module for weight unfold, also in the same order of predecessors and weights, from
-            neu.target.comps
-            
-            # for different comp, the weight should be handled differently
-            
-            # for conv2d, neu.target.raw_node.weights returns a kernel of the conv2d
-            # you need to unfold the kernel according to the conv2d parameters to get the weight between input_neu.target and raw_neu.target
-            
-            # for (max and average)pooling, the weight is None,
-            # you also need to unfold the kernel to get the weight between input_neu.target and raw_neu.target, and set the weight value to 1 
-            
-            # if comp is liner or None, the weight is the direct weight between input_neu.target and raw_neu.target, you can directly use it without unfold
-            
-            
-            # when you get the weight from input_neu.target to neu.target, you can set weights[i, j] 
-            # weights[i, j] = weight_from_input_to_neu[elem.index.idx, neu.index.idx]
-
-            # the neu.target and elem.target are mostly same in raw_neus and input_neus
-            # so you can cache the weight matrix for each unique target node to accelerate the process
-
-            # there is a simple test example at PAIBox/test_paiir.py
-
-            weights[i, j] = -1  # unset weight value
+            # Both neuron and input indices are already flattened indices.
+            weights[i, j] = matrix[neu.index.idx, elem.index.idx]
 
     return weights
 

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -11,17 +11,15 @@ from paicorelib import (
     DataWidth,
     FoldType,
     NeuronType,
-    OfflineCoreRegV2,
     OfflineNeuDestInfoV2,
     OfflineNeuFullAttrsV2Part1,
-    OfflineNeuFullAttrsV2Part2,
-    OutputType,
     WeightCompressType,
     find_coordxy_shortest_path,
 )
 from torch import Tensor, nn
 from torch.nn import functional as F
 
+from ..paiir import AccumulateOp, AddOp, SequentialOp, StandaloneActOp, StandaloneCompOp
 from .core_config import Backend_Core_Config, Frontend_Core_Config
 from .coreplacement import (
     CorePlacement,
@@ -31,7 +29,6 @@ from .coreplacement import (
 from .neuron import InputElem, Neuron, OfflineNeuronPlacement
 from .op_node import CoreOpNode, InNode
 from .weight import Weight
-from ..paiir import AccumulateOp, AddOp, SequentialOp, StandaloneActOp, StandaloneCompOp
 
 FANIN_BASE = 512
 
@@ -102,7 +99,10 @@ def path_signs(target: CoreOpNode) -> list[int]:
 
 
 def direct_weight_matrix(
-    weight: Tensor, input_shape: tuple[int, ...], output_shape: tuple[int, ...], sign: int
+    weight: Tensor,
+    input_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+    sign: int,
 ) -> np.ndarray:
     # Linear/identity-like paths already expose a dense [out, in] matrix.
     matrix = np.asarray(weight.detach().cpu(), dtype=np.int32)
@@ -172,14 +172,18 @@ def conv2d_weight_matrix(
     n_input = in_channels * height * width
     matrix = np.zeros((out_channels * out_size, n_input), dtype=np.int32)
 
-    patches = unfold_input_indices_2d(
-        in_channels,
-        (height, width),
-        (kernel_height, kernel_width),
-        stride,
-        padding,
-        dilation,
-    ).cpu().numpy()
+    patches = (
+        unfold_input_indices_2d(
+            in_channels,
+            (height, width),
+            (kernel_height, kernel_width),
+            stride,
+            padding,
+            dilation,
+        )
+        .cpu()
+        .numpy()
+    )
 
     if patches.shape[1] != out_size:
         raise ValueError(
@@ -233,14 +237,18 @@ def pool2d_weight_matrix(
     n_input = in_channels * height * width
     matrix = np.zeros((out_channels * out_size, n_input), dtype=np.int32)
 
-    patches = unfold_input_indices_2d(
-        in_channels,
-        (height, width),
-        kernel_size,
-        stride,
-        padding,
-        dilation,
-    ).cpu().numpy()
+    patches = (
+        unfold_input_indices_2d(
+            in_channels,
+            (height, width),
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+        )
+        .cpu()
+        .numpy()
+    )
 
     if patches.shape[1] != out_size:
         raise ValueError(
@@ -324,7 +332,9 @@ def expanded_path_weight_matrix(
     input_shape = feature_shape(predecessor.shape)
     output_shape = feature_shape(target.shape)
 
-    if weight is not None and (comp is None or isinstance(comp, nn.Linear) or weight.ndim == 2):
+    if weight is not None and (
+        comp is None or isinstance(comp, nn.Linear) or weight.ndim == 2
+    ):
         return direct_weight_matrix(weight, input_shape, output_shape, sign)
 
     if isinstance(comp, nn.Conv1d):
@@ -733,7 +743,7 @@ class RoutingGroup:
             dest_strs = dest_strs[:3] + ["..."] + dest_strs[-3:]
         info_str += f"  Number of Neurons: {len(self.raw_neus)}\n"
         info_str += f"  Number of Inputs: {len(self.input_list)}\n"
-        info_str += f"  Dests:\n    " + "\n    ".join(dest_strs) + "\n"
+        info_str += "  Dests:\n    " + "\n    ".join(dest_strs) + "\n"
         info_str += f"  LCN: {self.lcn.name}\n"
         info_str += f"  Number of Core Placements: {len(self.core_placements)}\n"
         if self._base_coord is not None:

--- a/paibox/backendv2/weight.py
+++ b/paibox/backendv2/weight.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import Literal, Union
+from typing import Union
 
 import numpy as np
 from paicorelib import (
-    FRAME_DTYPE,
     DataWidth,
     FrameArrayType,
     OfflineFrameGenV2,

--- a/paibox/paiir/converter.py
+++ b/paibox/paiir/converter.py
@@ -367,9 +367,9 @@ def _fx_graph_to_paiir(
                 fx_to_ir[node.name] = ir_node.name
             elif node.target in CAT_OPS:
                 raw_dim = node.kwargs.get("dim", 0)
-                assert isinstance(raw_dim, int), (
-                    f"cat dim must be int, got {type(raw_dim)}"
-                )
+                assert isinstance(
+                    raw_dim, int
+                ), f"cat dim must be int, got {type(raw_dim)}"
                 ir_node = ConcatOp(dim=raw_dim)
                 _fill_shape_dims(ir_node, node)
                 paiir_graph.add_node(ir_node)

--- a/paibox/paiir/graph.py
+++ b/paibox/paiir/graph.py
@@ -86,10 +86,13 @@ class PAIIRGraph:
 
     def predecessors(self, name: str) -> list[str]:
         """Return predecessor node names, sorted by ``dst_port``."""
-        return [e.src for e in sorted(
-            (e for e in self.edges if e.dst == name),
-            key=lambda e: e.dst_port,
-        )]
+        return [
+            e.src
+            for e in sorted(
+                (e for e in self.edges if e.dst == name),
+                key=lambda e: e.dst_port,
+            )
+        ]
 
     def successors(self, name: str) -> list[str]:
         """Return successor node names."""

--- a/test.py
+++ b/test.py
@@ -12,16 +12,11 @@
 # export_single_framearray(random_array, "output_frames.txt")
 
 
-import pprint
-
 import torch
 from spikingjelly.activation_based import neuron
 from torch import nn
 
-from paibox._logging import DEFAULT_LOG_SETTINGS, set_logs
-from paibox.backendv2.op_node import CoreOpNode, build_nodes
-from paibox.fx_converter.core_op import BaseCoreOp
-from paibox.fx_converter.fuse import apply_passes, fuse_compute_act
+from paibox.fx_converter.fuse import fuse_compute_act
 from paibox.fx_converter.trace import (
     propagate_tensor_shape,
     remove_dropout_identity_and_fuse_conv_bn,

--- a/test_paiir.py
+++ b/test_paiir.py
@@ -1,13 +1,8 @@
-import pytest
 import torch
-from paicorelib import DataSign, DataWidth
-from spikingjelly.activation_based import neuron as sj
 from torch import Tensor, nn
 
 from paibox.backendv2.mapper import Mapper
-from paibox.paiir import CompileConfig, PAIIRGraph, compile_to_paiir
-from paibox.paiir.exceptions import UnsupportedOpError, UnsupportedOpWarning
-from paibox.paiir.op_node import AccumulateOp, ConcatOp, SequentialOp
+from paibox.paiir import compile_to_paiir
 
 
 def make_img_3ch_32x32() -> Tensor:

--- a/tests/backendv2/test_routing_v2_allocation.py
+++ b/tests/backendv2/test_routing_v2_allocation.py
@@ -1,19 +1,16 @@
-from unittest.mock import MagicMock, PropertyMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-from paicorelib import OfflineCoreRegV2, WeightCompressType
+from paicorelib import WeightCompressType
 
-from paibox.backendv2.coreplacement import OfflineCorePlamentV2
-from paibox.backendv2.neuron import NeuronType, OfflineNeuronPlacement
+from paibox.backendv2.neuron import NeuronType
 from paibox.backendv2.routing import RoutingGroup
 
 # 模拟导入 (防止环境缺失)
-from paibox.backendv2.weight import Weight
 
 
 class TestRoutingGroupAllocation:
-
     @pytest.fixture
     def mock_deps(self):
         """Mock external dependencies."""
@@ -28,7 +25,6 @@ class TestRoutingGroupAllocation:
             ) as mock_core_placement_cls,
             patch("paibox.backendv2.routing.OfflineCoreRegV2") as mock_reg_v2_cls,
         ):
-
             # [修复 1] 正确模拟 Pydantic 的 model_fields
             # 让 model_fields 表现为一个字典，这样 .keys() 就能正常工作
             mock_fields = {
@@ -38,7 +34,13 @@ class TestRoutingGroupAllocation:
             }
             mock_reg_v2_cls.model_fields = mock_fields
 
-            yield mock_weight_cls, mock_neu_placement_cls, mock_core_placement_cls, mock_reg_v2_cls, mock_get_weights
+            yield (
+                mock_weight_cls,
+                mock_neu_placement_cls,
+                mock_core_placement_cls,
+                mock_reg_v2_cls,
+                mock_get_weights,
+            )
 
     def create_mock_neuron(self, weight_width=1, core_config_id=1, config_obj=None):
         """Helper to create a mock neuron."""

--- a/tests/backendv2/test_routing_v2_raw_weights.py
+++ b/tests/backendv2/test_routing_v2_raw_weights.py
@@ -1,0 +1,155 @@
+import numpy as np
+import paicorelib
+import torch
+from torch import nn
+
+for name, value in {
+    "LUT_ACTIVATION_DTYPE": np.int8,
+    "LUT_POTENTIAL_DTYPE": np.int8,
+    "LUTActivationType": np.ndarray,
+    "LUTPotentialType": np.ndarray,
+}.items():
+    if not hasattr(paicorelib, name):
+        setattr(paicorelib, name, value)
+
+from paibox.backendv2.neuron import InputElem, Neuron
+from paibox.backendv2.op_node import CoreOpNode, CustomIndex, InNode
+from paibox.backendv2.routing import get_raw_weights
+from paibox.paiir import (
+    ANNNodeV25,
+    AccumulateOp,
+    LutReLU,
+    StandaloneActOp,
+    StandaloneCompOp,
+)
+
+
+def _configure_raw_node(raw_node):
+    raw_node.core_params.tick_start = 1
+    raw_node.core_params.tick_duration = 0
+    raw_node.core_params.tick_initial = 1
+    return raw_node
+
+
+def _input_elems(node: InNode) -> list[InputElem]:
+    return [InputElem(node, CustomIndex(i)) for i in range(node.shape.numel())]
+
+
+def _neurons(node: CoreOpNode) -> list[Neuron]:
+    return [Neuron(node, CustomIndex(i)) for i in range(node.shape.numel())]
+
+
+def test_get_raw_weights_linear_with_unconnected_inputs():
+    source = InNode("src", (1, 4))
+    unrelated = InNode("other", (1, 2))
+
+    linear = _configure_raw_node(StandaloneCompOp(nn.Linear(4, 3, bias=False)))
+    with torch.no_grad():
+        linear.comp.weight.copy_(
+            torch.tensor(
+                [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+                dtype=torch.float32,
+            )
+        )
+
+    linear.output_shape = (1, 3)
+    target = CoreOpNode("linear", linear, linear.output_shape)
+    target.predecessors = [source]
+
+    weights = get_raw_weights(_neurons(target), _input_elems(source) + _input_elems(unrelated))
+
+    expected = np.array(
+        [
+            [1, 2, 3, 4, 0, 0],
+            [5, 6, 7, 8, 0, 0],
+            [9, 10, 11, 12, 0, 0],
+        ],
+        dtype=np.int32,
+    )
+    np.testing.assert_array_equal(weights, expected)
+
+
+def test_get_raw_weights_conv2d():
+    source = InNode("img", (1, 1, 3, 3))
+
+    conv = _configure_raw_node(StandaloneCompOp(nn.Conv2d(1, 1, 2, bias=False)))
+    with torch.no_grad():
+        conv.comp.weight.copy_(torch.tensor([[[[1, 2], [3, 4]]]], dtype=torch.float32))
+
+    conv.output_shape = (1, 1, 2, 2)
+    target = CoreOpNode("conv", conv, conv.output_shape)
+    target.predecessors = [source]
+
+    weights = get_raw_weights(_neurons(target), _input_elems(source))
+
+    expected = np.array(
+        [
+            [1, 2, 0, 3, 4, 0, 0, 0, 0],
+            [0, 1, 2, 0, 3, 4, 0, 0, 0],
+            [0, 0, 0, 1, 2, 0, 3, 4, 0],
+            [0, 0, 0, 0, 1, 2, 0, 3, 4],
+        ],
+        dtype=np.int32,
+    )
+    np.testing.assert_array_equal(weights, expected)
+
+
+def test_get_raw_weights_pool2d():
+    source = InNode("pool_src", (1, 1, 3, 3))
+
+    pool = _configure_raw_node(StandaloneCompOp(nn.AvgPool2d(2, stride=1)))
+    pool.output_shape = (1, 1, 2, 2)
+    target = CoreOpNode("pool", pool, pool.output_shape)
+    target.predecessors = [source]
+
+    weights = get_raw_weights(_neurons(target), _input_elems(source))
+
+    expected = np.array(
+        [
+            [1, 1, 0, 1, 1, 0, 0, 0, 0],
+            [0, 1, 1, 0, 1, 1, 0, 0, 0],
+            [0, 0, 0, 1, 1, 0, 1, 1, 0],
+            [0, 0, 0, 0, 1, 1, 0, 1, 1],
+        ],
+        dtype=np.int32,
+    )
+    np.testing.assert_array_equal(weights, expected)
+
+
+def test_get_raw_weights_standalone_activation_identity():
+    source = InNode("act_src", (1, 4))
+
+    act = _configure_raw_node(StandaloneActOp(ANNNodeV25(lut=LutReLU())))
+    act.output_shape = (1, 4)
+    target = CoreOpNode("act", act, act.output_shape)
+    target.predecessors = [source]
+
+    weights = get_raw_weights(_neurons(target), _input_elems(source))
+
+    np.testing.assert_array_equal(weights, np.eye(4, dtype=np.int32))
+
+
+def test_get_raw_weights_accumulate_respects_negative_branch_sign():
+    source_a = InNode("a", (1, 2))
+    source_b = InNode("b", (1, 2))
+
+    acc = _configure_raw_node(
+        AccumulateOp(
+            comps=[nn.Linear(2, 2, bias=False), nn.Linear(2, 2, bias=False)],
+            act=ANNNodeV25(lut=LutReLU()),
+            op_signs=(1, -1),
+        )
+    )
+    with torch.no_grad():
+        acc.comps[0].weight.copy_(torch.tensor([[1, 2], [3, 4]], dtype=torch.float32))
+        acc.comps[1].weight.copy_(torch.tensor([[5, 6], [7, 8]], dtype=torch.float32))
+
+    acc.output_shape = (1, 2)
+    target = CoreOpNode("acc", acc, acc.output_shape)
+    target.predecessors = [source_a, source_b]
+
+    input_elems = _input_elems(source_a) + _input_elems(source_b)
+    weights = get_raw_weights(_neurons(target), input_elems)
+
+    expected = np.array([[1, 2, -5, -6], [3, 4, -7, -8]], dtype=np.int32)
+    np.testing.assert_array_equal(weights, expected)

--- a/tests/backendv2/test_routing_v2_raw_weights.py
+++ b/tests/backendv2/test_routing_v2_raw_weights.py
@@ -16,8 +16,8 @@ from paibox.backendv2.neuron import InputElem, Neuron
 from paibox.backendv2.op_node import CoreOpNode, CustomIndex, InNode
 from paibox.backendv2.routing import get_raw_weights
 from paibox.paiir import (
-    ANNNodeV25,
     AccumulateOp,
+    ANNNodeV25,
     LutReLU,
     StandaloneActOp,
     StandaloneCompOp,
@@ -56,7 +56,9 @@ def test_get_raw_weights_linear_with_unconnected_inputs():
     target = CoreOpNode("linear", linear, linear.output_shape)
     target.predecessors = [source]
 
-    weights = get_raw_weights(_neurons(target), _input_elems(source) + _input_elems(unrelated))
+    weights = get_raw_weights(
+        _neurons(target), _input_elems(source) + _input_elems(unrelated)
+    )
 
     expected = np.array(
         [

--- a/tests/paiir/test_compensation.py
+++ b/tests/paiir/test_compensation.py
@@ -79,25 +79,33 @@ class TestCompensateAvgPoolNeuron:
     def test_lif_decay_input_true_r0(self):
         """theta' = theta * window_size."""
         params = NeuronParams(thres_pos=1.0, reset_v=0.0)
-        result = compensate_avgpool_neuron(params, window_size=4, decay_input=True, tau=2.0)
+        result = compensate_avgpool_neuron(
+            params, window_size=4, decay_input=True, tau=2.0
+        )
         assert result.thres_pos == 4.0
 
     def test_lif_decay_input_false_r0(self):
         """theta' = theta * window_size / tau."""
         params = NeuronParams(thres_pos=1.0, reset_v=0.0)
-        result = compensate_avgpool_neuron(params, window_size=4, decay_input=False, tau=2.0)
+        result = compensate_avgpool_neuron(
+            params, window_size=4, decay_input=False, tau=2.0
+        )
         assert result.thres_pos == 2.0
 
     def test_lif_nonzero_reset(self):
         """theta' = r + (theta - r) * window_size."""
         params = NeuronParams(thres_pos=3.0, reset_v=1.0)
-        result = compensate_avgpool_neuron(params, window_size=4, decay_input=True, tau=2.0)
+        result = compensate_avgpool_neuron(
+            params, window_size=4, decay_input=True, tau=2.0
+        )
         assert result.thres_pos == 1.0 + (3.0 - 1.0) * 4  # = 9.0
 
     def test_thres_neg_also_compensated(self):
         """Both positive and negative thresholds are compensated."""
         params = NeuronParams(thres_pos=2.0, thres_neg=-4.0, reset_v=0.0)
-        result = compensate_avgpool_neuron(params, window_size=4, decay_input=True, tau=1.0)
+        result = compensate_avgpool_neuron(
+            params, window_size=4, decay_input=True, tau=1.0
+        )
         assert result.thres_pos == 8.0
         assert result.thres_neg == -16.0
 

--- a/tests/paiir/test_converter_and_passes.py
+++ b/tests/paiir/test_converter_and_passes.py
@@ -506,9 +506,9 @@ class TestRegisterNeuron:
         test_inputs = torch.tensor([-100, -2, -1, 0, 1, 2, 3, 4, 5, 20, 100])
         ref_outputs = torch.round(torch.clamp(test_inputs, 0, 4))
         lut_outputs = seq_nodes[0].act(test_inputs)
-        assert torch.equal(lut_outputs, ref_outputs), (
-            f"LUT mismatch: expected {ref_outputs.tolist()}, got {lut_outputs.tolist()}"
-        )
+        assert torch.equal(
+            lut_outputs, ref_outputs
+        ), f"LUT mismatch: expected {ref_outputs.tolist()}, got {lut_outputs.tolist()}"
 
 
 class TestSplitCoreAvgPoolIF:

--- a/tests/paiir/test_data_format.py
+++ b/tests/paiir/test_data_format.py
@@ -400,12 +400,12 @@ class TestPropagateEdgeConsistency:
             src = fused.nodes[edge.src]
             dst = fused.nodes[edge.dst]
             if isinstance(src, OfflineCoreOp) and isinstance(dst, OfflineCoreOp):
-                assert src.core_params.output_sign == dst.core_params.input_sign, (
-                    f"Sign mismatch at edge {edge.src} -> {edge.dst}"
-                )
-                assert src.core_params.output_width == dst.core_params.input_width, (
-                    f"Width mismatch at edge {edge.src} -> {edge.dst}"
-                )
+                assert (
+                    src.core_params.output_sign == dst.core_params.input_sign
+                ), f"Sign mismatch at edge {edge.src} -> {edge.dst}"
+                assert (
+                    src.core_params.output_width == dst.core_params.input_width
+                ), f"Width mismatch at edge {edge.src} -> {edge.dst}"
 
     def test_two_layer_ann(self):
         """Conv-ReLU -> Conv-Sigmoid: edge format consistency."""

--- a/tests/paiir/test_lut_activation.py
+++ b/tests/paiir/test_lut_activation.py
@@ -145,9 +145,9 @@ class TestNonlinearActivations:
         x = torch.linspace(-5, 5, 20)
         y = lut(x)
         ref = torch.tensor([ref_fn(xi.item()) for xi in x])
-        assert torch.allclose(y.float(), ref, atol=0.15), (
-            f"{cls.__name__} max error = {(y.float() - ref).abs().max().item():.4f}"
-        )
+        assert torch.allclose(
+            y.float(), ref, atol=0.15
+        ), f"{cls.__name__} max error = {(y.float() - ref).abs().max().item():.4f}"
 
     @pytest.mark.parametrize("cls, ref_fn, sign, scale", _NONLINEAR_PARAMS)
     def test_int_accuracy(self, cls, ref_fn, sign, scale):
@@ -162,18 +162,20 @@ class TestNonlinearActivations:
 
         for xn, yi in zip(norm_points, y.tolist()):
             expected = ref_fn(xn) * scale
-            assert abs(yi - expected) <= 15, (
-                f"{cls.__name__}: at x_norm={xn}, got {yi}, expected ~{expected:.1f}"
-            )
+            assert (
+                abs(yi - expected) <= 15
+            ), f"{cls.__name__}: at x_norm={xn}, got {yi}, expected ~{expected:.1f}"
 
     @pytest.mark.parametrize("cls, ref_fn, sign, scale", _NONLINEAR_PARAMS)
-    def test_threshold_density_near_zero(self, cls, ref_fn, sign, scale):  # noqa: ARG002
+    def test_threshold_density_near_zero(
+        self, cls, ref_fn, sign, scale
+    ):  # noqa: ARG002
         """Non-uniform binning concentrates thresholds near x=0."""
         thresholds = cls(min_val=-500, max_val=500, output_sign=sign).thresholds
         inner_count = ((thresholds >= -50) & (thresholds <= 50)).sum().item()
-        assert inner_count > 50, (
-            f"{cls.__name__}: only {inner_count} thresholds in [-50, 50]"
-        )
+        assert (
+            inner_count > 50
+        ), f"{cls.__name__}: only {inner_count} thresholds in [-50, 50]"
 
     @pytest.mark.parametrize("cls, ref_fn, sign, scale", _NONLINEAR_PARAMS)
     def test_saturation(self, cls, ref_fn, sign, scale):  # noqa: ARG002


### PR DESCRIPTION
This PR implements `get_raw_weights` in `backendv2` routing so routing groups can extract dense per-neuron weights from predecessor nodes.

The implementation now supports:
- direct linear / identity-like paths
- `Conv1d` / `Conv2d`
- `MaxPool1d` / `MaxPool2d`
- `AvgPool1d` / `AvgPool2d`

It also handles signed accumulation paths and caches expanded path matrices to avoid repeated unfolding work.

## Changes

- implement `get_raw_weights` in `paibox/backendv2/routing.py`
- add helper utilities to normalize feature shapes and reconstruct per-predecessor `comps` / `weights` when needed
- expand direct weight paths into dense `[out, in]` matrices
- unfold convolution kernels into dense routing weights for `Conv1d` and `Conv2d`
- unfold pooling connectivity into dense routing weights for max/average pooling
- preserve path signs for `AccumulateOp` / `AddOp`
- add focused backendv2 tests for:
  - linear paths
  - conv paths
  - pooling paths
  - standalone activation identity paths
  - accumulate subtraction paths