### PR TITLE
Feat(backendv2): add PAIIR-based routing, core placement and frame export pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,5 @@ debug
 *.drawio
 
 .idea/
+
+output/

--- a/paibox/backendv2/core_config.py
+++ b/paibox/backendv2/core_config.py
@@ -1,14 +1,14 @@
 from paicorelib import (
-    SNNMode,
-    PoolingMode,
+    LCN_EX,
     AddPotentialMode,
-    ZeroOutputMode,
+    CSCAccelerateMode,
     InputSignMode,
     OutputSignMode,
+    PoolingMode,
+    SNNMode,
     WeightSignMode,
-    CSCAccelerateMode,
     WeightWidth,
-    LCN_EX,
+    ZeroOutputMode,
 )
 
 
@@ -22,6 +22,7 @@ class Default_Core_Config:
         self.add_potential: AddPotentialMode = AddPotentialMode.NORMAL
         self.csc_accelerate: CSCAccelerateMode = CSCAccelerateMode.DISABLE
 
+
 # this core configs are automatically set by backend according to routing and allocation result
 class Auto_Core_Config:
     def __init__(self):
@@ -31,6 +32,7 @@ class Auto_Core_Config:
         self.test_core_y: int = 0
         self.global_send: int = 0
         self.global_receive: int = 0
+
 
 # this core configs are inherited from frontend's compute op nodes, backend can not modify them except weight_width
 # weigth_width can be modified by backend for optimization, if don't change, set weight_width in Manual_Core_Config to the same value
@@ -48,6 +50,7 @@ class Inherited_Core_Config:
         self.tick_start: int = 0
         self.tick_duration: int = 0
         self.tick_initial: int = 0
+
 
 # these core configs can be set for optimization requirements
 class Manual_Core_Config:

--- a/paibox/backendv2/core_config.py
+++ b/paibox/backendv2/core_config.py
@@ -2,11 +2,9 @@ from paicorelib import (
     LCN_EX,
     AddPotentialMode,
     CSCAccelerateMode,
-    InputSignMode,
-    OutputSignMode,
+    DataSign,
     PoolingMode,
     SNNMode,
-    WeightSignMode,
     WeightWidth,
     ZeroOutputMode,
 )
@@ -41,11 +39,11 @@ class Inherited_Core_Config:
         self.snn_ann: SNNMode = SNNMode.SNN
         self.max_pooling: PoolingMode = PoolingMode.MAX
         self.zero_output: ZeroOutputMode = ZeroOutputMode.DISABLE
-        self.input_sign: InputSignMode = InputSignMode.SIGNED
+        self.input_sign: DataSign = DataSign.SIGNED
         self.input_width: WeightWidth = WeightWidth.WEIGHT_WIDTH_1BIT
-        self.output_sign: OutputSignMode = OutputSignMode.SIGNED
+        self.output_sign: DataSign = DataSign.SIGNED
         self.output_width: WeightWidth = WeightWidth.WEIGHT_WIDTH_1BIT
-        self.weight_sign: WeightSignMode = WeightSignMode.SIGNED
+        self.weight_sign: DataSign = DataSign.SIGNED
         self.weight_width: WeightWidth = WeightWidth.WEIGHT_WIDTH_1BIT
         self.tick_start: int = 0
         self.tick_duration: int = 0

--- a/paibox/backendv2/core_config.py
+++ b/paibox/backendv2/core_config.py
@@ -1,59 +1,103 @@
+from dataclasses import dataclass
+
 from paicorelib import (
     LCN_EX,
     AddPotentialMode,
+    CoordXY,
     CSCAccelerateMode,
     DataSign,
+    DataWidth,
+    OfflineCoreRegV2,
     PoolingMode,
     SNNMode,
-    WeightWidth,
     ZeroOutputMode,
 )
 
+TEST_DEST_CORE = CoordXY(0, 0)
+
 
 # default core configs that not used temporarily, all cores share the same default configs
+@dataclass
 class Default_Core_Config:
-    def __init__(self):
-        self.busy_cycle: int = 1
-        self.delay_cycle: int = 1
-        self.width_cycle: int = 1
-        self.thread_number: int = 0
-        self.add_potential: AddPotentialMode = AddPotentialMode.NORMAL
-        self.csc_accelerate: CSCAccelerateMode = CSCAccelerateMode.DISABLE
+    busy_cycle: int = 2
+    delay_cycle: int = 2
+    width_cycle: int = 2
+    thread_number: int = 0
+    csc_accelerate: CSCAccelerateMode = CSCAccelerateMode.ENABLE
 
 
 # this core configs are automatically set by backend according to routing and allocation result
+@dataclass
 class Auto_Core_Config:
-    def __init__(self):
-        self.neuron_number: int = 0
-        self.test_core_xy: int = 0
-        self.test_core_x: int = 0
-        self.test_core_y: int = 0
-        self.global_send: int = 0
-        self.global_receive: int = 0
-
-
-# this core configs are inherited from frontend's compute op nodes, backend can not modify them except weight_width
-# weigth_width can be modified by backend for optimization, if don't change, set weight_width in Manual_Core_Config to the same value
-class Inherited_Core_Config:
-    def __init__(self):
-        self.snn_ann: SNNMode = SNNMode.SNN
-        self.max_pooling: PoolingMode = PoolingMode.MAX
-        self.zero_output: ZeroOutputMode = ZeroOutputMode.DISABLE
-        self.input_sign: DataSign = DataSign.SIGNED
-        self.input_width: WeightWidth = WeightWidth.WEIGHT_WIDTH_1BIT
-        self.output_sign: DataSign = DataSign.SIGNED
-        self.output_width: WeightWidth = WeightWidth.WEIGHT_WIDTH_1BIT
-        self.weight_sign: DataSign = DataSign.SIGNED
-        self.weight_width: WeightWidth = WeightWidth.WEIGHT_WIDTH_1BIT
-        self.tick_start: int = 0
-        self.tick_duration: int = 0
-        self.tick_initial: int = 0
+    neuron_number: int = 0
+    test_core_xy: int = 0
+    test_core_x: int = 0
+    test_core_y: int = 0
+    global_send: int = 0
+    global_receive: int = 0
 
 
 # these core configs can be set for optimization requirements
-class Manual_Core_Config:
-    def __init__(self):
-        self.lcn: LCN_EX = LCN_EX.LCN_1X
-        self.target_lcn: LCN_EX = LCN_EX.LCN_1X
-        self.weight_width: WeightWidth = WeightWidth.WEIGHT_WIDTH_1BIT
-        self.axon_skew: int = 0
+@dataclass(frozen=True)
+class Backend_Core_Config:
+    lcn: LCN_EX = LCN_EX.LCN_1X
+    target_lcn: LCN_EX = LCN_EX.LCN_1X
+    axon_skew: int = 0
+    add_potential: AddPotentialMode = AddPotentialMode.NORMAL
+
+
+@dataclass(frozen=True)
+class Frontend_Core_Config:
+    snn_ann: SNNMode = SNNMode.SNN
+    max_pooling: PoolingMode = PoolingMode.AVERAGE
+    zero_output: ZeroOutputMode = ZeroOutputMode.DISABLE
+    input_sign: DataSign = DataSign.SIGNED
+    input_width: DataWidth = DataWidth.WIDTH_8BIT
+    output_sign: DataSign = DataSign.SIGNED
+    output_width: DataWidth = DataWidth.WIDTH_8BIT
+    weight_sign: DataSign = DataSign.SIGNED
+    weight_width: DataWidth = DataWidth.WIDTH_8BIT
+    tick_start: int = 1
+    tick_duration: int = 0
+    tick_initial: int = 0
+
+
+def to_core_reg(
+    default_conf: Default_Core_Config,
+    auto_conf: Auto_Core_Config,
+    backend_conf: Backend_Core_Config,
+    frontend_conf: Frontend_Core_Config,
+    coord: CoordXY,
+) -> OfflineCoreRegV2:
+
+    core_reg = OfflineCoreRegV2(
+        name=f"core_reg_at_({coord.x},{coord.y})",
+        snn_ann=frontend_conf.snn_ann,
+        max_pooling=frontend_conf.max_pooling,
+        add_potential=backend_conf.add_potential,
+        zero_output=frontend_conf.zero_output,
+        input_sign=frontend_conf.input_sign,
+        input_width=frontend_conf.input_width,
+        output_sign=frontend_conf.output_sign,
+        output_width=frontend_conf.output_width,
+        weight_sign=frontend_conf.weight_sign,
+        weight_width=frontend_conf.weight_width,
+        lcn=backend_conf.lcn,
+        target_lcn=backend_conf.target_lcn,
+        axon_skew=backend_conf.axon_skew,
+        neuron_number=auto_conf.neuron_number,
+        test_core_xy=auto_conf.test_core_xy,
+        test_core_x=auto_conf.test_core_x,
+        test_core_y=auto_conf.test_core_y,
+        global_send=auto_conf.global_send,
+        csc_accelerate=default_conf.csc_accelerate,
+        global_receive=auto_conf.global_receive,
+        thread_number=default_conf.thread_number,
+        busy_cycle=default_conf.busy_cycle,
+        delay_cycle=default_conf.delay_cycle,
+        width_cycle=default_conf.width_cycle,
+        tick_start=frontend_conf.tick_start,
+        tick_duration=frontend_conf.tick_duration,
+        tick_initial=frontend_conf.tick_initial,
+    )
+    return core_reg

--- a/paibox/backendv2/core_config.py
+++ b/paibox/backendv2/core_config.py
@@ -1,0 +1,58 @@
+from paicorelib import (
+    SNNMode,
+    PoolingMode,
+    AddPotentialMode,
+    ZeroOutputMode,
+    InputSignMode,
+    OutputSignMode,
+    WeightSignMode,
+    CSCAccelerateMode,
+    WeightWidth,
+    LCN_EX,
+)
+
+
+# default core configs that not used temporarily, all cores share the same default configs
+class Default_Core_Config:
+    def __init__(self):
+        self.busy_cycle: int = 1
+        self.delay_cycle: int = 1
+        self.width_cycle: int = 1
+        self.thread_number: int = 0
+        self.add_potential: AddPotentialMode = AddPotentialMode.NORMAL
+        self.csc_accelerate: CSCAccelerateMode = CSCAccelerateMode.DISABLE
+
+# this core configs are automatically set by backend according to routing and allocation result
+class Auto_Core_Config:
+    def __init__(self):
+        self.neuron_number: int = 0
+        self.test_core_xy: int = 0
+        self.test_core_x: int = 0
+        self.test_core_y: int = 0
+        self.global_send: int = 0
+        self.global_receive: int = 0
+
+# this core configs are inherited from frontend's compute op nodes, backend can not modify them except weight_width
+# weigth_width can be modified by backend for optimization, if don't change, set weight_width in Manual_Core_Config to the same value
+class Inherited_Core_Config:
+    def __init__(self):
+        self.snn_ann: SNNMode = SNNMode.SNN
+        self.max_pooling: PoolingMode = PoolingMode.MAX
+        self.zero_output: ZeroOutputMode = ZeroOutputMode.DISABLE
+        self.input_sign: InputSignMode = InputSignMode.SIGNED
+        self.input_width: WeightWidth = WeightWidth.WEIGHT_WIDTH_1BIT
+        self.output_sign: OutputSignMode = OutputSignMode.SIGNED
+        self.output_width: WeightWidth = WeightWidth.WEIGHT_WIDTH_1BIT
+        self.weight_sign: WeightSignMode = WeightSignMode.SIGNED
+        self.weight_width: WeightWidth = WeightWidth.WEIGHT_WIDTH_1BIT
+        self.tick_start: int = 0
+        self.tick_duration: int = 0
+        self.tick_initial: int = 0
+
+# these core configs can be set for optimization requirements
+class Manual_Core_Config:
+    def __init__(self):
+        self.lcn: LCN_EX = LCN_EX.LCN_1X
+        self.target_lcn: LCN_EX = LCN_EX.LCN_1X
+        self.weight_width: WeightWidth = WeightWidth.WEIGHT_WIDTH_1BIT
+        self.axon_skew: int = 0

--- a/paibox/backendv2/core_config.py
+++ b/paibox/backendv2/core_config.py
@@ -73,7 +73,6 @@ def to_core_reg(
     frontend_conf: Frontend_Core_Config,
     coord: CoordXY,
 ) -> OfflineCoreRegV2:
-
     core_reg = OfflineCoreRegV2(
         name=f"core_reg_at_({coord.x},{coord.y})",
         snn_ann=frontend_conf.snn_ann,

--- a/paibox/backendv2/core_config.py
+++ b/paibox/backendv2/core_config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 from paicorelib import (
     LCN_EX,
@@ -12,6 +13,8 @@ from paicorelib import (
     SNNMode,
     ZeroOutputMode,
 )
+
+from paibox.paiir import LutData
 
 TEST_DEST_CORE = CoordXY(0, 0)
 
@@ -60,6 +63,7 @@ class Frontend_Core_Config:
     tick_start: int = 1
     tick_duration: int = 0
     tick_initial: int = 0
+    lut_data: Optional[LutData] = None
 
 
 def to_core_reg(

--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import Optional
 
-from paicorelib import CoordXY, OfflineCoreRegV2
-
+import numpy as np
 from neuron import NeuronPlacement, OfflineNeuronPlacement
+from paicorelib import (
+    FRAME_DTYPE,
+    CoordXY,
+    FrameArrayType,
+    OfflineCoreRegV2,
+    OfflineFrameGenV2,
+    find_coordxy_shortest_path,
+)
 from routing import RoutingGroup
 from weight import Weight
 
@@ -43,6 +50,10 @@ class CorePlacement:
             raise ValueError("coord has not been set yet.")
         return self._coord
 
+    @abstractmethod
+    def to_frame(self) -> tuple[FrameArrayType, FrameArrayType]:
+        pass
+
 
 class EmptyOfflineCorePlacementV2(CorePlacement):
     def __init__(self):
@@ -64,16 +75,32 @@ class OfflineCorePlamentV2(CorePlacement):
             n_sram += weight.n_sram_required()
         return n_sram
 
-    def to_frame(self):
-        packages = []
+    def to_frame(self) -> tuple[FrameArrayType, FrameArrayType]:
+        pkt_offset, _ = find_coordxy_shortest_path(self.coord)
+
+        # frame_type_1: core config
+        frame_type1 = OfflineFrameGenV2.gen_config_frame1(
+            pkt_offset=pkt_offset,
+            core_reg_=self.core_config,
+        )
+
+        package_arrays: list[FrameArrayType] = []
         for neu in self.neus:
-            packages.extend(neu.to_package())
+            package_arrays.append(neu.to_package())
+
         for weight in self.weights:
-            packages.extend(weight.to_package())
+            package_arrays.append(weight.to_package())
 
-        def gen_frame():
-            raise NotImplementedError("gen_frame method is not implemented yet.")
+        packages = np.concatenate(package_arrays, axis=0).astype(FRAME_DTYPE)
 
-        start_frame = gen_frame()
+        start_frame = OfflineFrameGenV2.gen_config_frame3_pkg_header(
+            pkt_offset=pkt_offset,
+            start_addr=0,
+            n_package=len(packages),
+        )
 
-        raise NotImplementedError("to_frame method is not implemented yet.")
+        frame_type3 = np.concatenate([start_frame, packages], axis=0).astype(
+            FRAME_DTYPE
+        )
+
+        return frame_type1, frame_type3

--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from typing import Optional
 
 import numpy as np
-from neuron import NeuronPlacement, OfflineNeuronPlacement
+from .neuron import NeuronPlacement, OfflineNeuronPlacement
 from paicorelib import (
     FRAME_DTYPE,
     CoordXY,
@@ -13,8 +13,8 @@ from paicorelib import (
     OfflineFrameGenV2,
     find_coordxy_shortest_path,
 )
-from routing import RoutingGroup
-from weight import Weight
+#from .routing import RoutingGroup
+from .weight import Weight
 
 
 class CorePlacement:

--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -4,7 +4,6 @@ from abc import abstractmethod
 from typing import Optional
 
 import numpy as np
-from .neuron import NeuronPlacement, OfflineNeuronPlacement
 from paicorelib import (
     FRAME_DTYPE,
     CoordXY,
@@ -13,7 +12,10 @@ from paicorelib import (
     OfflineFrameGenV2,
     find_coordxy_shortest_path,
 )
-#from .routing import RoutingGroup
+
+from .neuron import NeuronPlacement, OfflineNeuronPlacement
+
+# from .routing import RoutingGroup
 from .weight import Weight
 
 

--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -7,12 +7,22 @@ import numpy as np
 from paicorelib import (
     FRAME_DTYPE,
     CoordXY,
+    DataWidth,
     FrameArrayType,
+    NeuronType,
     OfflineCoreRegV2,
     OfflineFrameGenV2,
     find_coordxy_shortest_path,
 )
 
+from .core_config import (
+    TEST_DEST_CORE,
+    Auto_Core_Config,
+    Backend_Core_Config,
+    Default_Core_Config,
+    Frontend_Core_Config,
+    to_core_reg,
+)
 from .neuron import NeuronPlacement, OfflineNeuronPlacement
 
 # from .routing import RoutingGroup
@@ -24,7 +34,6 @@ class CorePlacement:
         self,
     ) -> None:
         self._coord: Optional[CoordXY] = None
-        self._core_config: Optional[OfflineCoreRegV2] = None
         self.neus: list[NeuronPlacement] = (
             []
         )  # full or half neu, depending on neu allocation
@@ -41,10 +50,14 @@ class CorePlacement:
         return max_input_num
 
     @property
+    @abstractmethod
     def core_config(self) -> OfflineCoreRegV2:
-        if self._core_config is None:
-            raise ValueError("core_config has not been set yet.")
-        return self._core_config
+        pass
+
+    @property
+    @abstractmethod
+    def output_width(self) -> DataWidth:
+        pass
 
     @property
     def coord(self) -> CoordXY:
@@ -56,17 +69,26 @@ class CorePlacement:
     def to_frame(self) -> tuple[FrameArrayType, FrameArrayType]:
         pass
 
+    @abstractmethod
+    def set_weight_address(self) -> None:
+        pass
 
-class EmptyOfflineCorePlacementV2(CorePlacement):
-    def __init__(self):
-        super().__init__()
+    @abstractmethod
+    def set_auto_core_config(self) -> None:
+        pass
 
 
-class OfflineCorePlamentV2(CorePlacement):
+class OfflineCorePlacementV2(CorePlacement):
     def __init__(
         self,
+        frontend_core_config: Frontend_Core_Config = Frontend_Core_Config(),
+        backend_core_config: Backend_Core_Config = Backend_Core_Config(),
     ) -> None:
         super().__init__()
+        self.frontend_core_config: Frontend_Core_Config = frontend_core_config
+        self.backend_core_config: Backend_Core_Config = backend_core_config
+        self.default_core_config: Default_Core_Config = Default_Core_Config()
+        self.auto_core_config: Auto_Core_Config = Auto_Core_Config()
         self.neus: list[OfflineNeuronPlacement] = []
 
     def n_sram_required(self) -> int:
@@ -76,6 +98,49 @@ class OfflineCorePlamentV2(CorePlacement):
         for weight in self.weights:
             n_sram += weight.n_sram_required()
         return n_sram
+
+    @property
+    def core_config(self) -> OfflineCoreRegV2:
+        core_reg = to_core_reg(
+            default_conf=self.default_core_config,
+            auto_conf=self.auto_core_config,
+            backend_conf=self.backend_core_config,
+            frontend_conf=self.frontend_core_config,
+            coord=self.coord,
+        )
+        return core_reg
+
+    @property
+    def output_width(self) -> DataWidth:
+        return self.frontend_core_config.output_width
+
+    def set_weight_address(self) -> None:
+        current_address = 0
+        for neu in self.neus:
+            current_address += neu.n_sram_required()
+        weight_start_address = [current_address]
+        for weight in self.weights:
+            weight_start_address.append(
+                weight_start_address[-1] + weight.n_sram_required()
+            )
+        for i, neu in enumerate(self.neus):
+            weight_idx = self.neu_weight_map[i]
+            selected_weight = self.weights[weight_idx]
+            neu.neu_attrs_part1.weight_address_start = weight_start_address[weight_idx]
+            neu.neu_attrs_part1.weight_address_end = (
+                weight_start_address[weight_idx + 1] - 1
+            )
+
+    def set_auto_core_config(self) -> None:
+        neuron_number = 0
+        for neu in self.neus:
+            neu_count = 1 if neu.neuron_type == NeuronType.HALF else 2
+            neuron_number += neu_count
+        self.auto_core_config.neuron_number = neuron_number
+        pkt_offset, _ = find_coordxy_shortest_path(self.coord, TEST_DEST_CORE)
+        self.auto_core_config.test_core_xy = pkt_offset.z
+        self.auto_core_config.test_core_x = pkt_offset.x
+        self.auto_core_config.test_core_y = pkt_offset.y
 
     def to_frame(self) -> tuple[FrameArrayType, FrameArrayType]:
         pkt_offset, _ = find_coordxy_shortest_path(self.coord)
@@ -106,3 +171,7 @@ class OfflineCorePlamentV2(CorePlacement):
         )
 
         return frame_type1, frame_type3
+
+
+class EmptyOfflineCorePlacementV2(OfflineCorePlacementV2):
+    pass

--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -1,21 +1,29 @@
 from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Optional
+
 from paicorelib import CoordXY, OfflineCoreRegV2
+
 from neuron import NeuronPlacement, OfflineNeuronPlacement
 from routing import RoutingGroup
-from typing import Optional
 from weight import Weight
-from abc import abstractmethod
+
 
 class CorePlacement:
     def __init__(
-        self, 
+        self,
     ) -> None:
-        self.coord: Optional[CoordXY] = None
+        self._coord: Optional[CoordXY] = None
         self._core_config: Optional[OfflineCoreRegV2] = None
-        self.neus: list[NeuronPlacement] = [] # full or half neu, depending on neu allocation
-        self.weights: list[Weight] = [] # weight of each single neu, can reuse for different single neu
-        self.neu_weight_map: dict[int, int] = {} # map from neu index to weight index
-    
+        self.neus: list[NeuronPlacement] = (
+            []
+        )  # full or half neu, depending on neu allocation
+        self.weights: list[Weight] = (
+            []
+        )  # weight of each single neu, can reuse for different single neu
+        self.neu_weight_map: dict[int, int] = {}  # map from neu index to weight index
+
     def max_input_num(self) -> int:
         max_input_num = 0
         for weight in self.weights:
@@ -23,13 +31,31 @@ class CorePlacement:
             max_input_num = max(max_input_num, input_num)
         return max_input_num
 
+    @property
+    def core_config(self) -> OfflineCoreRegV2:
+        if self._core_config is None:
+            raise ValueError("core_config has not been set yet.")
+        return self._core_config
+
+    @property
+    def coord(self) -> CoordXY:
+        if self._coord is None:
+            raise ValueError("coord has not been set yet.")
+        return self._coord
+
+
+class EmptyOfflineCorePlacementV2(CorePlacement):
+    def __init__(self):
+        super().__init__()
+
+
 class OfflineCorePlamentV2(CorePlacement):
     def __init__(
         self,
     ) -> None:
         super().__init__()
         self.neus: list[OfflineNeuronPlacement] = []
-    
+
     def n_sram_required(self) -> int:
         n_sram = 0
         for neu in self.neus:
@@ -37,8 +63,8 @@ class OfflineCorePlamentV2(CorePlacement):
         for weight in self.weights:
             n_sram += weight.n_sram_required()
         return n_sram
-    
-    def to_frame(self):    
+
+    def to_frame(self):
         packages = []
         for neu in self.neus:
             packages.extend(neu.to_package())
@@ -47,10 +73,7 @@ class OfflineCorePlamentV2(CorePlacement):
 
         def gen_frame():
             raise NotImplementedError("gen_frame method is not implemented yet.")
-        
+
         start_frame = gen_frame()
-        
+
         raise NotImplementedError("to_frame method is not implemented yet.")
-        
-        
-        

--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+from paicorelib import CoordXY, OfflineCoreRegV2
+from neuron import NeuronPlacement, OfflineNeuronPlacement
+from routing import RoutingGroup
+from typing import Optional
+from weight import Weight
+from abc import abstractmethod
+
+class CorePlacement:
+    def __init__(
+        self, 
+    ) -> None:
+        self.coord: Optional[CoordXY] = None
+        self._core_config: Optional[OfflineCoreRegV2] = None
+        self.neus: list[NeuronPlacement] = [] # full or half neu, depending on neu allocation
+        self.weights: list[Weight] = [] # weight of each single neu, can reuse for different single neu
+        self.neu_weight_map: dict[int, int] = {} # map from neu index to weight index
+    
+    def max_input_num(self) -> int:
+        max_input_num = 0
+        for weight in self.weights:
+            input_num = len(weight.processed_weights)
+            max_input_num = max(max_input_num, input_num)
+        return max_input_num
+
+class OfflineCorePlamentV2(CorePlacement):
+    def __init__(
+        self,
+    ) -> None:
+        super().__init__()
+        self.neus: list[OfflineNeuronPlacement] = []
+    
+    def n_sram_required(self) -> int:
+        n_sram = 0
+        for neu in self.neus:
+            n_sram += neu.n_sram_required()
+        for weight in self.weights:
+            n_sram += weight.n_sram_required()
+        return n_sram
+    
+    def to_frame(self):    
+        packages = []
+        for neu in self.neus:
+            packages.extend(neu.to_package())
+        for weight in self.weights:
+            packages.extend(weight.to_package())
+
+        def gen_frame():
+            raise NotImplementedError("gen_frame method is not implemented yet.")
+        
+        start_frame = gen_frame()
+        
+        raise NotImplementedError("to_frame method is not implemented yet.")
+        
+        
+        

--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -6,12 +6,17 @@ from typing import Optional
 import numpy as np
 from paicorelib import (
     FRAME_DTYPE,
+    LUT_ACTIVATION_DTYPE,
+    LUT_POTENTIAL_DTYPE,
     CoordXY,
     DataWidth,
     FrameArrayType,
+    LUTActivationType,
+    LUTPotentialType,
     NeuronType,
     OfflineCoreRegV2,
     OfflineFrameGenV2,
+    SNNMode,
     find_coordxy_shortest_path,
 )
 
@@ -66,7 +71,9 @@ class CorePlacement:
         return self._coord
 
     @abstractmethod
-    def to_frame(self) -> tuple[FrameArrayType, FrameArrayType]:
+    def to_frame(
+        self,
+    ) -> tuple[FrameArrayType, Optional[FrameArrayType], FrameArrayType]:
         pass
 
     @abstractmethod
@@ -142,7 +149,9 @@ class OfflineCorePlacementV2(CorePlacement):
         self.auto_core_config.test_core_x = pkt_offset.x
         self.auto_core_config.test_core_y = pkt_offset.y
 
-    def to_frame(self) -> tuple[FrameArrayType, FrameArrayType]:
+    def to_frame(
+        self,
+    ) -> tuple[FrameArrayType, Optional[FrameArrayType], FrameArrayType]:
         pkt_offset, _ = find_coordxy_shortest_path(self.coord)
 
         # frame_type_1: core config
@@ -150,6 +159,21 @@ class OfflineCorePlacementV2(CorePlacement):
             pkt_offset=pkt_offset,
             core_reg_=self.core_config,
         )
+
+        frame_type2: Optional[FrameArrayType] = None
+        # frame_type_2: lut config
+        if self.frontend_core_config.lut_data is not None:
+            # assert self.frontend_core_config.snn_ann == SNNMode.ANN, "lut_data should only be provided for ANN mode"
+            potential_tensor = self.frontend_core_config.lut_data.thresholds
+            activation_tensor = self.frontend_core_config.lut_data.values
+            potentials = potential_tensor.numpy()
+            activations = activation_tensor.numpy()
+
+            frame_type2 = OfflineFrameGenV2.gen_config_frame2(
+                pkt_offset=pkt_offset,
+                potentials=potentials,
+                activations=activations,
+            )
 
         package_arrays: list[FrameArrayType] = []
         for neu in self.neus:
@@ -170,7 +194,7 @@ class OfflineCorePlacementV2(CorePlacement):
             FRAME_DTYPE
         )
 
-        return frame_type1, frame_type3
+        return frame_type1, frame_type2, frame_type3
 
 
 class EmptyOfflineCorePlacementV2(OfflineCorePlacementV2):

--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -6,17 +6,12 @@ from typing import Optional
 import numpy as np
 from paicorelib import (
     FRAME_DTYPE,
-    LUT_ACTIVATION_DTYPE,
-    LUT_POTENTIAL_DTYPE,
     CoordXY,
     DataWidth,
     FrameArrayType,
-    LUTActivationType,
-    LUTPotentialType,
     NeuronType,
     OfflineCoreRegV2,
     OfflineFrameGenV2,
-    SNNMode,
     find_coordxy_shortest_path,
 )
 

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -1,33 +1,49 @@
 from __future__ import annotations
 
-from paicorelib import FRAME_DTYPE, FrameArrayType
-from route_solver import route_solve
-from routing import RoutingGroup, toposort_for_rg
+import os
+from typing import TextIO
+
+from paicorelib import LCN_EX, AERPacketZXYCopy, CoordXY, FrameArrayType
+from torch.fx import GraphModule
+
+from .op_node import CoreOpNode, InputNode, build_nodes
+from .rg_build import build_routing_groups
+from .route_solver import route_solve
+from .routing import RoutingGroup, toposort_for_rg
 
 
-def export_single_framearray(frame_array: FrameArrayType, file_path: str) -> None:
-    with open(file_path, "a") as f:
-        for frame in frame_array:
-            f.write(f"{frame:016x}\n")
+def export_single_framearray(frame_array: FrameArrayType, file: TextIO) -> None:
+    for frame in frame_array:
+        file.write(f"{frame:016x}\n")
 
 
 class Mapper:
     def __init__(self):
         self.routing_groups: list[RoutingGroup] = []
+        self.nodes: list[CoreOpNode | InputNode] = []
+        self.output_routing_group: RoutingGroup = RoutingGroup([], [])
+        self.output_routing_group._base_coord = CoordXY(0, 0)
+        self.output_routing_group._multicast_config = AERPacketZXYCopy(z=0, x=0, y=0)
 
-    def generate_routing_groups(self) -> list[RoutingGroup]:
-        raise NotImplementedError(
-            "generate_routing_groups method is not implemented yet."
-        )
+    def generate_routing_groups(self, torch_graph: GraphModule):
+        self.nodes = build_nodes(torch_graph)
+        self.routing_groups = build_routing_groups(self.nodes)
 
     def set_rough_dest(self):
         # determine which routing group each neuron sends to
         for rg in self.routing_groups:
+            rg.set_lcn()
             for neu in rg.raw_neus:
                 for dest_rg in self.routing_groups:
-                    if neu in dest_rg.input_list:
+                    # use set to accelerate lookup
+                    if neu in dest_rg.input_set:
                         rg.dests[neu] = dest_rg
                         break
+                rg.dests[neu] = self.output_routing_group
+                self.output_routing_group.input_list.append(neu)
+
+        self.output_routing_group.input_set = set(self.output_routing_group.input_list)
+        self.output_routing_group.lcn = LCN_EX.LCN_128X
 
     def routing(self):
         self.routing_groups, next_rg_group = toposort_for_rg(self.routing_groups)
@@ -40,6 +56,10 @@ class Mapper:
             input_area_ids=[],
             output_area_ids=[],
         )
+        print("Routing result:")
+        print("Copy Configs:", copy_configs)
+        print("Coords:", coords)
+
         for rg, copy_config, rg_coords in zip(
             self.routing_groups, copy_configs, coords
         ):
@@ -49,21 +69,32 @@ class Mapper:
         for rg in self.routing_groups:
             rg.set_detail_dest()
 
+    def set_auto_core_config(self):
+        for rg in self.routing_groups:
+            rg.set_auto_core_config()
+
     def export(self, output_path: str):
+        os.makedirs(output_path, exist_ok=True)
         frame1_path = output_path + "/frame_type1.txt"
         frame3_path = output_path + "/frame_type3.txt"
-        for rg in self.routing_groups:
-            for core_placement in rg.core_placements:
-                core_frame_type1, core_frame_type3 = core_placement.to_frame()
-                # export core_frame_type1 and core_frame_type3 to output_path
-                # framearray is np.ndarray of np.uint64 with shape (n_frames, )
-                # print each frame with 16 hex digits each line
-                export_single_framearray(core_frame_type1, frame1_path)
-                export_single_framearray(core_frame_type3, frame3_path)
+        with (
+            open(frame1_path, "w") as frame1_file,
+            open(frame3_path, "w") as frame3_file,
+        ):
+            for rg in self.routing_groups:
+                for core_placement in rg.core_placements:
+                    core_frame_type1, core_frame_type3 = core_placement.to_frame()
+                    # export core_frame_type1 and core_frame_type3 to output_path
+                    # framearray is np.ndarray of np.uint64 with shape (n_frames, )
+                    # print each frame with 16 hex digits each line
+                    export_single_framearray(core_frame_type1, frame1_file)
+                    export_single_framearray(core_frame_type3, frame3_file)
 
-    def compile(self):
+    def compile(self, torch_graph: GraphModule):
         # determine raw_neus in routing groups, other properties remain unset
-        self.routing_groups = self.generate_routing_groups()
+        self.generate_routing_groups(torch_graph)
+
+        print(self.routing_groups)
 
         # determine which rg each neuron sends to
         # dests and input_list set
@@ -73,10 +104,20 @@ class Mapper:
         for rg in self.routing_groups:
             rg.allocate_neurons()
 
+        for rg in self.routing_groups:
+            print(rg.info())
+
         # set core placements' coord, and generate detailed dest info for each neuron
         self.routing()
 
+        for rg in self.routing_groups:
+            print(rg.info())
+
         self.set_detail_dest()
+        for rg in self.routing_groups:
+            print(rg.routing_summary())
+
+        self.set_auto_core_config()
 
         # export to hardware executable format
         self.export(output_path="./output")

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -1,0 +1,39 @@
+
+from __future__ import annotations
+from routing import RoutingGroup
+
+class Mapper():
+    def __init__(self):
+        pass
+    
+    def generate_routing_groups(self) -> list[RoutingGroup]:
+        raise NotImplementedError("generate_routing_groups method is not implemented yet.")
+    
+    def set_rough_dest(self):
+        raise NotImplementedError("set_rough_dest method is not implemented yet.")
+        
+    def routing(self):
+        raise NotImplementedError("routing method is not implemented yet.")
+    
+    def export(self):
+        raise NotImplementedError("export method is not implemented yet.")
+    
+    def compile(self):
+        
+        # determine raw_neus in routing groups, other properties remain unset
+        self.routing_groups = self.generate_routing_groups()
+        
+        # determine which rg each neuron sends to
+        # dests and input_list set
+        # other properties remain unset
+        self.set_rough_dest()
+        
+        for rg in self.routing_groups:
+            rg.allocate_neurons()
+        
+        # set core placements' coord, and generate detailed dest info for each neuron
+        self.routing()
+        
+        # export to hardware executable format
+        self.export()
+        

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -1,39 +1,61 @@
-
 from __future__ import annotations
-from routing import RoutingGroup
 
-class Mapper():
+from route_solver import route_solve
+from routing import RoutingGroup, toposort_for_rg
+
+
+class Mapper:
     def __init__(self):
-        pass
-    
+        self.routing_groups: list[RoutingGroup] = []
+
     def generate_routing_groups(self) -> list[RoutingGroup]:
-        raise NotImplementedError("generate_routing_groups method is not implemented yet.")
-    
+        raise NotImplementedError(
+            "generate_routing_groups method is not implemented yet."
+        )
+
     def set_rough_dest(self):
         raise NotImplementedError("set_rough_dest method is not implemented yet.")
-        
+
     def routing(self):
-        raise NotImplementedError("routing method is not implemented yet.")
-    
+        self.routing_groups, next_rg_group = toposort_for_rg(self.routing_groups)
+
+        areas = [rg.n_core_required for rg in self.routing_groups]
+        copy_configs, coords = route_solve(
+            areas=areas,
+            next_area_id=next_rg_group,
+            io_target=(0, 0),
+            input_area_ids=[],
+            output_area_ids=[],
+        )
+        for rg, copy_config, rg_coords in zip(
+            self.routing_groups, copy_configs, coords
+        ):
+            rg.assign_coord(rg_coords, copy_config)
+
+    def set_detail_dest(self):
+        for rg in self.routing_groups:
+            rg.set_detail_dest()
+
     def export(self):
         raise NotImplementedError("export method is not implemented yet.")
-    
+
     def compile(self):
-        
+
         # determine raw_neus in routing groups, other properties remain unset
         self.routing_groups = self.generate_routing_groups()
-        
+
         # determine which rg each neuron sends to
         # dests and input_list set
         # other properties remain unset
         self.set_rough_dest()
-        
+
         for rg in self.routing_groups:
             rg.allocate_neurons()
-        
+
         # set core placements' coord, and generate detailed dest info for each neuron
         self.routing()
-        
+
+        self.set_detail_dest()
+
         # export to hardware executable format
         self.export()
-        

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+from paicorelib import FRAME_DTYPE, FrameArrayType
 from route_solver import route_solve
 from routing import RoutingGroup, toposort_for_rg
+
+
+def export_single_framearray(frame_array: FrameArrayType, file_path: str) -> None:
+    with open(file_path, "a") as f:
+        for frame in frame_array:
+            f.write(f"{frame:016x}\n")
 
 
 class Mapper:
@@ -14,7 +21,13 @@ class Mapper:
         )
 
     def set_rough_dest(self):
-        raise NotImplementedError("set_rough_dest method is not implemented yet.")
+        # determine which routing group each neuron sends to
+        for rg in self.routing_groups:
+            for neu in rg.raw_neus:
+                for dest_rg in self.routing_groups:
+                    if neu in dest_rg.input_list:
+                        rg.dests[neu] = dest_rg
+                        break
 
     def routing(self):
         self.routing_groups, next_rg_group = toposort_for_rg(self.routing_groups)
@@ -36,11 +49,19 @@ class Mapper:
         for rg in self.routing_groups:
             rg.set_detail_dest()
 
-    def export(self):
-        raise NotImplementedError("export method is not implemented yet.")
+    def export(self, output_path: str):
+        frame1_path = output_path + "/frame_type1.txt"
+        frame3_path = output_path + "/frame_type3.txt"
+        for rg in self.routing_groups:
+            for core_placement in rg.core_placements:
+                core_frame_type1, core_frame_type3 = core_placement.to_frame()
+                # export core_frame_type1 and core_frame_type3 to output_path
+                # framearray is np.ndarray of np.uint64 with shape (n_frames, )
+                # print each frame with 16 hex digits each line
+                export_single_framearray(core_frame_type1, frame1_path)
+                export_single_framearray(core_frame_type3, frame3_path)
 
     def compile(self):
-
         # determine raw_neus in routing groups, other properties remain unset
         self.routing_groups = self.generate_routing_groups()
 
@@ -58,4 +79,4 @@ class Mapper:
         self.set_detail_dest()
 
         # export to hardware executable format
-        self.export()
+        self.export(output_path="./output")

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -32,10 +32,6 @@ def export_framearray_to_bit(
         # 转成二进制字符串，每32位补0
         high_bin = f"{high32:032b}"
         low_bin = f"{low32:032b}"
-        # 每16位加下划线，可读性更好
-        high_bin = "_".join(high_bin[i : i + 16] for i in range(0, 32, 16))
-        low_bin = "_".join(low_bin[i : i + 16] for i in range(0, 32, 16))
-        # 输出到一行
         file.write(f"{prefix}0b{high_bin},0b{low_bin},\n")
 
 
@@ -120,10 +116,10 @@ class Mapper:
                         core_placement.to_frame()
                     )
                     # export core_frame_type1 and core_frame_type3 to output_path
-                    export_framearray_to_bit(core_frame_type1, frame1_file, "\t0x")
+                    export_framearray_to_bit(core_frame_type1, frame1_file, "\t")
                     if core_frame_type2 is not None:
-                        export_framearray_to_bit(core_frame_type2, frame2_file, "\t0x")
-                    export_framearray_to_bit(core_frame_type3, frame3_file, "\t0x")
+                        export_framearray_to_bit(core_frame_type2, frame2_file, "\t")
+                    export_framearray_to_bit(core_frame_type3, frame3_file, "\t")
 
             frame1_file.write("};\n")
             frame2_file.write("};\n")

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -4,7 +4,6 @@ import os
 from typing import TextIO
 
 from paicorelib import LCN_EX, AERPacketZXYCopy, CoordXY, FrameArrayType
-from torch.fx import GraphModule
 
 from paibox.paiir import PAIIRGraph
 
@@ -22,6 +21,7 @@ def export_single_framearray(
         hex_str = "_".join(hex_str[i : i + 4] for i in range(0, 16, 4))
         file.write(f"{prefix}{hex_str}\n")
 
+
 def export_framearray_to_bit(
     frame_array: FrameArrayType, file: TextIO, prefix: str = ""
 ) -> None:
@@ -33,8 +33,8 @@ def export_framearray_to_bit(
         high_bin = f"{high32:032b}"
         low_bin = f"{low32:032b}"
         # 每16位加下划线，可读性更好
-        high_bin = "_".join(high_bin[i:i+16] for i in range(0, 32, 16))
-        low_bin = "_".join(low_bin[i:i+16] for i in range(0, 32, 16))
+        high_bin = "_".join(high_bin[i : i + 16] for i in range(0, 32, 16))
+        low_bin = "_".join(low_bin[i : i + 16] for i in range(0, 32, 16))
         # 输出到一行
         file.write(f"{prefix}0b{high_bin},0b{low_bin},\n")
 
@@ -105,9 +105,15 @@ class Mapper:
             open(frame2_path, "w") as frame2_file,
             open(frame3_path, "w") as frame3_file,
         ):
-            frame1_file.write("volatile unsigned int config_frame1[] __attribute__((section(\".large_const_data\"))) ={\n")
-            frame2_file.write("volatile unsigned int config_frame2[] __attribute__((section(\".large_const_data\"))) ={\n")
-            frame3_file.write("volatile unsigned int config_frame3[] __attribute__((section(\".large_const_data\"))) ={\n")
+            frame1_file.write(
+                'volatile unsigned int config_frame1[] __attribute__((section(".large_const_data"))) ={\n'
+            )
+            frame2_file.write(
+                'volatile unsigned int config_frame2[] __attribute__((section(".large_const_data"))) ={\n'
+            )
+            frame3_file.write(
+                'volatile unsigned int config_frame3[] __attribute__((section(".large_const_data"))) ={\n'
+            )
             for rg in self.routing_groups:
                 for core_placement in rg.core_placements:
                     core_frame_type1, core_frame_type2, core_frame_type3 = (

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -6,27 +6,49 @@ from typing import TextIO
 from paicorelib import LCN_EX, AERPacketZXYCopy, CoordXY, FrameArrayType
 from torch.fx import GraphModule
 
-from .op_node import CoreOpNode, InputNode, build_nodes
+from paibox.paiir import PAIIRGraph
+
+from .op_node import CoreOpNode, InNode, build_nodes
 from .rg_build import build_routing_groups
 from .route_solver import route_solve
 from .routing import RoutingGroup, toposort_for_rg
 
 
-def export_single_framearray(frame_array: FrameArrayType, file: TextIO) -> None:
+def export_single_framearray(
+    frame_array: FrameArrayType, file: TextIO, prefix: str = ""
+) -> None:
     for frame in frame_array:
-        file.write(f"{frame:016x}\n")
+        hex_str = f"{frame:016x}"
+        hex_str = "_".join(hex_str[i : i + 4] for i in range(0, 16, 4))
+        file.write(f"{prefix}{hex_str}\n")
+
+def export_framearray_to_bit(
+    frame_array: FrameArrayType, file: TextIO, prefix: str = ""
+) -> None:
+    for frame in frame_array:
+        # mask 取高32位和低32位
+        high32 = (frame >> 32) & 0xFFFFFFFF
+        low32 = frame & 0xFFFFFFFF
+        # 转成二进制字符串，每32位补0
+        high_bin = f"{high32:032b}"
+        low_bin = f"{low32:032b}"
+        # 每16位加下划线，可读性更好
+        high_bin = "_".join(high_bin[i:i+16] for i in range(0, 32, 16))
+        low_bin = "_".join(low_bin[i:i+16] for i in range(0, 32, 16))
+        # 输出到一行
+        file.write(f"{prefix}0b{high_bin},0b{low_bin},\n")
 
 
 class Mapper:
     def __init__(self):
         self.routing_groups: list[RoutingGroup] = []
-        self.nodes: list[CoreOpNode | InputNode] = []
+        self.nodes: list[CoreOpNode | InNode] = []
         self.output_routing_group: RoutingGroup = RoutingGroup([], [])
         self.output_routing_group._base_coord = CoordXY(0, 0)
         self.output_routing_group._multicast_config = AERPacketZXYCopy(z=0, x=0, y=0)
 
-    def generate_routing_groups(self, torch_graph: GraphModule):
-        self.nodes = build_nodes(torch_graph)
+    def generate_routing_groups(self, pai_graph: PAIIRGraph):
+        self.nodes = build_nodes(pai_graph)
         self.routing_groups = build_routing_groups(self.nodes)
 
     def set_rough_dest(self):
@@ -73,26 +95,76 @@ class Mapper:
         for rg in self.routing_groups:
             rg.set_auto_core_config()
 
+    def export_cheader_file(self, output_path: str):
+        os.makedirs(output_path, exist_ok=True)
+        frame1_path = output_path + "/frame_type1.h"
+        frame2_path = output_path + "/frame_type2.h"
+        frame3_path = output_path + "/frame_type3.h"
+        with (
+            open(frame1_path, "w") as frame1_file,
+            open(frame2_path, "w") as frame2_file,
+            open(frame3_path, "w") as frame3_file,
+        ):
+            frame1_file.write("volatile unsigned int config_frame1[] __attribute__((section(\".large_const_data\"))) ={\n")
+            frame2_file.write("volatile unsigned int config_frame2[] __attribute__((section(\".large_const_data\"))) ={\n")
+            frame3_file.write("volatile unsigned int config_frame3[] __attribute__((section(\".large_const_data\"))) ={\n")
+            for rg in self.routing_groups:
+                for core_placement in rg.core_placements:
+                    core_frame_type1, core_frame_type2, core_frame_type3 = (
+                        core_placement.to_frame()
+                    )
+                    # export core_frame_type1 and core_frame_type3 to output_path
+                    export_framearray_to_bit(core_frame_type1, frame1_file, "\t0x")
+                    if core_frame_type2 is not None:
+                        export_framearray_to_bit(core_frame_type2, frame2_file, "\t0x")
+                    export_framearray_to_bit(core_frame_type3, frame3_file, "\t0x")
+
+            frame1_file.write("};\n")
+            frame2_file.write("};\n")
+            frame3_file.write("};\n")
+
     def export(self, output_path: str):
         os.makedirs(output_path, exist_ok=True)
         frame1_path = output_path + "/frame_type1.txt"
+        frame2_path = output_path + "/frame_type2.txt"
         frame3_path = output_path + "/frame_type3.txt"
         with (
             open(frame1_path, "w") as frame1_file,
+            open(frame2_path, "w") as frame2_file,
             open(frame3_path, "w") as frame3_file,
         ):
             for rg in self.routing_groups:
                 for core_placement in rg.core_placements:
-                    core_frame_type1, core_frame_type3 = core_placement.to_frame()
+                    frame1_file.write(
+                        f"# Core at coord ({core_placement.coord.x}, {core_placement.coord.y}):\n"
+                    )
+                    frame2_file.write(
+                        f"# Core at coord ({core_placement.coord.x}, {core_placement.coord.y}):\n"
+                    )
+                    frame3_file.write(
+                        f"# Core at coord ({core_placement.coord.x}, {core_placement.coord.y}):\n"
+                    )
+
+                    core_frame_type1, core_frame_type2, core_frame_type3 = (
+                        core_placement.to_frame()
+                    )
                     # export core_frame_type1 and core_frame_type3 to output_path
                     # framearray is np.ndarray of np.uint64 with shape (n_frames, )
                     # print each frame with 16 hex digits each line
-                    export_single_framearray(core_frame_type1, frame1_file)
-                    export_single_framearray(core_frame_type3, frame3_file)
+                    export_single_framearray(
+                        core_frame_type1, frame1_file, prefix="\t0x"
+                    )
+                    if core_frame_type2 is not None:
+                        export_single_framearray(
+                            core_frame_type2, frame2_file, prefix="\t0x"
+                        )
+                    export_single_framearray(
+                        core_frame_type3, frame3_file, prefix="\t0x"
+                    )
 
-    def compile(self, torch_graph: GraphModule):
+    def compile(self, pai_graph: PAIIRGraph):
         # determine raw_neus in routing groups, other properties remain unset
-        self.generate_routing_groups(torch_graph)
+        self.generate_routing_groups(pai_graph)
 
         print(self.routing_groups)
 
@@ -121,3 +193,4 @@ class Mapper:
 
         # export to hardware executable format
         self.export(output_path="./output")
+        self.export_cheader_file(output_path="./output")

--- a/paibox/backendv2/neuron.py
+++ b/paibox/backendv2/neuron.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
-from paicorelib import OfflineNeuFullAttrsV2Part1, OfflineNeuFullAttrsV2Part2, FoldedNeuAttrsV2Part1, OfflineFoldedNeuAttrsV2Part2, NeuDestInfoV2, OfflineNeuDestInfoV2
+
 from typing import Optional
-from paicorelib import OfflineCoreRegV2
+
+from paicorelib import (
+    FoldedNeuAttrsV2Part1,
+    NeuDestInfoV2,
+    OfflineCoreRegV2,
+    OfflineFoldedNeuAttrsV2Part2,
+    OfflineNeuDestInfoV2,
+    OfflineNeuFullAttrsV2Part1,
+    OfflineNeuFullAttrsV2Part2,
+)
+
 from core_config import Inherited_Core_Config
 
 
@@ -12,40 +22,56 @@ class CoreOpNode:
     def core_config(self) -> Inherited_Core_Config:
         raise NotImplementedError("core_config method is not implemented yet.")
 
+    def __hash__(self) -> int:
+        return hash(id(self))
+
+
 class CustomIndex:
-    pass
+    def __init__(self):
+        self.idx = 0
+
+    def __hash__(self) -> int:
+        return hash(self.idx)
 
 
 class Neuron:
-    def __init__(self):
-        self.target: Optional[CoreOpNode] = None
-        self.index: Optional[CustomIndex] = None
-    
+    def __init__(
+        self, target: Optional[CoreOpNode] = None, index: Optional[CustomIndex] = None
+    ):
+        if target is None or index is None:
+            raise ValueError("target and index must be provided.")
+        self.target = target
+        self.index = index
+
     def attrs_part2(self) -> OfflineNeuFullAttrsV2Part2:
         if self.target is not None:
             return self.target.attrs_part2()
         else:
             raise ValueError("target has not been set yet.")
-    
+
     def core_config(self) -> Inherited_Core_Config:
         if self.target is not None:
             return self.target.core_config()
         else:
             raise ValueError("target has not been set yet.")
 
+    def __hash__(self) -> int:
+        return hash((self.index, self.target))
+
+
 class NeuronPlacement:
-    pass
+    def __init__(self) -> None:
+        self.raw_neus: list[Neuron] = []
+        self.dest_info: Optional[OfflineNeuDestInfoV2] = None
+
 
 class OfflineNeuronPlacement(NeuronPlacement):
     def __init__(self):
-        self.dest_info: Optional[OfflineNeuDestInfoV2] = None
         self.neu_attrs_part1: Optional[OfflineNeuFullAttrsV2Part1] = None
         self.neu_attrs_part2: Optional[OfflineNeuFullAttrsV2Part2] = None
         self.folded_neu_attrs_part1: Optional[FoldedNeuAttrsV2Part1] = None
         self.folded_neu_attrs_part2s: list[OfflineFoldedNeuAttrsV2Part2] = []
-        self.raw_neus: list[Neuron] = []
-        
-    
+
     def n_sram_required(self) -> int:
         n_sram = 0
         if self.neu_attrs_part1 is not None:

--- a/paibox/backendv2/neuron.py
+++ b/paibox/backendv2/neuron.py
@@ -8,76 +8,84 @@ from paicorelib import (
     FrameArrayType,
     NeuDestInfoV2,
     NeuronType,
-    OfflineCoreRegV2,
     OfflineFrameGenV2,
     OfflineNeuDestInfoV2,
     OfflineNeuFoldedAttrsV2Part1,
     OfflineNeuFoldedAttrsV2Part2,
     OfflineNeuFullAttrsV2Part1,
     OfflineNeuFullAttrsV2Part2,
+    OutputType,
 )
 
-from .core_config import Inherited_Core_Config
-
-
-class CoreOpNode:
-    def attrs_part2(self) -> OfflineNeuFullAttrsV2Part2:
-        raise NotImplementedError("attrs_part2 method is not implemented yet.")
-
-    def core_config(self) -> Inherited_Core_Config:
-        raise NotImplementedError("core_config method is not implemented yet.")
-
-    def __hash__(self) -> int:
-        return hash(id(self))
-
-
-class CustomIndex:
-    def __init__(self):
-        self.idx = 0
-
-    def __hash__(self) -> int:
-        return hash(self.idx)
+from .core_config import Frontend_Core_Config
+from .op_node import CoreOpNode, CustomIndex, InputNode
 
 
 class Neuron:
-    def __init__(
-        self, target: Optional[CoreOpNode] = None, index: Optional[CustomIndex] = None
-    ):
-        if target is None or index is None:
-            raise ValueError("target and index must be provided.")
+    def __init__(self, target: CoreOpNode, index: CustomIndex):
         self.target = target
         self.index = index
 
     def attrs_part2(self) -> OfflineNeuFullAttrsV2Part2:
-        if self.target is not None:
-            return self.target.attrs_part2()
-        else:
-            raise ValueError("target has not been set yet.")
+        return self.target.attrs_part2()
 
-    def core_config(self) -> Inherited_Core_Config:
-        if self.target is not None:
-            return self.target.core_config()
-        else:
-            raise ValueError("target has not been set yet.")
+    def output_type(self) -> OutputType:
+        return self.target.output_type()
+
+    def core_config(self) -> Frontend_Core_Config:
+        return self.target.core_config()
 
     def __hash__(self) -> int:
         return hash((self.index, self.target))
 
+    def __eq__(self, value: "Neuron") -> bool:
+        return self.index == value.index and self.target is value.target
+
+    def __str__(self) -> str:
+        return f"{self.target.name}[{self.index.idx}]"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+class InputElem:
+    def __init__(self, target: InputNode, index: CustomIndex):
+        self.target = target
+        self.index = index
+
+    def __hash__(self) -> int:
+        return hash((self.index, self.target))
+
+    def __eq__(self, value: "InputElem") -> bool:
+        return self.index == value.index and self.target is value.target
+
+    def __str__(self) -> str:
+        return f"{self.target.name}[{self.index.idx}]"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
 
 class NeuronPlacement:
-    def __init__(self) -> None:
-        self.raw_neus: list[Neuron] = []
-        self.dest_info: Optional[OfflineNeuDestInfoV2] = None
+    def __init__(self, neu: list[Neuron]) -> None:
+        self.raw_neus: list[Neuron] = neu
+        self.dest_info: Optional[NeuDestInfoV2] = None
 
 
 class OfflineNeuronPlacement(NeuronPlacement):
-    def __init__(self, neu, attrs):
+    def __init__(
+        self,
+        neu: list[Neuron],
+        attrs_part1: OfflineNeuFullAttrsV2Part1,
+        attrs_part2: OfflineNeuFullAttrsV2Part2,
+    ):
         super().__init__(neu)
-        self.neu_attrs_part1: Optional[OfflineNeuFullAttrsV2Part1] = None
-        self.neu_attrs_part2: Optional[OfflineNeuFullAttrsV2Part2] = attrs
+        self.neu_attrs_part1: OfflineNeuFullAttrsV2Part1 = attrs_part1
+        self.neu_attrs_part2: Optional[OfflineNeuFullAttrsV2Part2] = (
+            attrs_part2 if attrs_part1.neuron_type == NeuronType.FULL else None
+        )
         self.folded_neu_attrs_part1: Optional[OfflineNeuFoldedAttrsV2Part1] = None
         self.folded_neu_attrs_part2s: list[OfflineNeuFoldedAttrsV2Part2] = []
-        self.neuron_type = NeuronType.FULL
 
     def n_sram_required(self) -> int:
         n_sram = 0
@@ -93,6 +101,8 @@ class OfflineNeuronPlacement(NeuronPlacement):
     def to_package(self) -> FrameArrayType:
         if self.dest_info is None:
             raise ValueError("dest_info has not been set yet.")
+        if not isinstance(self.dest_info, OfflineNeuDestInfoV2):
+            raise TypeError("dest_info must be of type OfflineNeuDestInfoV2.")
 
         half_neu, full_neu, fold_neu = OfflineFrameGenV2.gen_config_frame3_pkg_neu(
             dest_info=self.dest_info,
@@ -106,3 +116,7 @@ class OfflineNeuronPlacement(NeuronPlacement):
             [half_neu, full_neu, fold_neu], axis=0
         ).astype(FRAME_DTYPE)
         return frame_list
+
+    @property
+    def neuron_type(self) -> NeuronType:
+        return self.neu_attrs_part1.neuron_type

--- a/paibox/backendv2/neuron.py
+++ b/paibox/backendv2/neuron.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
-from core_config import Inherited_Core_Config
+from .core_config import Inherited_Core_Config
 from paicorelib import (
     FRAME_DTYPE,
     FrameArrayType,
@@ -15,6 +15,7 @@ from paicorelib import (
     OfflineNeuFoldedAttrsV2Part2,
     OfflineNeuFullAttrsV2Part1,
     OfflineNeuFullAttrsV2Part2,
+    NeuronType,
 )
 
 
@@ -69,11 +70,13 @@ class NeuronPlacement:
 
 
 class OfflineNeuronPlacement(NeuronPlacement):
-    def __init__(self):
+    def __init__(self, neu, attrs):
+        super().__init__(neu)
         self.neu_attrs_part1: Optional[OfflineNeuFullAttrsV2Part1] = None
-        self.neu_attrs_part2: Optional[OfflineNeuFullAttrsV2Part2] = None
+        self.neu_attrs_part2: Optional[OfflineNeuFullAttrsV2Part2] = attrs
         self.folded_neu_attrs_part1: Optional[OfflineNeuFoldedAttrsV2Part1] = None
         self.folded_neu_attrs_part2s: list[OfflineNeuFoldedAttrsV2Part2] = []
+        self.neuron_type = NeuronType.FULL
 
     def n_sram_required(self) -> int:
         n_sram = 0

--- a/paibox/backendv2/neuron.py
+++ b/paibox/backendv2/neuron.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+from paicorelib import OfflineNeuFullAttrsV2Part1, OfflineNeuFullAttrsV2Part2, FoldedNeuAttrsV2Part1, OfflineFoldedNeuAttrsV2Part2, NeuDestInfoV2, OfflineNeuDestInfoV2
+from typing import Optional
+from paicorelib import OfflineCoreRegV2
+from core_config import Inherited_Core_Config
+
+
+class CoreOpNode:
+    def attrs_part2(self) -> OfflineNeuFullAttrsV2Part2:
+        raise NotImplementedError("attrs_part2 method is not implemented yet.")
+
+    def core_config(self) -> Inherited_Core_Config:
+        raise NotImplementedError("core_config method is not implemented yet.")
+
+class CustomIndex:
+    pass
+
+
+class Neuron:
+    def __init__(self):
+        self.target: Optional[CoreOpNode] = None
+        self.index: Optional[CustomIndex] = None
+    
+    def attrs_part2(self) -> OfflineNeuFullAttrsV2Part2:
+        if self.target is not None:
+            return self.target.attrs_part2()
+        else:
+            raise ValueError("target has not been set yet.")
+    
+    def core_config(self) -> Inherited_Core_Config:
+        if self.target is not None:
+            return self.target.core_config()
+        else:
+            raise ValueError("target has not been set yet.")
+
+class NeuronPlacement:
+    pass
+
+class OfflineNeuronPlacement(NeuronPlacement):
+    def __init__(self):
+        self.dest_info: Optional[OfflineNeuDestInfoV2] = None
+        self.neu_attrs_part1: Optional[OfflineNeuFullAttrsV2Part1] = None
+        self.neu_attrs_part2: Optional[OfflineNeuFullAttrsV2Part2] = None
+        self.folded_neu_attrs_part1: Optional[FoldedNeuAttrsV2Part1] = None
+        self.folded_neu_attrs_part2s: list[OfflineFoldedNeuAttrsV2Part2] = []
+        self.raw_neus: list[Neuron] = []
+        
+    
+    def n_sram_required(self) -> int:
+        n_sram = 0
+        if self.neu_attrs_part1 is not None:
+            n_sram += 1
+        if self.neu_attrs_part2 is not None:
+            n_sram += 1
+        if self.folded_neu_attrs_part1 is not None:
+            n_sram += 1
+        n_sram += len(self.folded_neu_attrs_part2s)
+        return n_sram
+
+    def to_package(self):
+        raise NotImplementedError("to_package method is not implemented yet.")

--- a/paibox/backendv2/neuron.py
+++ b/paibox/backendv2/neuron.py
@@ -2,17 +2,20 @@ from __future__ import annotations
 
 from typing import Optional
 
+import numpy as np
+from core_config import Inherited_Core_Config
 from paicorelib import (
-    FoldedNeuAttrsV2Part1,
+    FRAME_DTYPE,
+    FrameArrayType,
     NeuDestInfoV2,
     OfflineCoreRegV2,
-    OfflineFoldedNeuAttrsV2Part2,
+    OfflineFrameGenV2,
     OfflineNeuDestInfoV2,
+    OfflineNeuFoldedAttrsV2Part1,
+    OfflineNeuFoldedAttrsV2Part2,
     OfflineNeuFullAttrsV2Part1,
     OfflineNeuFullAttrsV2Part2,
 )
-
-from core_config import Inherited_Core_Config
 
 
 class CoreOpNode:
@@ -69,8 +72,8 @@ class OfflineNeuronPlacement(NeuronPlacement):
     def __init__(self):
         self.neu_attrs_part1: Optional[OfflineNeuFullAttrsV2Part1] = None
         self.neu_attrs_part2: Optional[OfflineNeuFullAttrsV2Part2] = None
-        self.folded_neu_attrs_part1: Optional[FoldedNeuAttrsV2Part1] = None
-        self.folded_neu_attrs_part2s: list[OfflineFoldedNeuAttrsV2Part2] = []
+        self.folded_neu_attrs_part1: Optional[OfflineNeuFoldedAttrsV2Part1] = None
+        self.folded_neu_attrs_part2s: list[OfflineNeuFoldedAttrsV2Part2] = []
 
     def n_sram_required(self) -> int:
         n_sram = 0
@@ -83,5 +86,19 @@ class OfflineNeuronPlacement(NeuronPlacement):
         n_sram += len(self.folded_neu_attrs_part2s)
         return n_sram
 
-    def to_package(self):
-        raise NotImplementedError("to_package method is not implemented yet.")
+    def to_package(self) -> FrameArrayType:
+        if self.dest_info is None:
+            raise ValueError("dest_info has not been set yet.")
+
+        half_neu, full_neu, fold_neu = OfflineFrameGenV2.gen_config_frame3_pkg_neu(
+            dest_info=self.dest_info,
+            full_attrs1=self.neu_attrs_part1,
+            full_attrs2=self.neu_attrs_part2,
+            folded_attrs1=self.folded_neu_attrs_part1,
+            folded_attrs2_=self.folded_neu_attrs_part2s,
+        )
+
+        frame_list: FrameArrayType = np.concatenate(
+            [half_neu, full_neu, fold_neu], axis=0
+        ).astype(FRAME_DTYPE)
+        return frame_list

--- a/paibox/backendv2/neuron.py
+++ b/paibox/backendv2/neuron.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
-from .core_config import Inherited_Core_Config
 from paicorelib import (
     FRAME_DTYPE,
     FrameArrayType,
     NeuDestInfoV2,
+    NeuronType,
     OfflineCoreRegV2,
     OfflineFrameGenV2,
     OfflineNeuDestInfoV2,
@@ -15,8 +15,9 @@ from paicorelib import (
     OfflineNeuFoldedAttrsV2Part2,
     OfflineNeuFullAttrsV2Part1,
     OfflineNeuFullAttrsV2Part2,
-    NeuronType,
 )
+
+from .core_config import Inherited_Core_Config
 
 
 class CoreOpNode:

--- a/paibox/backendv2/neuron.py
+++ b/paibox/backendv2/neuron.py
@@ -18,7 +18,7 @@ from paicorelib import (
 )
 
 from .core_config import Frontend_Core_Config
-from .op_node import CoreOpNode, CustomIndex, InputNode
+from .op_node import CoreOpNode, CustomIndex, InNode
 
 
 class Neuron:
@@ -27,7 +27,7 @@ class Neuron:
         self.index = index
 
     def attrs_part2(self) -> OfflineNeuFullAttrsV2Part2:
-        return self.target.attrs_part2()
+        return self.target.attrs_part2(self.index.idx)
 
     def output_type(self) -> OutputType:
         return self.target.output_type()
@@ -49,7 +49,7 @@ class Neuron:
 
 
 class InputElem:
-    def __init__(self, target: InputNode, index: CustomIndex):
+    def __init__(self, target: InNode, index: CustomIndex):
         self.target = target
         self.index = index
 

--- a/paibox/backendv2/op_node.py
+++ b/paibox/backendv2/op_node.py
@@ -1,0 +1,175 @@
+import torch
+from paicorelib import (
+    DataSign,
+    DataWidth,
+    OfflineNeuFullAttrsV2Part2,
+    OutputType,
+    PoolingMode,
+    SNNMode,
+    WeightCompressType,
+    ZeroOutputMode,
+)
+from torch.fx import GraphModule, Node
+
+from ..fx_converter.clac_params import NeuV2ClacParams, OfflineCoreV2CalcParams
+from ..fx_converter.core_op import BaseCoreOp
+from .core_config import Frontend_Core_Config
+
+
+class CustomIndex:
+    def __init__(self, idx: int):
+        self.idx = idx
+
+    def __hash__(self) -> int:
+        return hash(self.idx)
+
+    def __eq__(self, value: "CustomIndex") -> bool:
+        return self.idx == value.idx
+
+
+def get_frontend_core_conf(
+    core_params: OfflineCoreV2CalcParams,
+) -> Frontend_Core_Config:
+    def to_enum(value, enum_cls):
+        return enum_cls(value) if isinstance(value, int) else value
+
+    snn_ann = to_enum(core_params.snn_ann, SNNMode)
+
+    return Frontend_Core_Config(
+        snn_ann=to_enum(core_params.snn_ann, SNNMode),
+        max_pooling=to_enum(core_params.max_pooling, PoolingMode),
+        zero_output=to_enum(core_params.zero_output, ZeroOutputMode),
+        input_sign=to_enum(core_params.input_sign, DataSign),
+        input_width=to_enum(core_params.input_width, DataWidth),
+        output_sign=to_enum(core_params.output_sign, DataSign),
+        output_width=to_enum(core_params.output_width, DataWidth),
+        weight_sign=to_enum(core_params.weight_sign, DataSign),
+        weight_width=to_enum(core_params.weight_width, DataWidth),
+        tick_start=core_params.tick_start,
+        tick_duration=core_params.tick_duration,
+        tick_initial=core_params.tick_initial,
+    )
+
+
+class InputNode:
+    def __init__(self, name: str, shape: torch.Size):
+        self.name = name
+        self.shape = shape
+        self.successors: list[CoreOpNode] = []
+
+    def __hash__(self) -> int:
+        return hash(id(self))
+
+    def __str__(self) -> str:
+        return f"InputNode({self.name})"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+class CoreOpNode:
+    def __init__(self, name: str, raw_node: BaseCoreOp, shape: torch.Size):
+        self.name = name
+        self.raw_node = raw_node
+        self.shape = shape
+        self.successors: list[CoreOpNode] = []
+        self.predecessors: list[CoreOpNode | InputNode] = []
+        self.frontend_core_config: Frontend_Core_Config = get_frontend_core_conf(
+            raw_node.core_params
+        )
+
+    def __hash__(self) -> int:
+        return hash(id(self))
+
+    def __str__(self) -> str:
+        return f"CoreOpNode({self.name})"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def attrs_part2(self) -> OfflineNeuFullAttrsV2Part2:
+        _, nue_attr, _ = self.raw_node.get_attrs()
+        return OfflineNeuFullAttrsV2Part2(
+            reset_mode=nue_attr.reset_mode,
+            reset_v=int(nue_attr.reset_v),
+            threshold_neg_mode=nue_attr.thres_neg_mode,
+            threshold_pos_mode=nue_attr.thres_pos_mode,
+            threshold_neg=int(nue_attr.thres_neg),
+            threshold_pos=int(nue_attr.thres_pos),
+            lateral_inhibition=nue_attr.lateral_inhi,
+            leak_multi_sequence=nue_attr.leak_multi_sequence,
+            leak_multi_input=nue_attr.leak_multi_input,
+            leak_multi_mode=nue_attr.leak_multi_mode,
+            leak_add_mode=nue_attr.leak_add_mode,
+            leak_tau=nue_attr.leak_tau,
+            leak_v=int(nue_attr.leak_v),
+            weight_compress=WeightCompressType.DENSE,
+            vjt_initial=int(nue_attr.init_v),
+        )
+
+    def output_type(self) -> OutputType:
+        _, neu_attrs, _ = self.raw_node.get_attrs()
+        return neu_attrs.output_type
+
+    def core_config(self) -> Frontend_Core_Config:
+        return self.frontend_core_config
+
+
+def build_nodes(gm: GraphModule) -> list[CoreOpNode | InputNode]:
+    raw_node_graph: dict[str, list[str]] = dict()
+    raw_core_nodes: dict[str, BaseCoreOp] = dict()
+    raw_io_nodes: dict[str, Node] = dict()
+    raw_node_shapes: dict[str, torch.Size] = dict()
+    for name, module in gm.named_modules():
+        if isinstance(module, BaseCoreOp):
+            raw_core_nodes[name] = module
+
+    for torch_node in gm.graph.nodes:
+        raw_node_name = str(torch_node.target)
+        if len(torch_node.users) == 0:
+            continue  # skip nodes with no users
+
+        if raw_node_name not in raw_core_nodes:
+            raw_io_nodes[raw_node_name] = torch_node
+
+        raw_node_shapes[raw_node_name] = torch_node.meta["tensor_meta"].shape
+        succ_raw_nodes: list[str] = []
+        print(f"\n[Node: {torch_node.name}]")
+        for user_node in torch_node.users:
+            if len(user_node.users) == 0:
+                continue  # skip users with no users
+
+            succ_raw_node = str(user_node.target)
+            succ_raw_nodes.append(succ_raw_node)
+        raw_node_graph[raw_node_name] = succ_raw_nodes
+
+    print("\n=== Raw Node Graph ===")
+    for name, succs_name in raw_node_graph.items():
+        print(f"{name} -> {succs_name}")
+
+    nodes: list[CoreOpNode | InputNode] = []
+    for name, raw_node in raw_core_nodes.items():
+        shape = raw_node_shapes[name]
+        node = CoreOpNode(name, raw_node, shape)
+        nodes.append(node)
+
+    for name, raw_node in raw_io_nodes.items():
+        shape = raw_node_shapes[name]
+        node = InputNode(name, shape)
+        nodes.append(node)
+
+    for node in nodes:
+        succ_names = raw_node_graph.get(node.name, [])
+        for succ_name in succ_names:
+            for user_node in nodes:
+                if user_node.name == succ_name:
+                    assert isinstance(user_node, CoreOpNode)
+                    node.successors.append(user_node)
+                    user_node.predecessors.append(node)
+
+    for node in nodes:
+        print(f"\nNode {node.name} ({node.shape}) ({node.shape.numel()}):")
+        print(f"\tsuccessors: {[succ.name for succ in node.successors]}")
+        if isinstance(node, CoreOpNode):
+            print(f"\tpredecessors: {[pred.name for pred in node.predecessors]}")
+    return nodes

--- a/paibox/backendv2/op_node.py
+++ b/paibox/backendv2/op_node.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import torch
 from paicorelib import (
     DataSign,
@@ -9,10 +11,23 @@ from paicorelib import (
     WeightCompressType,
     ZeroOutputMode,
 )
-from torch.fx import GraphModule, Node
+from torch import nn, Tensor
 
 from ..fx_converter.clac_params import NeuV2ClacParams, OfflineCoreV2CalcParams
 from ..fx_converter.core_op import BaseCoreOp
+from ..paiir import (
+    InputNode,
+    LutData,
+    OfflineCoreOp,
+    OfflineCoreParams,
+    OutputNode,
+    PAIIRGraph,
+    PAIIRNode,
+    SequentialOp,
+    AccumulateOp,
+    StandaloneCompOp,
+    StandaloneActOp
+)
 from .core_config import Frontend_Core_Config
 
 
@@ -28,34 +43,40 @@ class CustomIndex:
 
 
 def get_frontend_core_conf(
-    core_params: OfflineCoreV2CalcParams,
+    core_params: OfflineCoreParams, lut_data: Optional[LutData]
 ) -> Frontend_Core_Config:
-    def to_enum(value, enum_cls):
-        return enum_cls(value) if isinstance(value, int) else value
-
-    snn_ann = to_enum(core_params.snn_ann, SNNMode)
+    assert core_params.tick_start is not None
+    if core_params.snn_mode == SNNMode.ANN:
+        assert core_params.tick_initial == 1, "ANN mode requires tick_initial=1"
+        # assert lut_data is not None, "lut_data must be provided for ANN mode"
+    elif core_params.snn_mode == SNNMode.SNN:
+        assert lut_data is None, "lut_data should not be provided for SNN mode"
 
     return Frontend_Core_Config(
-        snn_ann=to_enum(core_params.snn_ann, SNNMode),
-        max_pooling=to_enum(core_params.max_pooling, PoolingMode),
-        zero_output=to_enum(core_params.zero_output, ZeroOutputMode),
-        input_sign=to_enum(core_params.input_sign, DataSign),
-        input_width=to_enum(core_params.input_width, DataWidth),
-        output_sign=to_enum(core_params.output_sign, DataSign),
-        output_width=to_enum(core_params.output_width, DataWidth),
-        weight_sign=to_enum(core_params.weight_sign, DataSign),
-        weight_width=to_enum(core_params.weight_width, DataWidth),
+        snn_ann=core_params.snn_mode,
+        max_pooling=core_params.pooling_mode,
+        zero_output=core_params.zero_output,
+        input_sign=core_params.input_sign,
+        input_width=core_params.input_width,
+        output_sign=core_params.output_sign,
+        output_width=core_params.output_width,
+        weight_sign=core_params.weight_sign,
+        weight_width=core_params.weight_width,
         tick_start=core_params.tick_start,
         tick_duration=core_params.tick_duration,
         tick_initial=core_params.tick_initial,
+        lut_data=lut_data,
     )
 
 
-class InputNode:
-    def __init__(self, name: str, shape: torch.Size):
+class InNode:
+    def __init__(self, name: str, shape: tuple[int, ...]):
         self.name = name
-        self.shape = shape
+        self.shape = torch.Size(shape)
         self.successors: list[CoreOpNode] = []
+
+        # Note: InNodes don't have predecessors since they represent external inputs, but we keep the attribute for uniformity
+        self.predecessors: list[CoreOpNode | InNode] = []
 
     def __hash__(self) -> int:
         return hash(id(self))
@@ -68,15 +89,40 @@ class InputNode:
 
 
 class CoreOpNode:
-    def __init__(self, name: str, raw_node: BaseCoreOp, shape: torch.Size):
+    def __init__(self, name: str, raw_node: OfflineCoreOp, shape: tuple[int, ...]):
         self.name = name
         self.raw_node = raw_node
-        self.shape = shape
+        self.shape = torch.Size(shape)
         self.successors: list[CoreOpNode] = []
-        self.predecessors: list[CoreOpNode | InputNode] = []
+        self.predecessors: list[CoreOpNode | InNode] = []
+        self.comps: list[Optional[nn.Module]] = []
+        self.weights: list[Optional[Tensor]] = []
+        
         self.frontend_core_config: Frontend_Core_Config = get_frontend_core_conf(
-            raw_node.core_params
+            raw_node.core_params, raw_node.lut_data
         )
+        
+    
+    def set_comps_and_weights(self)-> None:
+        """Set self.comps based on the type of raw_node."""
+        if isinstance(self.raw_node, SequentialOp):
+            self.comps = [self.raw_node.comp]
+        elif isinstance(self.raw_node, AccumulateOp):
+            self.comps = list(self.raw_node.comps)
+        elif isinstance(self.raw_node, StandaloneCompOp):
+            self.comps = [self.raw_node.comp]
+        elif isinstance(self.raw_node, StandaloneActOp):
+            self.comps = [None]
+        else:
+            raise NotImplementedError(f"Unsupported node type: {type(self.raw_node)}")
+
+        weights = self.raw_node.weights
+        if weights is not None:
+            self.weights = list(weights)
+        else:
+            self.weights = [None]
+        
+        
 
     def __hash__(self) -> int:
         return hash(id(self))
@@ -87,89 +133,73 @@ class CoreOpNode:
     def __repr__(self) -> str:
         return self.__str__()
 
-    def attrs_part2(self) -> OfflineNeuFullAttrsV2Part2:
-        _, nue_attr, _ = self.raw_node.get_attrs()
+    def attrs_part2(self, idx=0) -> OfflineNeuFullAttrsV2Part2:
+        neu_attrs = self.raw_node.neuron_params
+
+        if isinstance(neu_attrs.leak_v, torch.Tensor):
+            assert self.shape[0] == 1, "Batch size > 1 not supported for tensor leak_v"
+            out_channel = self.shape[1]
+            assert (
+                neu_attrs.leak_v.numel() == out_channel
+            ), "leak_v tensor size must match output channels"
+            cur_channel = idx // (self.shape.numel() // self.shape[1])
+            leak_v = neu_attrs.leak_v[cur_channel].item()
+        else:
+            leak_v = neu_attrs.leak_v
+
         return OfflineNeuFullAttrsV2Part2(
-            reset_mode=nue_attr.reset_mode,
-            reset_v=int(nue_attr.reset_v),
-            threshold_neg_mode=nue_attr.thres_neg_mode,
-            threshold_pos_mode=nue_attr.thres_pos_mode,
-            threshold_neg=int(nue_attr.thres_neg),
-            threshold_pos=int(nue_attr.thres_pos),
-            lateral_inhibition=nue_attr.lateral_inhi,
-            leak_multi_sequence=nue_attr.leak_multi_sequence,
-            leak_multi_input=nue_attr.leak_multi_input,
-            leak_multi_mode=nue_attr.leak_multi_mode,
-            leak_add_mode=nue_attr.leak_add_mode,
-            leak_tau=nue_attr.leak_tau,
-            leak_v=int(nue_attr.leak_v),
+            reset_mode=neu_attrs.reset_mode,
+            reset_v=round(neu_attrs.reset_v),
+            threshold_neg_mode=neu_attrs.thres_neg_mode,
+            threshold_pos_mode=neu_attrs.thres_pos_mode,
+            threshold_neg=round(neu_attrs.thres_neg),
+            threshold_pos=round(neu_attrs.thres_pos),
+            lateral_inhibition=neu_attrs.lateral_inhi,
+            leak_multi_sequence=neu_attrs.leak_multi_sequence,
+            leak_multi_input=neu_attrs.leak_multi_input,
+            leak_multi_mode=neu_attrs.leak_multi_mode,
+            leak_add_mode=neu_attrs.leak_add_mode,
+            leak_tau=neu_attrs.leak_tau,
+            leak_v=round(leak_v),
             weight_compress=WeightCompressType.DENSE,
-            vjt_initial=int(nue_attr.init_v),
+            vjt_initial=round(neu_attrs.init_v),
         )
 
     def output_type(self) -> OutputType:
-        _, neu_attrs, _ = self.raw_node.get_attrs()
+        neu_attrs = self.raw_node.neuron_params
         return neu_attrs.output_type
 
     def core_config(self) -> Frontend_Core_Config:
         return self.frontend_core_config
 
 
-def build_nodes(gm: GraphModule) -> list[CoreOpNode | InputNode]:
-    raw_node_graph: dict[str, list[str]] = dict()
-    raw_core_nodes: dict[str, BaseCoreOp] = dict()
-    raw_io_nodes: dict[str, Node] = dict()
-    raw_node_shapes: dict[str, torch.Size] = dict()
-    for name, module in gm.named_modules():
-        if isinstance(module, BaseCoreOp):
-            raw_core_nodes[name] = module
-
-    for torch_node in gm.graph.nodes:
-        raw_node_name = str(torch_node.target)
-        if len(torch_node.users) == 0:
-            continue  # skip nodes with no users
-
-        if raw_node_name not in raw_core_nodes:
-            raw_io_nodes[raw_node_name] = torch_node
-
-        raw_node_shapes[raw_node_name] = torch_node.meta["tensor_meta"].shape
-        succ_raw_nodes: list[str] = []
-        print(f"\n[Node: {torch_node.name}]")
-        for user_node in torch_node.users:
-            if len(user_node.users) == 0:
-                continue  # skip users with no users
-
-            succ_raw_node = str(user_node.target)
-            succ_raw_nodes.append(succ_raw_node)
-        raw_node_graph[raw_node_name] = succ_raw_nodes
-
-    print("\n=== Raw Node Graph ===")
-    for name, succs_name in raw_node_graph.items():
-        print(f"{name} -> {succs_name}")
-
-    nodes: list[CoreOpNode | InputNode] = []
-    for name, raw_node in raw_core_nodes.items():
-        shape = raw_node_shapes[name]
-        node = CoreOpNode(name, raw_node, shape)
+def build_nodes(graph: PAIIRGraph) -> list[CoreOpNode | InNode]:
+    nodes: list[CoreOpNode | InNode] = []
+    nodes_map: dict[str, CoreOpNode | InNode] = {}
+    for raw_node in graph.nodes.values():
+        if isinstance(raw_node, OfflineCoreOp):
+            node = CoreOpNode(raw_node.name, raw_node, raw_node.output_shape)
+        elif isinstance(raw_node, InputNode):
+            node = InNode(raw_node.name, raw_node.shape)
+        elif isinstance(raw_node, OutputNode):
+            pass
+        else:
+            raise NotImplementedError(f"Unsupported node type: {type(raw_node)}")
+        nodes_map[raw_node.name] = node
         nodes.append(node)
 
-    for name, raw_node in raw_io_nodes.items():
-        shape = raw_node_shapes[name]
-        node = InputNode(name, shape)
-        nodes.append(node)
+    for node_name, cur_node in nodes_map.items():
+        succ_node_names = graph.successors(node_name)
+        for succ_name in succ_node_names:
+            succ_node = nodes_map[succ_name]
+            assert isinstance(
+                succ_node, (CoreOpNode)
+            ), "Only CoreOpNode can be a successor of other node"
+            cur_node.successors.append(succ_node)
+        if isinstance(cur_node, CoreOpNode):
+            pred_node_names = graph.predecessors(node_name)
+            for pred_name in pred_node_names:
+                pred_node = nodes_map[pred_name]
+                cur_node.predecessors.append(pred_node)
 
-    for node in nodes:
-        succ_names = raw_node_graph.get(node.name, [])
-        for succ_name in succ_names:
-            for user_node in nodes:
-                if user_node.name == succ_name:
-                    assert isinstance(user_node, CoreOpNode)
-                    node.successors.append(user_node)
-                    user_node.predecessors.append(node)
-
-    for node in nodes:
-        print(f"\nNode {node.name} ({node.shape}) ({node.shape.numel()}):")
-        print(f"\tsuccessors: {[succ.name for succ in node.successors]}")
-        if isinstance(node, CoreOpNode):
-            print(f"\tpredecessors: {[pred.name for pred in node.predecessors]}")
     return nodes

--- a/paibox/backendv2/op_node.py
+++ b/paibox/backendv2/op_node.py
@@ -90,6 +90,7 @@ class CoreOpNode:
         self.predecessors: list[CoreOpNode | InNode] = []
         self.comps: list[Optional[nn.Module]] = []
         self.weights: list[Optional[Tensor]] = []
+        self.set_comps_and_weights()
 
         self.frontend_core_config: Frontend_Core_Config = get_frontend_core_conf(
             raw_node.core_params, raw_node.lut_data
@@ -109,6 +110,7 @@ class CoreOpNode:
             raise NotImplementedError(f"Unsupported node type: {type(self.raw_node)}")
 
         weights = self.raw_node.weights
+        print(f"Setting comps and weights for node {self.name} \n\tcomps: {self.comps} \n\traw weights: {weights}")
         if weights is not None:
             self.weights = list(weights)
         else:

--- a/paibox/backendv2/op_node.py
+++ b/paibox/backendv2/op_node.py
@@ -2,31 +2,24 @@ from typing import Optional
 
 import torch
 from paicorelib import (
-    DataSign,
-    DataWidth,
     OfflineNeuFullAttrsV2Part2,
     OutputType,
-    PoolingMode,
     SNNMode,
     WeightCompressType,
-    ZeroOutputMode,
 )
-from torch import nn, Tensor
+from torch import Tensor, nn
 
-from ..fx_converter.clac_params import NeuV2ClacParams, OfflineCoreV2CalcParams
-from ..fx_converter.core_op import BaseCoreOp
 from ..paiir import (
+    AccumulateOp,
     InputNode,
     LutData,
     OfflineCoreOp,
     OfflineCoreParams,
     OutputNode,
     PAIIRGraph,
-    PAIIRNode,
     SequentialOp,
-    AccumulateOp,
+    StandaloneActOp,
     StandaloneCompOp,
-    StandaloneActOp
 )
 from .core_config import Frontend_Core_Config
 
@@ -97,13 +90,12 @@ class CoreOpNode:
         self.predecessors: list[CoreOpNode | InNode] = []
         self.comps: list[Optional[nn.Module]] = []
         self.weights: list[Optional[Tensor]] = []
-        
+
         self.frontend_core_config: Frontend_Core_Config = get_frontend_core_conf(
             raw_node.core_params, raw_node.lut_data
         )
-        
-    
-    def set_comps_and_weights(self)-> None:
+
+    def set_comps_and_weights(self) -> None:
         """Set self.comps based on the type of raw_node."""
         if isinstance(self.raw_node, SequentialOp):
             self.comps = [self.raw_node.comp]
@@ -121,8 +113,6 @@ class CoreOpNode:
             self.weights = list(weights)
         else:
             self.weights = [None]
-        
-        
 
     def __hash__(self) -> int:
         return hash(id(self))

--- a/paibox/backendv2/op_node.py
+++ b/paibox/backendv2/op_node.py
@@ -110,7 +110,9 @@ class CoreOpNode:
             raise NotImplementedError(f"Unsupported node type: {type(self.raw_node)}")
 
         weights = self.raw_node.weights
-        print(f"Setting comps and weights for node {self.name} \n\tcomps: {self.comps} \n\traw weights: {weights}")
+        print(
+            f"Setting comps and weights for node {self.name} \n\tcomps: {self.comps} \n\traw weights: {weights}"
+        )
         if weights is not None:
             self.weights = list(weights)
         else:

--- a/paibox/backendv2/rg_build.py
+++ b/paibox/backendv2/rg_build.py
@@ -1,0 +1,81 @@
+from .neuron import InputElem, Neuron
+from .op_node import CoreOpNode, CustomIndex, InputNode
+from .routing import RoutingGroup
+
+
+def gen_neurons(node: CoreOpNode) -> list[Neuron]:
+    neurons: list[Neuron] = []
+    # flatten the shape to get total number of neurons
+    num_neu = node.shape.numel()
+    for idx in range(num_neu):
+        neu: Neuron = Neuron(target=node, index=CustomIndex(idx))
+        neurons.append(neu)
+    return neurons
+
+
+def gen_ioelements(node: InputNode) -> list[InputElem]:
+    ioelements: list[InputElem] = []
+    # flatten the shape to get total number of neurons
+    num_elem = node.shape.numel()
+    for idx in range(num_elem):
+        ioelem: InputElem = InputElem(target=node, index=CustomIndex(idx))
+        ioelements.append(ioelem)
+    return ioelements
+
+
+def build_routing_group(
+    nodes: set[CoreOpNode], input_nodes: set[CoreOpNode | InputNode]
+) -> RoutingGroup:
+    # Placeholder implementation
+
+    raw_neus: list[Neuron] = []
+    for node in nodes:
+        raw_neus.extend(gen_neurons(node))
+    input_list: list[Neuron | InputElem] = []
+    for in_node in input_nodes:
+        if isinstance(in_node, CoreOpNode):
+            input_list.extend(gen_neurons(in_node))
+        elif isinstance(in_node, InputNode):
+            input_list.extend(gen_ioelements(in_node))
+    rg = RoutingGroup(raw_neus, input_list)
+    # Logic to build a routing group from nodes goes here
+    return rg
+
+
+def build_routing_groups(nodes: list[CoreOpNode | InputNode]) -> list[RoutingGroup]:
+    # Placeholder implementation
+    routing_groups: list[RoutingGroup] = []
+    # Logic to build routing groups from nodes goes here
+    node_sets: list[set[CoreOpNode]] = []
+    for node in nodes:
+        if len(node.successors) > 0:
+            node_sets.append(set(node.successors))
+        if isinstance(node, CoreOpNode):
+            node_sets.append({node})
+
+    while True:
+        merged = False
+        for i in range(len(node_sets)):
+            for j in range(i + 1, len(node_sets)):
+                if node_sets[i] & node_sets[j]:
+                    node_sets[i] |= node_sets[j]
+                    node_sets.pop(j)
+                    merged = True
+                    break
+            if merged:
+                break
+        if not merged:
+            break
+    print(f"Identified {len(node_sets)} routing groups.")
+    print(node_sets)
+
+    routing_groups: list[RoutingGroup] = []
+
+    for node_set in node_sets:
+        input_nodes: set[CoreOpNode | InputNode] = set()
+        for node in node_set:
+            input_nodes.update(node.predecessors)
+        rg = build_routing_group(node_set, input_nodes)
+        routing_groups.append(rg)
+
+    return routing_groups

--- a/paibox/backendv2/rg_build.py
+++ b/paibox/backendv2/rg_build.py
@@ -1,5 +1,5 @@
 from .neuron import InputElem, Neuron
-from .op_node import CoreOpNode, CustomIndex, InputNode
+from .op_node import CoreOpNode, CustomIndex, InNode
 from .routing import RoutingGroup
 
 
@@ -13,7 +13,7 @@ def gen_neurons(node: CoreOpNode) -> list[Neuron]:
     return neurons
 
 
-def gen_ioelements(node: InputNode) -> list[InputElem]:
+def gen_ioelements(node: InNode) -> list[InputElem]:
     ioelements: list[InputElem] = []
     # flatten the shape to get total number of neurons
     num_elem = node.shape.numel()
@@ -24,7 +24,7 @@ def gen_ioelements(node: InputNode) -> list[InputElem]:
 
 
 def build_routing_group(
-    nodes: set[CoreOpNode], input_nodes: set[CoreOpNode | InputNode]
+    nodes: set[CoreOpNode], input_nodes: set[CoreOpNode | InNode]
 ) -> RoutingGroup:
     # Placeholder implementation
 
@@ -35,14 +35,14 @@ def build_routing_group(
     for in_node in input_nodes:
         if isinstance(in_node, CoreOpNode):
             input_list.extend(gen_neurons(in_node))
-        elif isinstance(in_node, InputNode):
+        elif isinstance(in_node, InNode):
             input_list.extend(gen_ioelements(in_node))
-    rg = RoutingGroup(raw_neus, input_list)
+    rg = RoutingGroup(raw_neus, input_list, nodes, input_nodes)
     # Logic to build a routing group from nodes goes here
     return rg
 
 
-def build_routing_groups(nodes: list[CoreOpNode | InputNode]) -> list[RoutingGroup]:
+def build_routing_groups(nodes: list[CoreOpNode | InNode]) -> list[RoutingGroup]:
     # Placeholder implementation
     routing_groups: list[RoutingGroup] = []
     # Logic to build routing groups from nodes goes here
@@ -72,7 +72,7 @@ def build_routing_groups(nodes: list[CoreOpNode | InputNode]) -> list[RoutingGro
     routing_groups: list[RoutingGroup] = []
 
     for node_set in node_sets:
-        input_nodes: set[CoreOpNode | InputNode] = set()
+        input_nodes: set[CoreOpNode | InNode] = set()
         for node in node_set:
             input_nodes.update(node.predecessors)
         rg = build_routing_group(node_set, input_nodes)

--- a/paibox/backendv2/route_solver.py
+++ b/paibox/backendv2/route_solver.py
@@ -40,13 +40,13 @@ def get_shapes_by_area() -> (
     for coord in itertools.product(range(0, 5), range(0, 5), range(0, 5)):
         n = aer_packet_area(coord)
         copy_config = AERPacketZXYCopy(*coord)
+        copy_configs[n].append(copy_config.copy())
         packet = AERPacket(ncopy=copy_config)
         covered = aer_packet_walk(packet)
         n_covered = len(covered)
 
         assert n == n_covered
         shapes[n].append(covered)
-        copy_configs[n].append(copy_config)
 
     return shapes, copy_configs
 
@@ -117,6 +117,7 @@ def print_route_result(
 
 
 SHAPES_BY_AREA, COPY_CONFIGS = get_shapes_by_area()
+MAX_AREA = max(SHAPES_BY_AREA.keys())
 
 
 def route_solve(
@@ -129,7 +130,13 @@ def route_solve(
     placement_area = []
 
     for area_id, area in enumerate(areas):
-        shapes = SHAPES_BY_AREA.get(area, [])
+
+        shapes = []
+        for selected_area in range(area, MAX_AREA + 1):
+            if selected_area in SHAPES_BY_AREA:
+                shapes = SHAPES_BY_AREA[selected_area]
+                break
+
         for shape_id, shape in enumerate(shapes):
             for h in HIVE:
                 shifted = [
@@ -137,6 +144,7 @@ def route_solve(
                 ]  # (h_row + s_row, h_col + s_col)
                 if all(c in HIVE for c in shifted):
                     placement_dict = {
+                        "actual_area": selected_area,
                         "area_id": area_id,
                         "shape_id": shape_id,
                         "cells": [HIVE_INDEX[c] for c in shifted],
@@ -248,7 +256,7 @@ def route_solve(
         for i in range(N):
             if solver.Value(x[i]) == 1:
                 p = placements[i]
-                copy_config = COPY_CONFIGS[areas[p["area_id"]]][p["shape_id"]]
+                copy_config = COPY_CONFIGS[p["actual_area"]][p["shape_id"]]
                 copy_configs.append(copy_config)
                 coords.append([CoordXY(r, c) for r, c in p["absolute_coords"]])
     else:

--- a/paibox/backendv2/route_solver.py
+++ b/paibox/backendv2/route_solver.py
@@ -1,0 +1,262 @@
+import itertools
+import os
+from collections import defaultdict
+
+from ortools.sat.python import cp_model
+from paicorelib.coordinate import CoordXY
+from paicorelib.routing_hexa import (
+    AERPacket,
+    AERPacketZXYCopy,
+    aer_packet_area,
+    aer_packet_walk,
+)
+
+ROW_START = 2
+ROW_END = 9
+COL_START = 0
+COL_END = 9
+
+HIVE = set()
+for i in range(ROW_START, ROW_END):
+    for j in range(COL_START, COL_END):
+        HIVE.add((i, j))
+
+HIVE_LIST = list(HIVE)
+HIVE_INDEX = {h: i for i, h in enumerate(HIVE_LIST)}
+
+# CANONICAL_SECTOR = set()
+# for i in range(0, 5):
+#     for j in range(2, 6):
+#         CANONICAL_SECTOR.add((i, j))
+
+
+def get_shapes_by_area() -> (
+    tuple[dict[int, list[list[CoordXY]]], dict[int, list[AERPacketZXYCopy]]]
+):
+    # Some area may not be covered
+    shapes = defaultdict(list)
+    copy_configs = defaultdict(list)
+
+    for coord in itertools.product(range(0, 5), range(0, 5), range(0, 5)):
+        n = aer_packet_area(coord)
+        copy_config = AERPacketZXYCopy(*coord)
+        packet = AERPacket(ncopy=copy_config)
+        covered = aer_packet_walk(packet)
+        n_covered = len(covered)
+
+        assert n == n_covered
+        shapes[n].append(covered)
+        copy_configs[n].append(copy_config)
+
+    return shapes, copy_configs
+
+
+def test_get_shapes_by_area():
+    shapes, copy_configs = get_shapes_by_area()
+
+    for k, v in shapes.items():
+        print(f"Area {k}: {len(v)} shapes")
+
+
+def print_route_result(
+    solver: cp_model.CpSolver,
+    N: int,
+    num_areas: int,
+    placements: list[dict],
+    x: list[cp_model.IntVar],
+    cx: list[cp_model.IntVar],
+    cy: list[cp_model.IntVar],
+    dx: dict[tuple[int, int], cp_model.IntVar],
+    dy: dict[tuple[int, int], cp_model.IntVar],
+    next_area_id: dict[int, list[int]],
+):
+    used = []
+    covered = set()
+    grid_map = {}
+    placed_area_ids = set()
+    for i in range(N):
+        if solver.Value(x[i]) == 1:
+            used.append(i)
+            p = placements[i]
+            area_id = p["area_id"]
+            placed_area_ids.add(area_id)
+            for abs_coord in p["absolute_coords"]:
+                grid_map[abs_coord] = str(area_id)
+            covered.update(p["cells"])
+
+    print("Covered cells:", len(covered), f"/ {len(HIVE_LIST)}")
+    print("Utilization:", len(covered) / len(HIVE_LIST))
+    print("Number of areas placed:", len(placed_area_ids), f"/ {num_areas}")
+    print("Placed Area IDs:", sorted(list(placed_area_ids)))
+
+    print("\nPlacements used:")
+    for i in used:
+        p = placements[i]
+        abs_coords = p["absolute_coords"]
+        print(f"  Area {p['area_id']} Shape {p['shape_id']}: {abs_coords}")
+
+    print("\nVisualization (Numbers = Area ID, . = empty):")
+    grid = [["." for _ in range(COL_END)] for _ in range(ROW_END)]
+    for (r, c), area_id_str in grid_map.items():
+        grid[r][c] = area_id_str
+    for r_idx, row in reversed(list(enumerate(grid))):
+        print(f"{r_idx:2d}: {''.join(row)}")
+
+    print("\nFinal center coordinates for placed areas:")
+    for i in sorted(placed_area_ids):
+        print(f"  Area {i}: (r={solver.Value(cx[i])}, c={solver.Value(cy[i])})")
+
+    print("\nCalculated distances between placed adjacent areas:")
+    for i, next_list in next_area_id.items():
+        for j in next_list:
+            dx_val = solver.Value(dx[i, j])
+            dy_val = solver.Value(dy[i, j])
+            print(
+                f"  Area {i} to Area {j}: dx={dx_val}, dy={dy_val}, total={dx_val + dy_val}"
+            )
+
+
+SHAPES_BY_AREA, COPY_CONFIGS = get_shapes_by_area()
+
+
+def route_solve(
+    areas=[1], next_area_id={}, io_target=(0, 0), input_area_ids=[], output_area_ids=[]
+):
+
+    num_areas = len(areas)
+    placements = []
+    placement_cells = []
+    placement_area = []
+
+    for area_id, area in enumerate(areas):
+        shapes = SHAPES_BY_AREA.get(area, [])
+        for shape_id, shape in enumerate(shapes):
+            for h in HIVE:
+                shifted = [
+                    (h[0] + s.x, h[1] + s.y) for s in shape
+                ]  # (h_row + s_row, h_col + s_col)
+                if all(c in HIVE for c in shifted):
+                    placement_dict = {
+                        "area_id": area_id,
+                        "shape_id": shape_id,
+                        "cells": [HIVE_INDEX[c] for c in shifted],
+                        "area": len(shifted),
+                        "absolute_coords": shifted,
+                        "center_r": round(
+                            sum(coord[0] for coord in shifted) / len(shifted)
+                        ),
+                        "center_c": round(
+                            sum(coord[1] for coord in shifted) / len(shifted)
+                        ),
+                    }
+                    placements.append(placement_dict)
+                    placement_cells.append(placement_dict["cells"])
+                    placement_area.append(placement_dict["area"])
+
+    N = len(placements)
+
+    model = cp_model.CpModel()
+
+    # x present whether each placement is used
+    x = [model.NewBoolVar(f"x_{i}") for i in range(N)]
+
+    # y present whether each hive cell is covered
+    y = [model.NewBoolVar(f"y_{i}") for i in range(len(HIVE_LIST))]
+
+    # sum up x[i] if placement i covers hive cell h_idx
+    for h_idx in range(len(HIVE_LIST)):
+        model.Add(
+            sum(x[i] for i in range(N) if h_idx in placement_cells[i]) == y[h_idx]
+        )
+
+    # each hive cell can be covered at most once
+    for h_idx in range(len(HIVE_LIST)):
+        model.Add(y[h_idx] <= 1)
+
+    # each area is placed exactly once
+    for area_id in range(num_areas):
+        model.Add(
+            sum(x[i] for i, p in enumerate(placements) if p["area_id"] == area_id) == 1
+        )
+
+    # break symmetry: the hive cell is a rectangle, so we can enforce an order on area placements
+    # model.Add(sum(y[HIVE_INDEX[h]] for h in CANONICAL_SECTOR) >= 1)
+
+    cx = [model.NewIntVar(ROW_START, ROW_END - 1, f"cx_{i}") for i in range(num_areas)]
+    cy = [model.NewIntVar(COL_START, COL_END - 1, f"cy_{i}") for i in range(num_areas)]
+
+    # assign center coordinate for each area based on selected placement
+    for i, p in enumerate(placements):
+        p = placements[i]
+        model.Add(cx[p["area_id"]] == p["center_r"]).OnlyEnforceIf(x[i])
+        model.Add(cy[p["area_id"]] == p["center_c"]).OnlyEnforceIf(x[i])
+
+    # dictionary of noc distances between adjacent areas
+    dx = {}
+    dy = {}
+
+    total_distance = 0
+    for i, next_list in next_area_id.items():
+        for j in next_list:
+            dx[i, j] = model.NewIntVar(ROW_START, ROW_END - 1, f"dx_{i}_{j}")
+            dy[i, j] = model.NewIntVar(COL_START, COL_END - 1, f"dy_{i}_{j}")
+            model.AddAbsEquality(dx[i, j], cx[j] - cx[i])
+            model.AddAbsEquality(dy[i, j], cy[j] - cy[i])
+            total_distance += dx[i, j] + dy[i, j]
+
+    for input_area_id in input_area_ids:
+        dx_input = model.NewIntVar(ROW_START, ROW_END - 1, f"dx_input_{input_area_id}")
+        dy_input = model.NewIntVar(COL_START, COL_END - 1, f"dy_input_{input_area_id}")
+        model.AddAbsEquality(dx_input, cx[input_area_id] - io_target[0])
+        model.AddAbsEquality(dy_input, cy[input_area_id] - io_target[1])
+        total_distance += dx_input + dy_input
+
+    for output_area_id in output_area_ids:
+        dx_output = model.NewIntVar(
+            ROW_START, ROW_END - 1, f"dx_output_{output_area_id}"
+        )
+        dy_output = model.NewIntVar(
+            COL_START, COL_END - 1, f"dy_output_{output_area_id}"
+        )
+        model.AddAbsEquality(dx_output, cx[output_area_id] - io_target[0])
+        model.AddAbsEquality(dy_output, cy[output_area_id] - io_target[1])
+        total_distance += dx_output + dy_output
+
+    # Objective: maximize covered cells and minimize total distance
+    max_possible_distance = (ROW_END + COL_END) * num_areas * num_areas
+
+    weight_for_distance = 1
+    weight_for_placement = max_possible_distance + 1
+
+    model.Maximize(
+        sum(x[i] for i in range(N)) * weight_for_placement
+        - total_distance * weight_for_distance
+    )
+
+    solver = cp_model.CpSolver()
+
+    num_cpu_threads = os.cpu_count() or 2
+    solver.parameters.num_search_workers = num_cpu_threads // 2
+    solver.parameters.max_time_in_seconds = 120.0
+    # solver.parameters.log_search_progress = True
+    status = solver.Solve(model)
+
+    copy_configs: list[AERPacketZXYCopy] = []
+    coords: list[list[CoordXY]] = []
+
+    if status in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+        for i in range(N):
+            if solver.Value(x[i]) == 1:
+                p = placements[i]
+                copy_config = COPY_CONFIGS[areas[p["area_id"]]][p["shape_id"]]
+                copy_configs.append(copy_config)
+                coords.append([CoordXY(r, c) for r, c in p["absolute_coords"]])
+    else:
+        print("No solution found or solver timed out.")
+        print(f"Solver status: {solver.StatusName(status)}")
+        raise RuntimeError("No solution found or solver timed out.")
+
+    return copy_configs, coords
+
+
+route_solve()

--- a/paibox/backendv2/route_solver.py
+++ b/paibox/backendv2/route_solver.py
@@ -123,14 +123,12 @@ MAX_AREA = max(SHAPES_BY_AREA.keys())
 def route_solve(
     areas=[1], next_area_id={}, io_target=(0, 0), input_area_ids=[], output_area_ids=[]
 ):
-
     num_areas = len(areas)
     placements = []
     placement_cells = []
     placement_area = []
 
     for area_id, area in enumerate(areas):
-
         shapes = []
         for selected_area in range(area, MAX_AREA + 1):
             if selected_area in SHAPES_BY_AREA:

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
-from coreplacement import CorePlacement, EmptyOfflineCorePlacementV2,OfflineCorePlamentV2
-from neuron import Neuron,OfflineNeuronPlacement
-from weight import Weight
+from .coreplacement import CorePlacement, EmptyOfflineCorePlacementV2,OfflineCorePlamentV2
+from .neuron import Neuron,OfflineNeuronPlacement
+from .weight import Weight
 
 from paicorelib import (
     LCN_EX,
@@ -15,6 +15,9 @@ from paicorelib import (
     find_coordxy_shortest_path,
     NeuronType,
     WeightCompressType,
+    OfflineCoreRegV2,
+    OfflineNeuFullAttrsV2Part1,
+    OfflineNeuFullAttrsV2Part2
 
 )
 
@@ -69,88 +72,127 @@ class RoutingGroup:
 
         weights = get_raw_weights(self.raw_neus, self.input_list)
 
-        col_nnz = np.count_nonzero(weights, axis=0)
-        sorted_indices = np.argsort(-col_nnz)
-        
-        self.input_list = [self.input_list[i] for i in sorted_indices]
-        weights = weights[:, sorted_indices]
+        # 1. Grouping Phase
+        groups = []
+        for i, neu in enumerate(self.raw_neus):
+            cfg = neu.core_config()
+            t_lcn = self.dests[neu].lcn
+            lcn = self.lcn
+            w_row = weights[i]
+            
+            match_group = None
+            for g in groups:
+                if g['config'] == cfg and g['target_lcn'] == t_lcn and g['lcn'] == lcn:
+                    match_group = g
+                    break
+            
+            if match_group:
+                match_group['items'].append((neu, w_row, i))
+            else:
+                groups.append({
+                    'config': cfg,
+                    'target_lcn': t_lcn,
+                    'lcn': lcn,
+                    'items': [(neu, w_row, i)]
+                })
 
         self.core_placements = []
-        current_core: Optional[OfflineCorePlamentV2] = None
-        
-        last_full_attrs = None 
 
-        for i, neu in enumerate(self.raw_neus):
+        def create_new_core_for_group(config):
+            new_core = OfflineCorePlamentV2()
+            
+            target_fields = OfflineCoreRegV2.model_fields.keys()
+            
+            init_data = {}
+            for field_name in target_fields:
+                if hasattr(config, field_name):
+                    init_data[field_name] = getattr(config, field_name)
+                else:
+                    if field_name == "neuron_number":
+                        init_data[field_name] = 0
+                    elif field_name in ["axon_skew", "test_core_xy", "test_core_x", "test_core_y"]:
+                        init_data[field_name] = 0
+                    elif field_name in ["global_send", "global_receive", "tick_start", "tick_duration", "tick_initial"]:
+                        init_data[field_name] = 0
+                    elif field_name in ["busy_cycle", "delay_cycle", "width_cycle"]:
+                        init_data[field_name] = 2  # gt=1 约束
+            
+            try:
+                reg_config = OfflineCoreRegV2(**init_data)
+            except Exception as e:
+                raise ValueError(f"Failed to initialize OfflineCoreRegV2. \nConfig: {config}\nError: {e}")
 
-            attrs = neu.attrs_part2()
-            inherited_core_config = neu.core_config()
-            
-            w_row = weights[i]
+            new_core._core_config = reg_config
+            return new_core
 
-            w_dense = Weight(w_row, WeightCompressType.DENSE)
-            w_sparse = Weight(w_row, WeightCompressType.SPARSE)
+        # 2. Allocation Phase
+        for group in groups:
+            group_config = group['config']
+            group_items = group['items']
             
-           
-            if w_sparse.n_sram_required() < w_dense.n_sram_required():
-                selected_weight = w_sparse
-                attrs.weight_compress = WeightCompressType.SPARSE
-            else:
-                selected_weight = w_dense
-                attrs.weight_compress = WeightCompressType.DENSE
+            # Initialize the first core for the current group
+            current_core = create_new_core_for_group(group_config)
+            
+            last_full_attrs = None
+            
+            for neu, w_row, original_idx in group_items:
+                attrs = neu.attrs_part2()
+                
+                # Weight Strategy
+                current_weight_width = group_config.weight_width
+                w_dense = Weight(w_row, WeightCompressType.DENSE, current_weight_width)
+                w_sparse = Weight(w_row, WeightCompressType.SPARSE, current_weight_width)
 
-   
-            if current_core is not None and last_full_attrs is not None and attrs == last_full_attrs:
-                neuron_type = NeuronType.HALF
-            else:
-                neuron_type = NeuronType.FULL
-            
-   
-            neu_placement = OfflineNeuronPlacement(neu, attrs)
-            
-            if hasattr(neu_placement, 'neuron_type'):
+                if w_sparse.n_sram_required() < w_dense.n_sram_required():
+                    selected_weight = w_sparse
+                    attrs.weight_compress = WeightCompressType.SPARSE
+                else:
+                    selected_weight = w_dense
+                    attrs.weight_compress = WeightCompressType.DENSE
+
+                # Neuron Type (Full/Half)
+                if len(current_core.neus) > 0 and last_full_attrs is not None and attrs == last_full_attrs:
+                    neuron_type = NeuronType.HALF
+                else:
+                    neuron_type = NeuronType.FULL
+
+                # Create Placement
+                neu_placement = OfflineNeuronPlacement(neu, attrs)
                 neu_placement.neuron_type = neuron_type
 
-
-            neu_sram_req = neu_placement.n_sram_required()
-            weight_sram_req = selected_weight.n_sram_required()
-            total_req = neu_sram_req + weight_sram_req
-            
-            # Check for core overflow
-            if current_core is None or (current_core.n_sram_required() + total_req > 4096):
+                # SRAM Check
+                neu_sram_req = neu_placement.n_sram_required()
+                weight_sram_req = selected_weight.n_sram_required()
+                total_req = neu_sram_req + weight_sram_req
                 
-                # Check for single-neuron overflow
-                if total_req > 4096:
-                     raise NotImplementedError(
-                        f"Neuron {i} requires {total_req} SRAM lines, exceeding the 4096 limit. "
-                        "Large input splitting logic is required."
-                    )
-                
-                if current_core is not None:
-                    self.core_placements.append(current_core)
-                
-                current_core = OfflineCorePlamentV2()
-                current_core._core_config = inherited_core_config
-                
-                # Force the first neuron in a new core to be FULL (no predecessor to reuse).
-                if neuron_type == NeuronType.HALF:
+                if current_core.n_sram_required() + total_req > 4096:
+                    if total_req > 4096:
+                         raise NotImplementedError(
+                            f"Neuron {original_idx} requires {total_req} SRAM lines."
+                        )
+                    
+                    if len(current_core.neus) > 0:
+                        self.core_placements.append(current_core)
+                    
+                    # Create new core with inheritance
+                    current_core = create_new_core_for_group(group_config)
+                    
                     neuron_type = NeuronType.FULL
-                    if hasattr(neu_placement, 'neuron_type'):
-                        neu_placement.neuron_type = NeuronType.FULL
+                    neu_placement.neuron_type = NeuronType.FULL
+                    last_full_attrs = attrs
                 
-                last_full_attrs = attrs
+                elif neuron_type == NeuronType.FULL:
+                    last_full_attrs = attrs
+                
+                current_core.neus.append(neu_placement)
+                current_core.weights.append(selected_weight)
+                
+                idx = len(current_core.neus) - 1
+                current_core.neu_weight_map[idx] = idx
             
-            elif neuron_type == NeuronType.FULL:
-                last_full_attrs = attrs
-            
-            current_core.neus.append(neu_placement)
-            current_core.weights.append(selected_weight)
-            
-            idx = len(current_core.neus) - 1
-            current_core.neu_weight_map[idx] = idx
+            if len(current_core.neus) > 0:
+                self.core_placements.append(current_core)
 
-        if current_core is not None:
-            self.core_placements.append(current_core)
-        
         self.n_core_required = len(self.core_placements)
 
         # implement your core placement generation logic here

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
+from coreplacement import CorePlacement, EmptyOfflineCorePlacementV2
+from neuron import Neuron
 from paicorelib import (
     LCN_EX,
     AERPacketZXYCopy,
@@ -10,9 +12,6 @@ from paicorelib import (
     OfflineNeuDestInfoV2,
     find_coordxy_shortest_path,
 )
-
-from coreplacement import CorePlacement, EmptyOfflineCorePlacementV2
-from neuron import Neuron
 
 FANIN_BASE = 512
 

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -3,14 +3,19 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
-from coreplacement import CorePlacement, EmptyOfflineCorePlacementV2
-from neuron import Neuron
+from coreplacement import CorePlacement, EmptyOfflineCorePlacementV2,OfflineCorePlamentV2
+from neuron import Neuron,OfflineNeuronPlacement
+from weight import Weight
+
 from paicorelib import (
     LCN_EX,
     AERPacketZXYCopy,
     CoordXY,
     OfflineNeuDestInfoV2,
     find_coordxy_shortest_path,
+    NeuronType,
+    WeightCompressType,
+
 )
 
 FANIN_BASE = 512
@@ -62,11 +67,91 @@ class RoutingGroup:
         # all the attrs in neu_attrs_part2 are valid except weight compress, you should set weight compress according to your weight storage strategy
         # inherited core_config are valid except weight_width, you can set weight_width larger than or equal to the original value for optimization
 
-        for neu in self.raw_neus:
+        weights = get_raw_weights(self.raw_neus, self.input_list)
+
+        col_nnz = np.count_nonzero(weights, axis=0)
+        sorted_indices = np.argsort(-col_nnz)
+        
+        self.input_list = [self.input_list[i] for i in sorted_indices]
+        weights = weights[:, sorted_indices]
+
+        self.core_placements = []
+        current_core: Optional[OfflineCorePlamentV2] = None
+        
+        last_full_attrs = None 
+
+        for i, neu in enumerate(self.raw_neus):
+
             attrs = neu.attrs_part2()
             inherited_core_config = neu.core_config()
-            target_lcn = self.dests[neu].lcn
-            lcn = self.lcn
+            
+            w_row = weights[i]
+
+            w_dense = Weight(w_row, WeightCompressType.DENSE)
+            w_sparse = Weight(w_row, WeightCompressType.SPARSE)
+            
+           
+            if w_sparse.n_sram_required() < w_dense.n_sram_required():
+                selected_weight = w_sparse
+                attrs.weight_compress = WeightCompressType.SPARSE
+            else:
+                selected_weight = w_dense
+                attrs.weight_compress = WeightCompressType.DENSE
+
+   
+            if current_core is not None and last_full_attrs is not None and attrs == last_full_attrs:
+                neuron_type = NeuronType.HALF
+            else:
+                neuron_type = NeuronType.FULL
+            
+   
+            neu_placement = OfflineNeuronPlacement(neu, attrs)
+            
+            if hasattr(neu_placement, 'neuron_type'):
+                neu_placement.neuron_type = neuron_type
+
+
+            neu_sram_req = neu_placement.n_sram_required()
+            weight_sram_req = selected_weight.n_sram_required()
+            total_req = neu_sram_req + weight_sram_req
+            
+            # Check for core overflow
+            if current_core is None or (current_core.n_sram_required() + total_req > 4096):
+                
+                # Check for single-neuron overflow
+                if total_req > 4096:
+                     raise NotImplementedError(
+                        f"Neuron {i} requires {total_req} SRAM lines, exceeding the 4096 limit. "
+                        "Large input splitting logic is required."
+                    )
+                
+                if current_core is not None:
+                    self.core_placements.append(current_core)
+                
+                current_core = OfflineCorePlamentV2()
+                current_core._core_config = inherited_core_config
+                
+                # Force the first neuron in a new core to be FULL (no predecessor to reuse).
+                if neuron_type == NeuronType.HALF:
+                    neuron_type = NeuronType.FULL
+                    if hasattr(neu_placement, 'neuron_type'):
+                        neu_placement.neuron_type = NeuronType.FULL
+                
+                last_full_attrs = attrs
+            
+            elif neuron_type == NeuronType.FULL:
+                last_full_attrs = attrs
+            
+            current_core.neus.append(neu_placement)
+            current_core.weights.append(selected_weight)
+            
+            idx = len(current_core.neus) - 1
+            current_core.neu_weight_map[idx] = idx
+
+        if current_core is not None:
+            self.core_placements.append(current_core)
+        
+        self.n_core_required = len(self.core_placements)
 
         # implement your core placement generation logic here
         # you need to create OfflineCorePlamentV2 instances, set their properties including:
@@ -89,7 +174,7 @@ class RoutingGroup:
         # 2. you can reorder the input_list, to move as many as possible zero weights to the end of each weight row, so that you can reduce the weight storage requirement
         # ... etc.
 
-        raise NotImplementedError("allocate_neurons method is not implemented yet.")
+        #raise NotImplementedError("allocate_neurons method is not implemented yet.")
 
     def assign_coord(self, coords: list[CoordXY], copy_config: AERPacketZXYCopy):
         assert len(coords) >= len(

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
+import torch
 from paicorelib import (
     LCN_EX,
     AERPacketZXYCopy,
@@ -18,6 +19,8 @@ from paicorelib import (
     WeightCompressType,
     find_coordxy_shortest_path,
 )
+from torch import Tensor, nn
+from torch.nn import functional as F
 
 from .core_config import Backend_Core_Config, Frontend_Core_Config
 from .coreplacement import (
@@ -28,68 +31,444 @@ from .coreplacement import (
 from .neuron import InputElem, Neuron, OfflineNeuronPlacement
 from .op_node import CoreOpNode, InNode
 from .weight import Weight
+from ..paiir import AccumulateOp, AddOp, SequentialOp, StandaloneActOp, StandaloneCompOp
 
 FANIN_BASE = 512
+
+
+def feature_shape(shape: torch.Size | tuple[int, ...]) -> tuple[int, ...]:
+    # Backend weight extraction works on feature dimensions only.
+    # The leading batch dimension is stripped and must stay equal to 1.
+    feature_shape = tuple(shape)
+    if len(feature_shape) > 1:
+        batch = feature_shape[0]
+        if batch != 1:
+            raise NotImplementedError(
+                f"Only batch size 1 is supported, but got shape {feature_shape}."
+            )
+        feature_shape = feature_shape[1:]
+
+    return feature_shape
+
+
+def to_nd_tuple(value: int | tuple[int, ...], ndim: int) -> tuple[int, ...]:
+    if isinstance(value, tuple):
+        if len(value) != ndim:
+            raise ValueError(f"Expected a tuple of length {ndim}, but got {value}.")
+        return value
+
+    return (value,) * ndim
+
+
+def ensure_target_components(target: CoreOpNode) -> None:
+    # Lazily reconstruct per-predecessor comps/weights so routing can
+    # query them even if node initialization did not populate them yet.
+    if not target.predecessors:
+        return
+
+    if len(target.comps) == len(target.predecessors) and len(target.weights) == len(
+        target.predecessors
+    ):
+        return
+
+    raw_node = target.raw_node
+    if isinstance(raw_node, SequentialOp):
+        target.comps = [raw_node.comp]
+    elif isinstance(raw_node, AccumulateOp):
+        target.comps = list(raw_node.comps)
+    elif isinstance(raw_node, StandaloneCompOp):
+        target.comps = [raw_node.comp]
+    elif isinstance(raw_node, StandaloneActOp):
+        target.comps = [None]
+    elif isinstance(raw_node, AddOp):
+        target.comps = [None] * len(raw_node.signs)
+    else:
+        raise NotImplementedError(f"Unsupported node type: {type(raw_node)}")
+
+    raw_weights = raw_node.weights
+    if raw_weights is None:
+        target.weights = [None] * len(target.comps)
+    else:
+        target.weights = list(raw_weights)
+
+
+def path_signs(target: CoreOpNode) -> list[int]:
+    # Accumulate/Add nodes may encode subtraction through per-path signs.
+    raw_node = target.raw_node
+    if isinstance(raw_node, (AccumulateOp, AddOp)):
+        return list(raw_node.signs)
+
+    return [1] * len(target.predecessors)
+
+
+def direct_weight_matrix(
+    weight: Tensor, input_shape: tuple[int, ...], output_shape: tuple[int, ...], sign: int
+) -> np.ndarray:
+    # Linear/identity-like paths already expose a dense [out, in] matrix.
+    matrix = np.asarray(weight.detach().cpu(), dtype=np.int32)
+    n_input = int(np.prod(input_shape))
+    n_output = int(np.prod(output_shape))
+
+    if matrix.shape != (n_output, n_input):
+        raise ValueError(
+            f"Direct weight shape mismatch: expected {(n_output, n_input)}, got {matrix.shape}."
+        )
+
+    if sign != 1:
+        matrix = sign * matrix
+
+    return matrix
+
+
+def unfold_input_indices_2d(
+    channels: int,
+    spatial_shape: tuple[int, int],
+    kernel_size: tuple[int, int],
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+) -> torch.Tensor:
+    # Build a lookup table from each sliding-window position back to the
+    # flattened input indices. Zero means "came from padding".
+    height, width = spatial_shape
+    n_input = channels * height * width
+    input_ids = torch.arange(1, n_input + 1, dtype=torch.float64).reshape(
+        1, channels, height, width
+    )
+    patches = F.unfold(
+        input_ids,
+        kernel_size=kernel_size,
+        dilation=dilation,
+        padding=padding,
+        stride=stride,
+    )
+    return patches.to(torch.int64).squeeze(0)
+
+
+def conv2d_weight_matrix(
+    weight: Tensor,
+    input_shape: tuple[int, int, int],
+    output_shape: tuple[int, int, int],
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+    groups: int,
+    sign: int,
+) -> np.ndarray:
+    # Expand a Conv2d kernel into a full dense matrix with shape [out, in],
+    # where rows are flattened output neurons and columns are flattened inputs.
+    in_channels, height, width = input_shape
+    out_channels, out_height, out_width = output_shape
+    kernel = np.asarray(weight.detach().cpu(), dtype=np.int32)
+    _, in_channels_per_group, kernel_height, kernel_width = kernel.shape
+
+    if in_channels != in_channels_per_group * groups:
+        raise ValueError(
+            f"Conv groups mismatch: input channels {in_channels}, kernel channels {in_channels_per_group}, groups {groups}."
+        )
+
+    out_channels_per_group = out_channels // groups
+    out_size = out_height * out_width
+    n_input = in_channels * height * width
+    matrix = np.zeros((out_channels * out_size, n_input), dtype=np.int32)
+
+    patches = unfold_input_indices_2d(
+        in_channels,
+        (height, width),
+        (kernel_height, kernel_width),
+        stride,
+        padding,
+        dilation,
+    ).cpu().numpy()
+
+    if patches.shape[1] != out_size:
+        raise ValueError(
+            f"Conv unfold mismatch: expected {out_size} output positions, got {patches.shape[1]}."
+        )
+
+    row_offsets = np.tile(
+        np.arange(out_size, dtype=np.int64),
+        in_channels_per_group * kernel_height * kernel_width,
+    )
+
+    for out_channel in range(out_channels):
+        group_idx = out_channel // out_channels_per_group
+        patch_start = group_idx * in_channels_per_group * kernel_height * kernel_width
+        patch_end = patch_start + in_channels_per_group * kernel_height * kernel_width
+
+        # Scatter each kernel coefficient to the input positions that feed the
+        # corresponding flattened output locations.
+        flat_cols = patches[patch_start:patch_end].reshape(-1)
+        valid = flat_cols > 0
+        flat_rows = row_offsets[valid]
+        flat_values = np.repeat(kernel[out_channel].reshape(-1), out_size)[valid]
+        matrix[out_channel * out_size + flat_rows, flat_cols[valid] - 1] = flat_values
+
+    if sign != 1:
+        matrix *= sign
+
+    return matrix
+
+
+def pool2d_weight_matrix(
+    channels: int,
+    input_shape: tuple[int, int, int],
+    output_shape: tuple[int, int, int],
+    kernel_size: tuple[int, int],
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+    sign: int,
+) -> np.ndarray:
+    # Pooling has no explicit weight tensor, but connectivity still forms a
+    # dense [out, in] matrix. Every valid input in the pooling window gets 1.
+    in_channels, height, width = input_shape
+    out_channels, out_height, out_width = output_shape
+    if in_channels != channels or out_channels != channels:
+        raise ValueError(
+            f"Pooling channel mismatch: input={in_channels}, output={out_channels}, channels={channels}."
+        )
+
+    out_size = out_height * out_width
+    n_input = in_channels * height * width
+    matrix = np.zeros((out_channels * out_size, n_input), dtype=np.int32)
+
+    patches = unfold_input_indices_2d(
+        in_channels,
+        (height, width),
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+    ).cpu().numpy()
+
+    if patches.shape[1] != out_size:
+        raise ValueError(
+            f"Pooling unfold mismatch: expected {out_size} output positions, got {patches.shape[1]}."
+        )
+
+    kernel_elems = int(np.prod(kernel_size))
+    row_offsets = np.tile(np.arange(out_size, dtype=np.int64), kernel_elems)
+
+    for channel in range(channels):
+        patch_start = channel * kernel_elems
+        patch_end = patch_start + kernel_elems
+
+        flat_cols = patches[patch_start:patch_end].reshape(-1)
+        valid = flat_cols > 0
+        matrix[channel * out_size + row_offsets[valid], flat_cols[valid] - 1] = sign
+
+    return matrix
+
+
+def conv1d_weight_matrix(
+    weight: Tensor,
+    input_shape: tuple[int, int],
+    output_shape: tuple[int, int],
+    stride: tuple[int],
+    padding: tuple[int],
+    dilation: tuple[int],
+    groups: int,
+    sign: int,
+) -> np.ndarray:
+    # Reuse the 2D expansion path by treating 1D signals as H=1 feature maps.
+    in_channels, in_length = input_shape
+    out_channels, out_length = output_shape
+    kernel = weight.reshape(weight.shape[0], weight.shape[1], 1, weight.shape[2])
+    return conv2d_weight_matrix(
+        kernel,
+        (in_channels, 1, in_length),
+        (out_channels, 1, out_length),
+        (1, stride[0]),
+        (0, padding[0]),
+        (1, dilation[0]),
+        groups,
+        sign,
+    )
+
+
+def pool1d_weight_matrix(
+    channels: int,
+    input_shape: tuple[int, int],
+    output_shape: tuple[int, int],
+    kernel_size: tuple[int],
+    stride: tuple[int],
+    padding: tuple[int],
+    dilation: tuple[int],
+    sign: int,
+) -> np.ndarray:
+    # Reuse the 2D pooling expansion path by treating 1D signals as H=1 maps.
+    in_channels, in_length = input_shape
+    out_channels, out_length = output_shape
+    return pool2d_weight_matrix(
+        channels,
+        (in_channels, 1, in_length),
+        (out_channels, 1, out_length),
+        (1, kernel_size[0]),
+        (1, stride[0]),
+        (0, padding[0]),
+        (1, dilation[0]),
+        sign,
+    )
+
+
+def expanded_path_weight_matrix(
+    predecessor: CoreOpNode | InNode,
+    target: CoreOpNode,
+    comp: Optional[nn.Module],
+    weight: Optional[Tensor],
+    sign: int,
+) -> np.ndarray:
+    # Convert one predecessor path into a dense [out, in] matrix, choosing
+    # the correct expansion strategy from the comp type.
+    input_shape = feature_shape(predecessor.shape)
+    output_shape = feature_shape(target.shape)
+
+    if weight is not None and (comp is None or isinstance(comp, nn.Linear) or weight.ndim == 2):
+        return direct_weight_matrix(weight, input_shape, output_shape, sign)
+
+    if isinstance(comp, nn.Conv1d):
+        return conv1d_weight_matrix(
+            weight,
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.stride, 1),
+            to_nd_tuple(comp.padding, 1),
+            to_nd_tuple(comp.dilation, 1),
+            comp.groups,
+            sign,
+        )
+
+    if isinstance(comp, nn.Conv2d):
+        return conv2d_weight_matrix(
+            weight,
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.stride, 2),
+            to_nd_tuple(comp.padding, 2),
+            to_nd_tuple(comp.dilation, 2),
+            comp.groups,
+            sign,
+        )
+
+    if isinstance(comp, nn.MaxPool1d):
+        if comp.ceil_mode:
+            raise NotImplementedError("MaxPool1d with ceil_mode=True is not supported.")
+
+        return pool1d_weight_matrix(
+            input_shape[0],
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.kernel_size, 1),
+            to_nd_tuple(comp.stride or comp.kernel_size, 1),
+            to_nd_tuple(comp.padding, 1),
+            to_nd_tuple(comp.dilation, 1),
+            sign,
+        )
+
+    if isinstance(comp, nn.AvgPool1d):
+        if comp.ceil_mode:
+            raise NotImplementedError("AvgPool1d with ceil_mode=True is not supported.")
+
+        return pool1d_weight_matrix(
+            input_shape[0],
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.kernel_size, 1),
+            to_nd_tuple(comp.stride or comp.kernel_size, 1),
+            to_nd_tuple(comp.padding, 1),
+            (1,),
+            sign,
+        )
+
+    if isinstance(comp, nn.MaxPool2d):
+        if comp.ceil_mode:
+            raise NotImplementedError("MaxPool2d with ceil_mode=True is not supported.")
+
+        return pool2d_weight_matrix(
+            input_shape[0],
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.kernel_size, 2),
+            to_nd_tuple(comp.stride or comp.kernel_size, 2),
+            to_nd_tuple(comp.padding, 2),
+            to_nd_tuple(comp.dilation, 2),
+            sign,
+        )
+
+    if isinstance(comp, nn.AvgPool2d):
+        if comp.ceil_mode:
+            raise NotImplementedError("AvgPool2d with ceil_mode=True is not supported.")
+
+        return pool2d_weight_matrix(
+            input_shape[0],
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.kernel_size, 2),
+            to_nd_tuple(comp.stride or comp.kernel_size, 2),
+            to_nd_tuple(comp.padding, 2),
+            (1, 1),
+            sign,
+        )
+
+    raise NotImplementedError(
+        f"Unsupported weight expansion for comp {type(comp)} with weight {type(weight)}."
+    )
 
 
 def get_raw_weights(
     raw_neus: list[Neuron], input_neus: list[Neuron | InputElem]
 ) -> np.ndarray:
-    # emplement your own weight retrieval logic here
-    # raw_neu and input_neu are both single neuron at an index of a CoreOpNode or InputNode
-    # the shape of the complete core op node or input node can be found in raw_neu.target.shape or input_neu.target.shape
-    # the index of the elem in flatten is neu.index.idx or elem.index.idx
-    for neu in raw_neus:
-        neu.target.shape
-        neu.index.idx
-    for elem in input_neus:
-        elem.target.shape
-        elem.index.idx
-
+    # Return a dense routing-group weight matrix with shape
+    # [number of output neurons, number of input elements].
     n_output = len(raw_neus)
     n_input = len(input_neus)
-
-    # weight's shape should be (n_output, n_input)
     weights = np.zeros((n_output, n_input), dtype=np.int32)
+
+    # Cache expanded matrices per target node and predecessor node because
+    # many raw neurons share the same source/target pair.
+    target_cache: dict[CoreOpNode, dict[CoreOpNode | InNode, np.ndarray]] = {}
+
+    for neu in raw_neus:
+        target = neu.target
+        if target in target_cache:
+            continue
+
+        ensure_target_components(target)
+        signs = path_signs(target)
+        path_matrices: dict[CoreOpNode | InNode, np.ndarray] = {}
+
+        for predecessor, comp, weight, sign in zip(
+            target.predecessors,
+            target.comps,
+            target.weights,
+            signs,
+        ):
+            # Each predecessor contributes one dense [target_out, pred_out] block.
+            matrix = expanded_path_weight_matrix(
+                predecessor,
+                target,
+                comp,
+                weight,
+                sign,
+            )
+            if predecessor in path_matrices:
+                path_matrices[predecessor] = path_matrices[predecessor] + matrix
+            else:
+                path_matrices[predecessor] = matrix
+
+        target_cache[target] = path_matrices
+
     for i, neu in enumerate(raw_neus):
+        path_matrices = target_cache[neu.target]
         for j, elem in enumerate(input_neus):
-            # set weight value according to your logic
-            # weights[i, j] should be the weight from input_neus[j] to raw_neus[i]
-            # which is the weight from elem.target to neu.target
-            # at the corresponding indices elem.index.idx and neu.index.idx
+            matrix = path_matrices.get(elem.target)
+            if matrix is None:
+                # No edge from this input node to the current output neuron.
+                continue
 
-            # if there is no weight connection, set weights[i, j] to 0
-            
-            # the weight of neu.target 
-            neu.target.weights 
-            # is the weights for 
-            neu.target.predecessors 
-            # to neu.target
-            # the order of weights corresponds to the order of predecessors, which can be CoreOpNode or InNode
-            
-            # you can get the nn.Module for weight unfold, also in the same order of predecessors and weights, from
-            neu.target.comps
-            
-            # for different comp, the weight should be handled differently
-            
-            # for conv2d, neu.target.raw_node.weights returns a kernel of the conv2d
-            # you need to unfold the kernel according to the conv2d parameters to get the weight between input_neu.target and raw_neu.target
-            
-            # for (max and average)pooling, the weight is None,
-            # you also need to unfold the kernel to get the weight between input_neu.target and raw_neu.target, and set the weight value to 1 
-            
-            # if comp is liner or None, the weight is the direct weight between input_neu.target and raw_neu.target, you can directly use it without unfold
-            
-            
-            # when you get the weight from input_neu.target to neu.target, you can set weights[i, j] 
-            # weights[i, j] = weight_from_input_to_neu[elem.index.idx, neu.index.idx]
-
-            # the neu.target and elem.target are mostly same in raw_neus and input_neus
-            # so you can cache the weight matrix for each unique target node to accelerate the process
-
-            # there is a simple test example at PAIBox/test_paiir.py
-
-            weights[i, j] = -1  # unset weight value
+            # Both neuron and input indices are already flattened indices.
+            weights[i, j] = matrix[neu.index.idx, elem.index.idx]
 
     return weights
 

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -7,44 +7,98 @@ from paicorelib import (
     LCN_EX,
     AERPacketZXYCopy,
     CoordXY,
+    DataWidth,
+    FoldType,
     NeuronType,
     OfflineCoreRegV2,
     OfflineNeuDestInfoV2,
     OfflineNeuFullAttrsV2Part1,
     OfflineNeuFullAttrsV2Part2,
+    OutputType,
     WeightCompressType,
     find_coordxy_shortest_path,
 )
 
+from .core_config import Backend_Core_Config, Frontend_Core_Config
 from .coreplacement import (
     CorePlacement,
     EmptyOfflineCorePlacementV2,
-    OfflineCorePlamentV2,
+    OfflineCorePlacementV2,
 )
-from .neuron import Neuron, OfflineNeuronPlacement
+from .neuron import InputElem, Neuron, OfflineNeuronPlacement
 from .weight import Weight
 
 FANIN_BASE = 512
 
 
-def get_raw_weights(raw_neus: list[Neuron], input_neus: list[Neuron]) -> np.ndarray:
+def get_raw_weights(
+    raw_neus: list[Neuron], input_neus: list[Neuron | InputElem]
+) -> np.ndarray:
+    # emplement your own weight retrieval logic here
+    # raw_neu and input_neu are both single neuron at an index of a CoreOpNode or InputNode
+    # the shape of the complete core op node or input node can be found in raw_neu.target.shape or input_neu.target.shape
+    # the index of the elem in flatten is neu.index.idx or elem.index.idx 
+    for neu in raw_neus:
+        neu.target.shape
+        neu.index.idx
+    for elem in input_neus:
+        elem.target.shape
+        elem.index.idx
+
     n_output = len(raw_neus)
     n_input = len(input_neus)
-    # random weights for testing, shape (n_output, n_input)
-    weights = np.random.randint(-128, 127, size=(n_output, n_input), dtype=np.int8)
+    
+    # weight's shape should be (n_output, n_input)
+    weights = np.zeros((n_output, n_input), dtype=np.int32)
+    for i, neu in enumerate(raw_neus):
+        for j, elem in enumerate(input_neus):
+            # set weight value according to your logic
+            # weights[i, j] should be the weight from input_neus[j] to raw_neus[i]
+            # which is the weight from elem.target to neu.target
+            # at the corresponding indices elem.index.idx and neu.index.idx
+            
+            # if there is no weight connection, set weights[i, j] to 0
+            # for now, we can only consider the neu.target.raw_node is a SeqCoreOp
+            # at PAIBox/paibox/fx_converter/core_op.py:208
+            
+            # if neu.target.predecessors contains elem.target
+            # then the weight is decided by neu.target.raw_node.op1
+            # op1 is can be linear or conv2d
+            # for linear the weight from neu.target to elem.target can be found in op1.weight
+            
+            # for conv2d the weight from neu.target to elem.target 
+            # should be the unfolded weight of the conv2d
+            # (you can ask how to convert conv2d to a matrix multiplication for more details)
+            
+            # the neu.target and elem.target are mostly same in raw_neus and input_neus
+            # so you can cache the weight matrix for each unique target node to accelerate the process
+            
+            # there is a simple test example at PAIBox/test.py
+            
+            weights[i, j] = -1 # unset weight value  
+
     return weights
 
 
 class RoutingGroup:
+    _counter = 0
+
     # core_blocks in the same routing group share the same following properties
     # lcn, input_sign, input_width
-    def __init__(self):
+    def __init__(self, raw_neus: list[Neuron], input_list: list[Neuron | InputElem]):
+        self.id: int = type(self)._counter
+        type(self)._counter += 1
+        self.name: str = f"RG_{self.id}"
+
         # set by generate_routing_groups
-        self.raw_neus: list[Neuron] = []
+        self.raw_neus: list[Neuron] = raw_neus
+        self.input_list: list[Neuron | InputElem] = (
+            input_list  # input_list can be reordered later
+        )
+        self.input_set: set[Neuron | InputElem] = set(input_list)
 
         # set by mapper.set_rough_dest()
         self.dests: dict[Neuron, "RoutingGroup"] = {}
-        self.input_list: list[Neuron] = []  # input_list can be reordered later
         self.lcn: LCN_EX = LCN_EX.LCN_1X
 
         # self.core_blocks: list[CoreBlock] = []
@@ -53,17 +107,19 @@ class RoutingGroup:
 
         # set by mapper.routing() call self.assign_coord()
         self.assigned_cores: dict[CoordXY, CorePlacement] = {}
-        self._muticast_config: Optional[AERPacketZXYCopy] = None
+        self._multicast_config: Optional[AERPacketZXYCopy] = None
         self._base_coord: Optional[CoordXY] = None
 
     def set_lcn(self):
-        input_widths = set([neu.core_config().input_width for neu in self.raw_neus])
+        input_widths: set[DataWidth] = set(
+            [neu.core_config().input_width for neu in self.raw_neus]
+        )
         assert (
             len(input_widths) == 1
         ), "All neurons in the routing group must have the same input width."
         # if input width, input sign weight are different, need to split routing group before calling this function
         input_width = input_widths.pop()
-        max_axon_addr = len(self.input_list) * input_width
+        max_axon_addr = len(self.input_list) * (2**input_width)
         lcn = ((max_axon_addr - 1) // FANIN_BASE).bit_length()
         self.lcn = LCN_EX(lcn)
 
@@ -75,139 +131,97 @@ class RoutingGroup:
 
         weights = get_raw_weights(self.raw_neus, self.input_list)
 
+        print(
+            f"Allocating neurons for Routing Group {self.name} with {len(self.raw_neus)} neurons."
+        )
+
         # 1. Grouping Phase
-        groups = []
+        core_groups: dict[
+            tuple[Frontend_Core_Config, Backend_Core_Config],
+            list[tuple[Neuron, np.ndarray]],
+        ] = {}
         for i, neu in enumerate(self.raw_neus):
-            cfg = neu.core_config()
-            t_lcn = self.dests[neu].lcn
-            lcn = self.lcn
-            w_row = weights[i]
+            frontend_core_conf = neu.core_config()
+            backend_core_conf = Backend_Core_Config(
+                lcn=self.lcn,
+                target_lcn=self.dests[neu].lcn,
+            )
+            weight_of_neu = weights[i]
+            key = (frontend_core_conf, backend_core_conf)
+            if key not in core_groups:
+                core_groups[key] = []
+            core_groups[key].append((neu, weight_of_neu))
 
-            match_group = None
-            for g in groups:
-                if g["config"] == cfg and g["target_lcn"] == t_lcn and g["lcn"] == lcn:
-                    match_group = g
-                    break
-
-            if match_group:
-                match_group["items"].append((neu, w_row, i))
-            else:
-                groups.append(
-                    {
-                        "config": cfg,
-                        "target_lcn": t_lcn,
-                        "lcn": lcn,
-                        "items": [(neu, w_row, i)],
-                    }
-                )
-
-        self.core_placements = []
-
-        def create_new_core_for_group(config):
-            new_core = OfflineCorePlamentV2()
-
-            target_fields = OfflineCoreRegV2.model_fields.keys()
-
-            init_data = {}
-            for field_name in target_fields:
-                if hasattr(config, field_name):
-                    init_data[field_name] = getattr(config, field_name)
-                else:
-                    if field_name == "neuron_number":
-                        init_data[field_name] = 0
-                    elif field_name in [
-                        "axon_skew",
-                        "test_core_xy",
-                        "test_core_x",
-                        "test_core_y",
-                    ]:
-                        init_data[field_name] = 0
-                    elif field_name in [
-                        "global_send",
-                        "global_receive",
-                        "tick_start",
-                        "tick_duration",
-                        "tick_initial",
-                    ]:
-                        init_data[field_name] = 0
-                    elif field_name in ["busy_cycle", "delay_cycle", "width_cycle"]:
-                        init_data[field_name] = 2  # gt=1 约束
-
-            try:
-                reg_config = OfflineCoreRegV2(**init_data)
-            except Exception as e:
-                raise ValueError(
-                    f"Failed to initialize OfflineCoreRegV2. \nConfig: {config}\nError: {e}"
-                )
-
-            new_core._core_config = reg_config
-            return new_core
+        self.core_placements: list[CorePlacement] = []
 
         # 2. Allocation Phase
-        for group in groups:
-            group_config = group["config"]
-            group_items = group["items"]
-
+        for key, group_items in core_groups.items():
+            frontend_core_conf, backend_core_conf = key
             # Initialize the first core for the current group
-            current_core = create_new_core_for_group(group_config)
+            current_core = OfflineCorePlacementV2(frontend_core_conf, backend_core_conf)
 
             last_full_attrs = None
 
-            for neu, w_row, original_idx in group_items:
-                attrs = neu.attrs_part2()
+            for neu, weight_of_neu in group_items:
+                attrs_part2 = neu.attrs_part2()
 
                 # Weight Strategy
-                current_weight_width = group_config.weight_width
-                w_dense = Weight(w_row, WeightCompressType.DENSE, current_weight_width)
+                current_weight_width = frontend_core_conf.weight_width
+                w_dense = Weight(
+                    weight_of_neu, WeightCompressType.DENSE, current_weight_width
+                )
                 w_sparse = Weight(
-                    w_row, WeightCompressType.SPARSE, current_weight_width
+                    weight_of_neu, WeightCompressType.SPARSE, current_weight_width
                 )
 
                 if w_sparse.n_sram_required() < w_dense.n_sram_required():
                     selected_weight = w_sparse
-                    attrs.weight_compress = WeightCompressType.SPARSE
+                    attrs_part2.weight_compress = WeightCompressType.SPARSE
                 else:
                     selected_weight = w_dense
-                    attrs.weight_compress = WeightCompressType.DENSE
+                    attrs_part2.weight_compress = WeightCompressType.DENSE
 
-                # Neuron Type (Full/Half)
-                if (
-                    len(current_core.neus) > 0
-                    and last_full_attrs is not None
-                    and attrs == last_full_attrs
-                ):
-                    neuron_type = NeuronType.HALF
-                else:
-                    neuron_type = NeuronType.FULL
-
-                # Create Placement
-                neu_placement = OfflineNeuronPlacement(neu, attrs)
-                neu_placement.neuron_type = neuron_type
+                neuron_type = (
+                    NeuronType.HALF
+                    if attrs_part2 == last_full_attrs
+                    else NeuronType.FULL
+                )
+                output_type = neu.output_type()
+                attrs_part1 = OfflineNeuFullAttrsV2Part1(
+                    weight_skew=0,
+                    weight_address_start=0,
+                    weight_address_end=0,
+                    fold_type=FoldType.UNFOLDED,
+                    neuron_type=neuron_type,
+                    output_type=output_type,
+                )
+                neu_placement = OfflineNeuronPlacement([neu], attrs_part1, attrs_part2)
 
                 # SRAM Check
                 neu_sram_req = neu_placement.n_sram_required()
                 weight_sram_req = selected_weight.n_sram_required()
                 total_req = neu_sram_req + weight_sram_req
 
-                if current_core.n_sram_required() + total_req > 4096:
-                    if total_req > 4096:
-                        raise NotImplementedError(
-                            f"Neuron {original_idx} requires {total_req} SRAM lines."
-                        )
+                if total_req > 4096:
+                    raise NotImplementedError(
+                        f"Neuron {neu} with its weight requires {total_req} SRAM lines."
+                    )
 
-                    if len(current_core.neus) > 0:
-                        self.core_placements.append(current_core)
+                if current_core.n_sram_required() + total_req > 4096:
+                    self.core_placements.append(current_core)
 
                     # Create new core with inheritance
-                    current_core = create_new_core_for_group(group_config)
-
+                    current_core = OfflineCorePlacementV2(
+                        frontend_core_conf, backend_core_conf
+                    )
                     neuron_type = NeuronType.FULL
-                    neu_placement.neuron_type = NeuronType.FULL
-                    last_full_attrs = attrs
+                    neu_placement.neu_attrs_part1.neuron_type = NeuronType.FULL
+                    last_full_attrs = attrs_part2
 
                 elif neuron_type == NeuronType.FULL:
-                    last_full_attrs = attrs
+                    last_full_attrs = attrs_part2
 
+                # print(f"Neuron {neu} assigned type {neu_placement.neuron_type}.")
                 current_core.neus.append(neu_placement)
                 current_core.weights.append(selected_weight)
 
@@ -219,28 +233,8 @@ class RoutingGroup:
 
         self.n_core_required = len(self.core_placements)
 
-        # implement your core placement generation logic here
-        # you need to create OfflineCorePlamentV2 instances, set their properties including:
-        # coreplacement._core_config, coreplacment.neus, coreplacment.weights, coreplacment.neu_weight_map
-        # remember the neurons in the same core placement share the same core config, so
-
-        # the number of core placements created should be set to self.n_core_required
-        # dest_info in NeuronPlacement should remain unset, it will be set later during routing.
-        # auto_core_config in CorePlacement should remain unset, it will be set later during core allocation.
-
-        # each Coreplacement has 4096 sram, you need to make sure the total sram required by neu and weight in each coreplacement does not exceed 4096
-        # you can get the sram required by each neuron using OfflineNeuronPlacement.n_sram_required() function
-        # you can get the sram required by each weight using Weight.n_sram_required() function
-
-        # you can use get_raw_weights function to get the raw weights between self.raw_neus and self.input_list
-        # then you can reorder the input_list as well as the weight's rows according to your core placement strategy
-
-        # you can think about the following optimizations:
-        # 1. for neurons in the same Coreplacement with the same attrs_part2, you can use half neuron to save SRAM
-        # 2. you can reorder the input_list, to move as many as possible zero weights to the end of each weight row, so that you can reduce the weight storage requirement
-        # ... etc.
-
-        # raise NotImplementedError("allocate_neurons method is not implemented yet.")
+        for core_placement in self.core_placements:
+            core_placement.set_weight_address()
 
     def assign_coord(self, coords: list[CoordXY], copy_config: AERPacketZXYCopy):
         assert len(coords) >= len(
@@ -251,8 +245,9 @@ class RoutingGroup:
                 self.assigned_cores[coord] = self.core_placements[i]
             else:
                 self.assigned_cores[coord] = EmptyOfflineCorePlacementV2()
+            self.assigned_cores[coord]._coord = coord
         self._base_coord = coords[0]
-        self._muticast_config = copy_config
+        self._multicast_config = copy_config
 
     def set_detail_dest(self):
         for core_placement in self.core_placements:
@@ -269,9 +264,7 @@ class RoutingGroup:
 
                 # the input width of all cores in dest routing group should be the same,
                 # so we can use the output width of this core as the input width of dest routing group
-                axon_addr_count = (
-                    axon_addr_logic * core_placement.core_config.output_width
-                )
+                axon_addr_count = axon_addr_logic * (2**core_placement.output_width)
 
                 addr_axon = axon_addr_count % FANIN_BASE
                 tick_relative = axon_addr_count // FANIN_BASE
@@ -291,11 +284,15 @@ class RoutingGroup:
                     addr_copy_y=coord_copy.y,
                 )
 
+    def set_auto_core_config(self):
+        for core_placement in self.core_placements:
+            core_placement.set_auto_core_config()
+
     @property
     def multicast_config(self) -> AERPacketZXYCopy:
-        if self._muticast_config is None:
+        if self._multicast_config is None:
             raise ValueError("multicast_config has not been set yet.")
-        return self._muticast_config
+        return self._multicast_config
 
     @property
     def base_coord(self) -> CoordXY:
@@ -306,6 +303,47 @@ class RoutingGroup:
     def __hash__(self):
         # use hash of each raw_neu to identify routing group
         return hash(tuple(sorted([hash(neu) for neu in self.raw_neus])))
+
+    def __str__(self) -> str:
+        neu_strs = [str(neu) for neu in self.raw_neus]
+        # if too many neurons, only show first 3 and last 3
+        if len(neu_strs) > 6:
+            neu_strs = neu_strs[:3] + ["..."] + neu_strs[-3:]
+        # if too many inputs, only show first 3 and last 3
+        input_strs = [str(neu) for neu in self.input_list]
+        if len(input_strs) > 6:
+            input_strs = input_strs[:3] + ["..."] + input_strs[-3:]
+        return f"\n{self.name}(\nraw_neus=[{', '.join(neu_strs)}], \ninput_list=[{', '.join(input_strs)}])\n"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def info(self) -> str:
+        info_str = f"{self.name}:\n"
+        # if too many dests, only show first 3 and last 3
+        dest_strs = []
+        for neu, dest_rg in self.dests.items():
+            dest_strs.append(f"{str(neu)} -> {dest_rg.name}")
+        if len(dest_strs) > 6:
+            dest_strs = dest_strs[:3] + ["..."] + dest_strs[-3:]
+        info_str += f"  Number of Neurons: {len(self.raw_neus)}\n"
+        info_str += f"  Number of Inputs: {len(self.input_list)}\n"
+        info_str += f"  Dests:\n    " + "\n    ".join(dest_strs) + "\n"
+        info_str += f"  LCN: {self.lcn.name}\n"
+        info_str += f"  Number of Core Placements: {len(self.core_placements)}\n"
+        if self._base_coord is not None:
+            info_str += f"  Base Coord: ({self._base_coord.x}, {self._base_coord.y})\n"
+        if self._multicast_config is not None:
+            info_str += f"  Multicast Config: (Z: {self._multicast_config.z}, X: {self._multicast_config.x}, Y: {self._multicast_config.y})\n"
+        return info_str
+
+    def routing_summary(self) -> str:
+        summary_str = f"{self.name} Routing Summary:\n"
+        for i, core_placement in enumerate(self.core_placements):
+            summary_str += f"  Core Placement {i} at {core_placement.coord}:\n"
+            summary_str += f"    Number of Neurons: {len(core_placement.neus)}\n"
+            summary_str += f"    Number of Weights: {len(core_placement.weights)}\n"
+        return summary_str
 
 
 def toposort_for_rg(
@@ -319,6 +357,8 @@ def toposort_for_rg(
 
     for rg in routing_groups:
         for dest_rg in rg.dests.values():
+            if dest_rg not in routing_groups:
+                continue
             graph[rg].append(dest_rg)
             indegree[dest_rg] += 1
 
@@ -329,6 +369,8 @@ def toposort_for_rg(
         rg = queue.popleft()
         sorted_rgs.append(rg)
         for neighbor in graph[rg]:
+            if neighbor not in routing_groups:
+                continue
             indegree[neighbor] -= 1
             if indegree[neighbor] == 0:
                 queue.append(neighbor)

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -3,23 +3,26 @@ from __future__ import annotations
 from typing import Optional
 
 import numpy as np
-from .coreplacement import CorePlacement, EmptyOfflineCorePlacementV2,OfflineCorePlamentV2
-from .neuron import Neuron,OfflineNeuronPlacement
-from .weight import Weight
-
 from paicorelib import (
     LCN_EX,
     AERPacketZXYCopy,
     CoordXY,
-    OfflineNeuDestInfoV2,
-    find_coordxy_shortest_path,
     NeuronType,
-    WeightCompressType,
     OfflineCoreRegV2,
+    OfflineNeuDestInfoV2,
     OfflineNeuFullAttrsV2Part1,
-    OfflineNeuFullAttrsV2Part2
-
+    OfflineNeuFullAttrsV2Part2,
+    WeightCompressType,
+    find_coordxy_shortest_path,
 )
+
+from .coreplacement import (
+    CorePlacement,
+    EmptyOfflineCorePlacementV2,
+    OfflineCorePlamentV2,
+)
+from .neuron import Neuron, OfflineNeuronPlacement
+from .weight import Weight
 
 FANIN_BASE = 512
 
@@ -79,30 +82,32 @@ class RoutingGroup:
             t_lcn = self.dests[neu].lcn
             lcn = self.lcn
             w_row = weights[i]
-            
+
             match_group = None
             for g in groups:
-                if g['config'] == cfg and g['target_lcn'] == t_lcn and g['lcn'] == lcn:
+                if g["config"] == cfg and g["target_lcn"] == t_lcn and g["lcn"] == lcn:
                     match_group = g
                     break
-            
+
             if match_group:
-                match_group['items'].append((neu, w_row, i))
+                match_group["items"].append((neu, w_row, i))
             else:
-                groups.append({
-                    'config': cfg,
-                    'target_lcn': t_lcn,
-                    'lcn': lcn,
-                    'items': [(neu, w_row, i)]
-                })
+                groups.append(
+                    {
+                        "config": cfg,
+                        "target_lcn": t_lcn,
+                        "lcn": lcn,
+                        "items": [(neu, w_row, i)],
+                    }
+                )
 
         self.core_placements = []
 
         def create_new_core_for_group(config):
             new_core = OfflineCorePlamentV2()
-            
+
             target_fields = OfflineCoreRegV2.model_fields.keys()
-            
+
             init_data = {}
             for field_name in target_fields:
                 if hasattr(config, field_name):
@@ -110,38 +115,53 @@ class RoutingGroup:
                 else:
                     if field_name == "neuron_number":
                         init_data[field_name] = 0
-                    elif field_name in ["axon_skew", "test_core_xy", "test_core_x", "test_core_y"]:
+                    elif field_name in [
+                        "axon_skew",
+                        "test_core_xy",
+                        "test_core_x",
+                        "test_core_y",
+                    ]:
                         init_data[field_name] = 0
-                    elif field_name in ["global_send", "global_receive", "tick_start", "tick_duration", "tick_initial"]:
+                    elif field_name in [
+                        "global_send",
+                        "global_receive",
+                        "tick_start",
+                        "tick_duration",
+                        "tick_initial",
+                    ]:
                         init_data[field_name] = 0
                     elif field_name in ["busy_cycle", "delay_cycle", "width_cycle"]:
                         init_data[field_name] = 2  # gt=1 约束
-            
+
             try:
                 reg_config = OfflineCoreRegV2(**init_data)
             except Exception as e:
-                raise ValueError(f"Failed to initialize OfflineCoreRegV2. \nConfig: {config}\nError: {e}")
+                raise ValueError(
+                    f"Failed to initialize OfflineCoreRegV2. \nConfig: {config}\nError: {e}"
+                )
 
             new_core._core_config = reg_config
             return new_core
 
         # 2. Allocation Phase
         for group in groups:
-            group_config = group['config']
-            group_items = group['items']
-            
+            group_config = group["config"]
+            group_items = group["items"]
+
             # Initialize the first core for the current group
             current_core = create_new_core_for_group(group_config)
-            
+
             last_full_attrs = None
-            
+
             for neu, w_row, original_idx in group_items:
                 attrs = neu.attrs_part2()
-                
+
                 # Weight Strategy
                 current_weight_width = group_config.weight_width
                 w_dense = Weight(w_row, WeightCompressType.DENSE, current_weight_width)
-                w_sparse = Weight(w_row, WeightCompressType.SPARSE, current_weight_width)
+                w_sparse = Weight(
+                    w_row, WeightCompressType.SPARSE, current_weight_width
+                )
 
                 if w_sparse.n_sram_required() < w_dense.n_sram_required():
                     selected_weight = w_sparse
@@ -151,7 +171,11 @@ class RoutingGroup:
                     attrs.weight_compress = WeightCompressType.DENSE
 
                 # Neuron Type (Full/Half)
-                if len(current_core.neus) > 0 and last_full_attrs is not None and attrs == last_full_attrs:
+                if (
+                    len(current_core.neus) > 0
+                    and last_full_attrs is not None
+                    and attrs == last_full_attrs
+                ):
                     neuron_type = NeuronType.HALF
                 else:
                     neuron_type = NeuronType.FULL
@@ -164,32 +188,32 @@ class RoutingGroup:
                 neu_sram_req = neu_placement.n_sram_required()
                 weight_sram_req = selected_weight.n_sram_required()
                 total_req = neu_sram_req + weight_sram_req
-                
+
                 if current_core.n_sram_required() + total_req > 4096:
                     if total_req > 4096:
-                         raise NotImplementedError(
+                        raise NotImplementedError(
                             f"Neuron {original_idx} requires {total_req} SRAM lines."
                         )
-                    
+
                     if len(current_core.neus) > 0:
                         self.core_placements.append(current_core)
-                    
+
                     # Create new core with inheritance
                     current_core = create_new_core_for_group(group_config)
-                    
+
                     neuron_type = NeuronType.FULL
                     neu_placement.neuron_type = NeuronType.FULL
                     last_full_attrs = attrs
-                
+
                 elif neuron_type == NeuronType.FULL:
                     last_full_attrs = attrs
-                
+
                 current_core.neus.append(neu_placement)
                 current_core.weights.append(selected_weight)
-                
+
                 idx = len(current_core.neus) - 1
                 current_core.neu_weight_map[idx] = idx
-            
+
             if len(current_core.neus) > 0:
                 self.core_placements.append(current_core)
 
@@ -216,7 +240,7 @@ class RoutingGroup:
         # 2. you can reorder the input_list, to move as many as possible zero weights to the end of each weight row, so that you can reduce the weight storage requirement
         # ... etc.
 
-        #raise NotImplementedError("allocate_neurons method is not implemented yet.")
+        # raise NotImplementedError("allocate_neurons method is not implemented yet.")
 
     def assign_coord(self, coords: list[CoordXY], copy_config: AERPacketZXYCopy):
         assert len(coords) >= len(

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
-from coreplacement import CorePlacement
-from paicorelib import AERPacketZXYCopy, CoordXY, LCN_EX
-from typing import Optional
-from neuron import Neuron
-import numpy as np
 
+from typing import Optional
+
+import numpy as np
+from paicorelib import (
+    LCN_EX,
+    AERPacketZXYCopy,
+    CoordXY,
+    OfflineNeuDestInfoV2,
+    find_coordxy_shortest_path,
+)
+
+from coreplacement import CorePlacement, EmptyOfflineCorePlacementV2
+from neuron import Neuron
 
 FANIN_BASE = 512
+
 
 def get_raw_weights(raw_neus: list[Neuron], input_neus: list[Neuron]) -> np.ndarray:
     n_output = len(raw_neus)
@@ -15,69 +24,170 @@ def get_raw_weights(raw_neus: list[Neuron], input_neus: list[Neuron]) -> np.ndar
     weights = np.random.randint(-128, 127, size=(n_output, n_input), dtype=np.int8)
     return weights
 
+
 class RoutingGroup:
     # core_blocks in the same routing group share the same following properties
     # lcn, input_sign, input_width
     def __init__(self):
         # set by generate_routing_groups
         self.raw_neus: list[Neuron] = []
-        
-        # set by set_rough_dest
-        self.dests: list["RoutingGroup"] = []
-        self.input_list: list[Neuron] = [] # input_list can be reordered later
+
+        # set by mapper.set_rough_dest()
+        self.dests: dict[Neuron, "RoutingGroup"] = {}
+        self.input_list: list[Neuron] = []  # input_list can be reordered later
         self.lcn: LCN_EX = LCN_EX.LCN_1X
-        
+
         # self.core_blocks: list[CoreBlock] = []
         self.core_placements: list[CorePlacement] = []
         self.n_core_required: int = -1
-        
-        self.muticast_config: Optional[AERPacketZXYCopy] = None
-        self.base_coord: Optional[CoordXY] = None
-    
+
+        # set by mapper.routing() call self.assign_coord()
+        self.assigned_cores: dict[CoordXY, CorePlacement] = {}
+        self._muticast_config: Optional[AERPacketZXYCopy] = None
+        self._base_coord: Optional[CoordXY] = None
+
     def set_lcn(self):
         input_widths = set([neu.core_config().input_width for neu in self.raw_neus])
-        assert len(input_widths) == 1, "All neurons in the routing group must have the same input width."
+        assert (
+            len(input_widths) == 1
+        ), "All neurons in the routing group must have the same input width."
         # if input width, input sign weight are different, need to split routing group before calling this function
         input_width = input_widths.pop()
         max_axon_addr = len(self.input_list) * input_width
         lcn = ((max_axon_addr - 1) // FANIN_BASE).bit_length()
         self.lcn = LCN_EX(lcn)
-        
-    
+
     def allocate_neurons(self):
         """core placement generation"""
         # you can get neu_attrs_part2, inherited_core_config, target_lcn, lcn for each neuron in self.raw_neus, like:
         # all the attrs in neu_attrs_part2 are valid except weight compress, you should set weight compress according to your weight storage strategy
         # inherited core_config are valid except weight_width, you can set weight_width larger than or equal to the original value for optimization
-        
-        for neu, dest in zip(self.raw_neus, self.dests):
+
+        for neu in self.raw_neus:
             attrs = neu.attrs_part2()
             inherited_core_config = neu.core_config()
-            target_lcn = dest.lcn
+            target_lcn = self.dests[neu].lcn
             lcn = self.lcn
-        
+
         # implement your core placement generation logic here
         # you need to create OfflineCorePlamentV2 instances, set their properties including:
         # coreplacement._core_config, coreplacment.neus, coreplacment.weights, coreplacment.neu_weight_map
-        # remember the neurons in the same core placement share the same core config, so 
-        
+        # remember the neurons in the same core placement share the same core config, so
+
         # the number of core placements created should be set to self.n_core_required
         # dest_info in NeuronPlacement should remain unset, it will be set later during routing.
         # auto_core_config in CorePlacement should remain unset, it will be set later during core allocation.
-        
+
         # each Coreplacement has 4096 sram, you need to make sure the total sram required by neu and weight in each coreplacement does not exceed 4096
         # you can get the sram required by each neuron using OfflineNeuronPlacement.n_sram_required() function
         # you can get the sram required by each weight using Weight.n_sram_required() function
-        
+
         # you can use get_raw_weights function to get the raw weights between self.raw_neus and self.input_list
         # then you can reorder the input_list as well as the weight's rows according to your core placement strategy
-        
+
         # you can think about the following optimizations:
         # 1. for neurons in the same Coreplacement with the same attrs_part2, you can use half neuron to save SRAM
         # 2. you can reorder the input_list, to move as many as possible zero weights to the end of each weight row, so that you can reduce the weight storage requirement
         # ... etc.
-                
+
         raise NotImplementedError("allocate_neurons method is not implemented yet.")
-        
-        
-            
+
+    def assign_coord(self, coords: list[CoordXY], copy_config: AERPacketZXYCopy):
+        assert len(coords) >= len(
+            self.core_placements
+        ), "Not enough coordinates provided to assign."
+        for i, coord in enumerate(coords):
+            if i < len(self.core_placements):
+                self.assigned_cores[coord] = self.core_placements[i]
+            else:
+                self.assigned_cores[coord] = EmptyOfflineCorePlacementV2()
+        self._base_coord = coords[0]
+        self._muticast_config = copy_config
+
+    def set_detail_dest(self):
+        for core_placement in self.core_placements:
+            for neu_placement in core_placement.neus:
+                # mostly each neu_placement contains only one raw_neu
+                # for folded neuron placement, it may contain multiple raw_neus
+                # but we only need to set dest_info for the first raw_neu
+                main_neu = neu_placement.raw_neus[0]
+                dest_routing_group = self.dests[main_neu]
+
+                dest_coord = dest_routing_group.base_coord
+                coord_copy = dest_routing_group.multicast_config
+                axon_addr_logic = dest_routing_group.input_list.index(main_neu)
+
+                # the input width of all cores in dest routing group should be the same,
+                # so we can use the output width of this core as the input width of dest routing group
+                axon_addr_count = (
+                    axon_addr_logic * core_placement.core_config.output_width
+                )
+
+                addr_axon = axon_addr_count % FANIN_BASE
+                tick_relative = axon_addr_count // FANIN_BASE
+
+                coord_offset, _ = find_coordxy_shortest_path(
+                    target=dest_coord, start=core_placement.coord
+                )
+
+                neu_placement.dest_info = OfflineNeuDestInfoV2(
+                    tick_relative=tick_relative,
+                    addr_axon=addr_axon,  # to be set during core allocation
+                    addr_core_xy=coord_offset.z,
+                    addr_core_x=coord_offset.x,
+                    addr_core_y=coord_offset.y,
+                    addr_copy_xy=coord_copy.z,
+                    addr_copy_x=coord_copy.x,
+                    addr_copy_y=coord_copy.y,
+                )
+
+    @property
+    def multicast_config(self) -> AERPacketZXYCopy:
+        if self._muticast_config is None:
+            raise ValueError("multicast_config has not been set yet.")
+        return self._muticast_config
+
+    @property
+    def base_coord(self) -> CoordXY:
+        if self._base_coord is None:
+            raise ValueError("base_coord has not been set yet.")
+        return self._base_coord
+
+    def __hash__(self):
+        # use hash of each raw_neu to identify routing group
+        return hash(tuple(sorted([hash(neu) for neu in self.raw_neus])))
+
+
+def toposort_for_rg(
+    routing_groups: list[RoutingGroup],
+) -> tuple[list[RoutingGroup], dict[int, list[int]]]:
+    """topological sort for routing groups based on their dests"""
+    from collections import defaultdict, deque
+
+    indegree = {rg: 0 for rg in routing_groups}
+    graph = defaultdict(list)
+
+    for rg in routing_groups:
+        for dest_rg in rg.dests.values():
+            graph[rg].append(dest_rg)
+            indegree[dest_rg] += 1
+
+    queue = deque([rg for rg in routing_groups if indegree[rg] == 0])
+    sorted_rgs = []
+
+    while queue:
+        rg = queue.popleft()
+        sorted_rgs.append(rg)
+        for neighbor in graph[rg]:
+            indegree[neighbor] -= 1
+            if indegree[neighbor] == 0:
+                queue.append(neighbor)
+
+    next_rg_id = {}
+    for i, rg in enumerate(sorted_rgs):
+        next_rg_id[i] = [sorted_rgs.index(dest_rg) for dest_rg in graph[rg]]
+
+    if len(sorted_rgs) != len(routing_groups):
+        raise ValueError("Cycle detected in routing groups.")
+
+    return sorted_rgs, next_rg_id

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+from coreplacement import CorePlacement
+from paicorelib import AERPacketZXYCopy, CoordXY, LCN_EX
+from typing import Optional
+from neuron import Neuron
+import numpy as np
+
+
+FANIN_BASE = 512
+
+def get_raw_weights(raw_neus: list[Neuron], input_neus: list[Neuron]) -> np.ndarray:
+    n_output = len(raw_neus)
+    n_input = len(input_neus)
+    # random weights for testing, shape (n_output, n_input)
+    weights = np.random.randint(-128, 127, size=(n_output, n_input), dtype=np.int8)
+    return weights
+
+class RoutingGroup:
+    # core_blocks in the same routing group share the same following properties
+    # lcn, input_sign, input_width
+    def __init__(self):
+        # set by generate_routing_groups
+        self.raw_neus: list[Neuron] = []
+        
+        # set by set_rough_dest
+        self.dests: list["RoutingGroup"] = []
+        self.input_list: list[Neuron] = [] # input_list can be reordered later
+        self.lcn: LCN_EX = LCN_EX.LCN_1X
+        
+        # self.core_blocks: list[CoreBlock] = []
+        self.core_placements: list[CorePlacement] = []
+        self.n_core_required: int = -1
+        
+        self.muticast_config: Optional[AERPacketZXYCopy] = None
+        self.base_coord: Optional[CoordXY] = None
+    
+    def set_lcn(self):
+        input_widths = set([neu.core_config().input_width for neu in self.raw_neus])
+        assert len(input_widths) == 1, "All neurons in the routing group must have the same input width."
+        # if input width, input sign weight are different, need to split routing group before calling this function
+        input_width = input_widths.pop()
+        max_axon_addr = len(self.input_list) * input_width
+        lcn = ((max_axon_addr - 1) // FANIN_BASE).bit_length()
+        self.lcn = LCN_EX(lcn)
+        
+    
+    def allocate_neurons(self):
+        """core placement generation"""
+        # you can get neu_attrs_part2, inherited_core_config, target_lcn, lcn for each neuron in self.raw_neus, like:
+        # all the attrs in neu_attrs_part2 are valid except weight compress, you should set weight compress according to your weight storage strategy
+        # inherited core_config are valid except weight_width, you can set weight_width larger than or equal to the original value for optimization
+        
+        for neu, dest in zip(self.raw_neus, self.dests):
+            attrs = neu.attrs_part2()
+            inherited_core_config = neu.core_config()
+            target_lcn = dest.lcn
+            lcn = self.lcn
+        
+        # implement your core placement generation logic here
+        # you need to create OfflineCorePlamentV2 instances, set their properties including:
+        # coreplacement._core_config, coreplacment.neus, coreplacment.weights, coreplacment.neu_weight_map
+        # remember the neurons in the same core placement share the same core config, so 
+        
+        # the number of core placements created should be set to self.n_core_required
+        # dest_info in NeuronPlacement should remain unset, it will be set later during routing.
+        # auto_core_config in CorePlacement should remain unset, it will be set later during core allocation.
+        
+        # each Coreplacement has 4096 sram, you need to make sure the total sram required by neu and weight in each coreplacement does not exceed 4096
+        # you can get the sram required by each neuron using OfflineNeuronPlacement.n_sram_required() function
+        # you can get the sram required by each weight using Weight.n_sram_required() function
+        
+        # you can use get_raw_weights function to get the raw weights between self.raw_neus and self.input_list
+        # then you can reorder the input_list as well as the weight's rows according to your core placement strategy
+        
+        # you can think about the following optimizations:
+        # 1. for neurons in the same Coreplacement with the same attrs_part2, you can use half neuron to save SRAM
+        # 2. you can reorder the input_list, to move as many as possible zero weights to the end of each weight row, so that you can reduce the weight storage requirement
+        # ... etc.
+                
+        raise NotImplementedError("allocate_neurons method is not implemented yet.")
+        
+        
+            

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -26,6 +26,7 @@ from .coreplacement import (
     OfflineCorePlacementV2,
 )
 from .neuron import InputElem, Neuron, OfflineNeuronPlacement
+from .op_node import CoreOpNode, InNode
 from .weight import Weight
 
 FANIN_BASE = 512
@@ -37,7 +38,7 @@ def get_raw_weights(
     # emplement your own weight retrieval logic here
     # raw_neu and input_neu are both single neuron at an index of a CoreOpNode or InputNode
     # the shape of the complete core op node or input node can be found in raw_neu.target.shape or input_neu.target.shape
-    # the index of the elem in flatten is neu.index.idx or elem.index.idx 
+    # the index of the elem in flatten is neu.index.idx or elem.index.idx
     for neu in raw_neus:
         neu.target.shape
         neu.index.idx
@@ -47,7 +48,7 @@ def get_raw_weights(
 
     n_output = len(raw_neus)
     n_input = len(input_neus)
-    
+
     # weight's shape should be (n_output, n_input)
     weights = np.zeros((n_output, n_input), dtype=np.int32)
     for i, neu in enumerate(raw_neus):
@@ -56,26 +57,39 @@ def get_raw_weights(
             # weights[i, j] should be the weight from input_neus[j] to raw_neus[i]
             # which is the weight from elem.target to neu.target
             # at the corresponding indices elem.index.idx and neu.index.idx
-            
+
             # if there is no weight connection, set weights[i, j] to 0
-            # for now, we can only consider the neu.target.raw_node is a SeqCoreOp
-            # at PAIBox/paibox/fx_converter/core_op.py:208
             
-            # if neu.target.predecessors contains elem.target
-            # then the weight is decided by neu.target.raw_node.op1
-            # op1 is can be linear or conv2d
-            # for linear the weight from neu.target to elem.target can be found in op1.weight
+            # the weight of neu.target 
+            neu.target.weights 
+            # is the weights for 
+            neu.target.predecessors 
+            # to neu.target
+            # the order of weights corresponds to the order of predecessors, which can be CoreOpNode or InNode
             
-            # for conv2d the weight from neu.target to elem.target 
-            # should be the unfolded weight of the conv2d
-            # (you can ask how to convert conv2d to a matrix multiplication for more details)
+            # you can get the nn.Module for weight unfold, also in the same order of predecessors and weights, from
+            neu.target.comps
             
+            # for different comp, the weight should be handled differently
+            
+            # for conv2d, neu.target.raw_node.weights returns a kernel of the conv2d
+            # you need to unfold the kernel according to the conv2d parameters to get the weight between input_neu.target and raw_neu.target
+            
+            # for (max and average)pooling, the weight is None,
+            # you also need to unfold the kernel to get the weight between input_neu.target and raw_neu.target, and set the weight value to 1 
+            
+            # if comp is liner or None, the weight is the direct weight between input_neu.target and raw_neu.target, you can directly use it without unfold
+            
+            
+            # when you get the weight from input_neu.target to neu.target, you can set weights[i, j] 
+            # weights[i, j] = weight_from_input_to_neu[elem.index.idx, neu.index.idx]
+
             # the neu.target and elem.target are mostly same in raw_neus and input_neus
             # so you can cache the weight matrix for each unique target node to accelerate the process
-            
-            # there is a simple test example at PAIBox/test.py
-            
-            weights[i, j] = -1 # unset weight value  
+
+            # there is a simple test example at PAIBox/test_paiir.py
+
+            weights[i, j] = -1  # unset weight value
 
     return weights
 
@@ -85,10 +99,22 @@ class RoutingGroup:
 
     # core_blocks in the same routing group share the same following properties
     # lcn, input_sign, input_width
-    def __init__(self, raw_neus: list[Neuron], input_list: list[Neuron | InputElem]):
+    def __init__(
+        self,
+        raw_neus: list[Neuron],
+        input_list: list[Neuron | InputElem],
+        nodes: Optional[set[CoreOpNode]] = None,
+        input_nodes: Optional[set[CoreOpNode | InNode]] = None,
+    ):
         self.id: int = type(self)._counter
         type(self)._counter += 1
         self.name: str = f"RG_{self.id}"
+
+        # for better optimization, if nodes and input_nodes are provided,
+        # it means the raw_neus and input_list are all neu and input_elem generated from these nodes,
+        # so we can directly get the weight matrix for this routing group without checking the connection between each raw_neu and input_elem
+        self.nodes = nodes
+        self.input_nodes = input_nodes
 
         # set by generate_routing_groups
         self.raw_neus: list[Neuron] = raw_neus

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -11,17 +11,15 @@ from paicorelib import (
     DataWidth,
     FoldType,
     NeuronType,
-    OfflineCoreRegV2,
     OfflineNeuDestInfoV2,
     OfflineNeuFullAttrsV2Part1,
-    OfflineNeuFullAttrsV2Part2,
-    OutputType,
     WeightCompressType,
     find_coordxy_shortest_path,
 )
 from torch import Tensor, nn
 from torch.nn import functional as F
 
+from ..paiir import AccumulateOp, AddOp, SequentialOp, StandaloneActOp, StandaloneCompOp
 from .core_config import Backend_Core_Config, Frontend_Core_Config
 from .coreplacement import (
     CorePlacement,
@@ -31,7 +29,6 @@ from .coreplacement import (
 from .neuron import InputElem, Neuron, OfflineNeuronPlacement
 from .op_node import CoreOpNode, InNode
 from .weight import Weight
-from ..paiir import AccumulateOp, AddOp, SequentialOp, StandaloneActOp, StandaloneCompOp
 
 FANIN_BASE = 512
 
@@ -102,7 +99,10 @@ def path_signs(target: CoreOpNode) -> list[int]:
 
 
 def direct_weight_matrix(
-    weight: Tensor, input_shape: tuple[int, ...], output_shape: tuple[int, ...], sign: int
+    weight: Tensor,
+    input_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+    sign: int,
 ) -> np.ndarray:
     # Linear/identity-like paths already expose a dense [out, in] matrix.
     matrix = np.asarray(weight.detach().cpu(), dtype=np.int32)
@@ -172,14 +172,18 @@ def conv2d_weight_matrix(
     n_input = in_channels * height * width
     matrix = np.zeros((out_channels * out_size, n_input), dtype=np.int32)
 
-    patches = unfold_input_indices_2d(
-        in_channels,
-        (height, width),
-        (kernel_height, kernel_width),
-        stride,
-        padding,
-        dilation,
-    ).cpu().numpy()
+    patches = (
+        unfold_input_indices_2d(
+            in_channels,
+            (height, width),
+            (kernel_height, kernel_width),
+            stride,
+            padding,
+            dilation,
+        )
+        .cpu()
+        .numpy()
+    )
 
     if patches.shape[1] != out_size:
         raise ValueError(
@@ -233,14 +237,18 @@ def pool2d_weight_matrix(
     n_input = in_channels * height * width
     matrix = np.zeros((out_channels * out_size, n_input), dtype=np.int32)
 
-    patches = unfold_input_indices_2d(
-        in_channels,
-        (height, width),
-        kernel_size,
-        stride,
-        padding,
-        dilation,
-    ).cpu().numpy()
+    patches = (
+        unfold_input_indices_2d(
+            in_channels,
+            (height, width),
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+        )
+        .cpu()
+        .numpy()
+    )
 
     if patches.shape[1] != out_size:
         raise ValueError(
@@ -324,7 +332,9 @@ def expanded_path_weight_matrix(
     input_shape = feature_shape(predecessor.shape)
     output_shape = feature_shape(target.shape)
 
-    if weight is not None and (comp is None or isinstance(comp, nn.Linear) or weight.ndim == 2):
+    if weight is not None and (
+        comp is None or isinstance(comp, nn.Linear) or weight.ndim == 2
+    ):
         return direct_weight_matrix(weight, input_shape, output_shape, sign)
 
     if isinstance(comp, nn.Conv1d):
@@ -733,7 +743,7 @@ class RoutingGroup:
             dest_strs = dest_strs[:3] + ["..."] + dest_strs[-3:]
         info_str += f"  Number of Neurons: {len(self.raw_neus)}\n"
         info_str += f"  Number of Inputs: {len(self.input_list)}\n"
-        info_str += f"  Dests:\n    " + "\n    ".join(dest_strs) + "\n"
+        info_str += "  Dests:\n    " + "\n    ".join(dest_strs) + "\n"
         info_str += f"  LCN: {self.lcn.name}\n"
         info_str += f"  Number of Core Placements: {len(self.core_placements)}\n"
         if self._base_coord is not None:

--- a/paibox/backendv2/weight.py
+++ b/paibox/backendv2/weight.py
@@ -1,24 +1,20 @@
 from __future__ import annotations
 
-N_WEIGHTS_PER_SRAM = {
-    1: 7,
-    2: 7,
-    4: 6,
-    8: 5
-}
+N_WEIGHTS_PER_SRAM = {1: 7, 2: 7, 4: 6, 8: 5}
+
 
 class Weight:
     def __init__(self):
-        self.raw_weights: list[int] = [] # the raw weight 
-        self.weight_width: int = 0 # bit width of each weight
-        self.compress : bool = False # whether the weight is compressed
-        
+        self.raw_weights: list[int] = []  # the raw weight
+        self.weight_width: int = 0  # bit width of each weight
+        self.compress: bool = False  # whether the weight is compressed
+
         # processed weights remove zero at the end if not compressed
         self.processed_weights: list[int] = self.raw_weights.copy()
         # remove zero at the end of raw weights
         while len(self.processed_weights) > 0 and self.processed_weights[-1] == 0:
             self.processed_weights.pop()
-    
+
     def n_sram_required(self) -> int:
         if not self.compress:
             return (len(self.processed_weights) * self.weight_width + 127) // 128
@@ -28,8 +24,10 @@ class Weight:
             n_non_zero = sum(1 for w in self.raw_weights if w != 0)
             n_weight_per_sram = N_WEIGHTS_PER_SRAM.get(self.weight_width, 0)
             if n_weight_per_sram == 0:
-                raise ValueError(f"Unsupported weight width for compression: {self.weight_width}")
+                raise ValueError(
+                    f"Unsupported weight width for compression: {self.weight_width}"
+                )
             return (n_non_zero + n_weight_per_sram - 1) // n_weight_per_sram
-    
+
     def to_package(self):
         raise NotImplementedError("to_package method is not implemented yet.")

--- a/paibox/backendv2/weight.py
+++ b/paibox/backendv2/weight.py
@@ -1,20 +1,24 @@
 from __future__ import annotations
 
-from typing import Literal,Union
+from typing import Literal, Union
 
 import numpy as np
-from paicorelib import FRAME_DTYPE, FrameArrayType, OfflineFrameGenV2,WeightCompressType
-
+from paicorelib import (
+    FRAME_DTYPE,
+    FrameArrayType,
+    OfflineFrameGenV2,
+    WeightCompressType,
+)
 
 N_WEIGHTS_PER_SRAM = {1: 7, 2: 7, 4: 6, 8: 5}
 
 
 class Weight:
     def __init__(
-        self, 
-        data: Union[np.ndarray, list[int]], 
-        compress_type: WeightCompressType, 
-        weight_width: int
+        self,
+        data: Union[np.ndarray, list[int]],
+        compress_type: WeightCompressType,
+        weight_width: int,
     ):
         if isinstance(data, np.ndarray):
             self.raw_weights: list[int] = data.tolist()
@@ -25,8 +29,9 @@ class Weight:
             raise ValueError(f"Unsupported weight width: {weight_width}")
         self.weight_width = weight_width
 
-     
-        self.compress: bool = (compress_type == WeightCompressType.SPARSE)  # whether the weight is compressed
+        self.compress: bool = (
+            compress_type == WeightCompressType.SPARSE
+        )  # whether the weight is compressed
 
         # processed weights remove zero at the end if not compressed
         self.processed_weights: list[int] = self.raw_weights.copy()

--- a/paibox/backendv2/weight.py
+++ b/paibox/backendv2/weight.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+from typing import Literal
+
+import numpy as np
+from paicorelib import FRAME_DTYPE, FrameArrayType, OfflineFrameGenV2
+
 N_WEIGHTS_PER_SRAM = {1: 7, 2: 7, 4: 6, 8: 5}
 
 
 class Weight:
     def __init__(self):
         self.raw_weights: list[int] = []  # the raw weight
-        self.weight_width: int = 0  # bit width of each weight
+        self.weight_width: Literal[1, 2, 4, 8] = 1  # bit width of each weight
         self.compress: bool = False  # whether the weight is compressed
 
         # processed weights remove zero at the end if not compressed
@@ -29,5 +34,10 @@ class Weight:
                 )
             return (n_non_zero + n_weight_per_sram - 1) // n_weight_per_sram
 
-    def to_package(self):
-        raise NotImplementedError("to_package method is not implemented yet.")
+    def to_package(self) -> FrameArrayType:
+        frames = OfflineFrameGenV2.gen_config_frame3_weight_pkg(
+            weight=np.array(self.processed_weights),
+            weight_width=self.weight_width,
+            csc_compress=self.compress,
+        )
+        return frames

--- a/paibox/backendv2/weight.py
+++ b/paibox/backendv2/weight.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+N_WEIGHTS_PER_SRAM = {
+    1: 7,
+    2: 7,
+    4: 6,
+    8: 5
+}
+
+class Weight:
+    def __init__(self):
+        self.raw_weights: list[int] = [] # the raw weight 
+        self.weight_width: int = 0 # bit width of each weight
+        self.compress : bool = False # whether the weight is compressed
+        
+        # processed weights remove zero at the end if not compressed
+        self.processed_weights: list[int] = self.raw_weights.copy()
+        # remove zero at the end of raw weights
+        while len(self.processed_weights) > 0 and self.processed_weights[-1] == 0:
+            self.processed_weights.pop()
+    
+    def n_sram_required(self) -> int:
+        if not self.compress:
+            return (len(self.processed_weights) * self.weight_width + 127) // 128
+
+        else:
+            # non zero weight in raw weights
+            n_non_zero = sum(1 for w in self.raw_weights if w != 0)
+            n_weight_per_sram = N_WEIGHTS_PER_SRAM.get(self.weight_width, 0)
+            if n_weight_per_sram == 0:
+                raise ValueError(f"Unsupported weight width for compression: {self.weight_width}")
+            return (n_non_zero + n_weight_per_sram - 1) // n_weight_per_sram
+    
+    def to_package(self):
+        raise NotImplementedError("to_package method is not implemented yet.")

--- a/paibox/backendv2/weight.py
+++ b/paibox/backendv2/weight.py
@@ -5,12 +5,18 @@ from typing import Literal, Union
 import numpy as np
 from paicorelib import (
     FRAME_DTYPE,
+    DataWidth,
     FrameArrayType,
     OfflineFrameGenV2,
     WeightCompressType,
 )
 
-N_WEIGHTS_PER_SRAM = {1: 7, 2: 7, 4: 6, 8: 5}
+N_WEIGHTS_PER_SRAM = {
+    DataWidth.WIDTH_1BIT: 7,
+    DataWidth.WIDTH_2BIT: 7,
+    DataWidth.WIDTH_4BIT: 6,
+    DataWidth.WIDTH_8BIT: 5,
+}
 
 
 class Weight:
@@ -18,15 +24,13 @@ class Weight:
         self,
         data: Union[np.ndarray, list[int]],
         compress_type: WeightCompressType,
-        weight_width: int,
+        weight_width: DataWidth,
     ):
         if isinstance(data, np.ndarray):
             self.raw_weights: list[int] = data.tolist()
         else:
             self.raw_weights: list[int] = list(data)
 
-        if weight_width not in (1, 2, 4, 8):
-            raise ValueError(f"Unsupported weight width: {weight_width}")
         self.weight_width = weight_width
 
         self.compress: bool = (
@@ -41,7 +45,7 @@ class Weight:
 
     def n_sram_required(self) -> int:
         if not self.compress:
-            return (len(self.processed_weights) * self.weight_width + 127) // 128
+            return (len(self.processed_weights) * (2**self.weight_width) + 127) // 128
 
         else:
             # non zero weight in raw weights

--- a/paibox/backendv2/weight.py
+++ b/paibox/backendv2/weight.py
@@ -1,18 +1,32 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal,Union
 
 import numpy as np
-from paicorelib import FRAME_DTYPE, FrameArrayType, OfflineFrameGenV2
+from paicorelib import FRAME_DTYPE, FrameArrayType, OfflineFrameGenV2,WeightCompressType
+
 
 N_WEIGHTS_PER_SRAM = {1: 7, 2: 7, 4: 6, 8: 5}
 
 
 class Weight:
-    def __init__(self):
-        self.raw_weights: list[int] = []  # the raw weight
-        self.weight_width: Literal[1, 2, 4, 8] = 1  # bit width of each weight
-        self.compress: bool = False  # whether the weight is compressed
+    def __init__(
+        self, 
+        data: Union[np.ndarray, list[int]], 
+        compress_type: WeightCompressType, 
+        weight_width: int
+    ):
+        if isinstance(data, np.ndarray):
+            self.raw_weights: list[int] = data.tolist()
+        else:
+            self.raw_weights: list[int] = list(data)
+
+        if weight_width not in (1, 2, 4, 8):
+            raise ValueError(f"Unsupported weight width: {weight_width}")
+        self.weight_width = weight_width
+
+     
+        self.compress: bool = (compress_type == WeightCompressType.SPARSE)  # whether the weight is compressed
 
         # processed weights remove zero at the end if not compressed
         self.processed_weights: list[int] = self.raw_weights.copy()

--- a/paibox/backendv2/weight.py
+++ b/paibox/backendv2/weight.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import Literal, Union
+from typing import Union
 
 import numpy as np
 from paicorelib import (
-    FRAME_DTYPE,
     DataWidth,
     FrameArrayType,
     OfflineFrameGenV2,

--- a/paibox/paiir/ir/calc_params.py
+++ b/paibox/paiir/ir/calc_params.py
@@ -35,7 +35,7 @@ __all__ = [
 ]
 
 
-@dataclass
+@dataclass(frozen=True)
 class LutData:
     """LUT lookup table data for ANN mode offline cores.
 
@@ -46,6 +46,20 @@ class LutData:
     thresholds: Tensor  # shape (256,), bin boundaries
     values: Tensor  # shape (256,), output values
     is_float: bool = False  # True for float32 thresholds / bfloat16 values
+
+    def _tensor_hash(self, t: Tensor) -> int:
+        # detach + cpu 保证可序列化
+        t = t.detach().cpu().contiguous()
+        return hash((tuple(t.shape), str(t.dtype), t.numpy().tobytes()))
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self._tensor_hash(self.thresholds),
+                self._tensor_hash(self.values),
+                self.is_float,
+            )
+        )
 
 
 # Chip register limits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "torch>=2.2.0 ; python_full_version >= '3.12'",
     "spikingjelly>=0.0.0.0.12",
     "tabulate>=0.9.0",
+    "ortools==9.14.6026"
 ]
 
 [tool.uv]

--- a/test.py
+++ b/test.py
@@ -1,0 +1,127 @@
+# import numpy as np
+# from paicorelib import FRAME_DTYPE, FrameArrayType
+
+
+# def export_single_framearray(frame_array: FrameArrayType, file_path: str) -> None:
+#     with open(file_path, "a") as f:
+#         for frame in frame_array:
+#             f.write(f"{frame:016x}\n")
+
+
+# random_array = np.random.randint(0, 2**64, size=10, dtype=FRAME_DTYPE)
+# export_single_framearray(random_array, "output_frames.txt")
+
+
+import pprint
+
+import torch
+from spikingjelly.activation_based import neuron
+from torch import nn
+
+from paibox._logging import DEFAULT_LOG_SETTINGS, set_logs
+from paibox.backendv2.op_node import CoreOpNode, build_nodes
+from paibox.fx_converter.core_op import BaseCoreOp
+from paibox.fx_converter.fuse import apply_passes, fuse_compute_act
+from paibox.fx_converter.trace import (
+    propagate_tensor_shape,
+    remove_dropout_identity_and_fuse_conv_bn,
+)
+
+
+class M(nn.Module):
+    def __init__(self):
+        super().__init__()
+        conv2d_1 = nn.Conv2d(4, 16, 3, bias=False)
+        self.seq = nn.Sequential(conv2d_1, neuron.LIFNode(v_threshold=1.0, tau=2.0))
+        self.conv2 = nn.Conv2d(16, 8, 3)
+        self.if1 = neuron.IFNode(v_threshold=2.0)
+
+    def forward(self, x):
+        x1 = self.seq(x)
+        x2 = self.if1(self.conv2(x1))
+        return x2
+
+
+m = M()
+
+gm = remove_dropout_identity_and_fuse_conv_bn(m)
+gm.graph.print_tabular()
+
+print("Fusing to core op")
+gm = fuse_compute_act(gm)
+gm.graph.print_tabular()
+# print(gm.code)
+propagate_tensor_shape(gm, torch.randn(1, 4, 12, 12))
+
+from paibox.backendv2.mapper import Mapper
+
+mapper = Mapper()
+mapper.compile(gm)
+
+
+# print("\n=== Exported Attributes Inspection ===")
+# for name, module in gm.named_modules():
+#     if isinstance(module, BaseCoreOp):
+#         core_attrs, neu_attrs, comp_attrs = module.get_attrs()
+#         print(f"\n[Node: {name} ({type(module).__name__})]")
+#         print(">> Core Attributes:")
+#         pprint.pprint(core_attrs, indent=2)
+#         print(">> Neuron Attributes:")
+#         pprint.pprint(neu_attrs, indent=2)
+#         print(">> Compute Attributes:")
+#         pprint.pprint(comp_attrs, indent=2)
+
+# succ_graph: dict[BaseCoreOp, list[BaseCoreOp]] = dict()
+# succ_graph_str: dict[str, list[str]] = dict()
+
+# core_op_nodes: dict[str, BaseCoreOp] = dict()
+# core_op_node_shapes: dict[str, torch.Size] = dict()
+# for name, module in gm.named_modules():
+#     print(f"Module: {name}, Type: {type(module).__name__}")
+#     if isinstance(module, BaseCoreOp):
+#         core_op_nodes[name] = module
+
+# print(f"Core Op Nodes: {list(core_op_nodes.keys())}")
+
+# for node in gm.graph.nodes:
+#     node_target = str(node.target)
+#     if node_target in core_op_nodes:
+#         core_op_node_shapes[node_target] = node.meta["tensor_meta"].shape
+
+#         core_op = core_op_nodes[node_target]
+#         succs: list[BaseCoreOp] = []
+#         succs_str: list[str] = []
+#         print(f"\n[Node: {node.name}]")
+#         for succ_node in node.users:
+#             succ_node_target = str(succ_node.target)
+#             if succ_node_target in core_op_nodes:
+#                 succs.append(core_op_nodes[succ_node_target])
+#                 succs_str.append(succ_node_target)
+#         succ_graph[core_op] = succs
+#         succ_graph_str[node_target] = succs_str
+
+# # print("\n=== Core Op Output Shapes ===")
+# # for name, shape in core_op_node_shapes.items():
+# #     print(f"{name}: {shape}")
+
+# # print("\n=== Succession Graph ===")
+# # for name, succs_name in succ_graph_str.items():
+# #     print(f"{name} -> {succs_name}")
+
+# nodes: list[CoreOpNode] = []
+# for name, raw_node in core_op_nodes.items():
+#     shape = core_op_node_shapes[name]
+#     node = CoreOpNode(name, raw_node, shape)
+#     nodes.append(node)
+
+# for node in nodes:
+#     succ_names = succ_graph_str.get(node.name, [])
+#     for succ_name in succ_names:
+#         for succ_node in nodes:
+#             if succ_node.name == succ_name:
+#                 node.successors.append(succ_node)
+#                 succ_node.predecessors.append(node)
+
+# for node in nodes:
+#     print(f"Node {node.name} successors: {[succ.name for succ in node.successors]}")
+#     print(f"Node {node.name} predecessors: {[pred.name for pred in node.predecessors]}")

--- a/test.py
+++ b/test.py
@@ -12,16 +12,11 @@
 # export_single_framearray(random_array, "output_frames.txt")
 
 
-import pprint
-
 import torch
 from spikingjelly.activation_based import neuron
 from torch import nn
 
-from paibox._logging import DEFAULT_LOG_SETTINGS, set_logs
-from paibox.backendv2.op_node import CoreOpNode, build_nodes
-from paibox.fx_converter.core_op import BaseCoreOp
-from paibox.fx_converter.fuse import apply_passes, fuse_compute_act
+from paibox.fx_converter.fuse import fuse_compute_act
 from paibox.fx_converter.trace import (
     propagate_tensor_shape,
     remove_dropout_identity_and_fuse_conv_bn,

--- a/test.py
+++ b/test.py
@@ -13,14 +13,13 @@
 
 
 import torch
-from spikingjelly.activation_based import neuron
-from torch import nn
-
 from paibox.fx_converter.fuse import fuse_compute_act
 from paibox.fx_converter.trace import (
     propagate_tensor_shape,
     remove_dropout_identity_and_fuse_conv_bn,
 )
+from spikingjelly.activation_based import neuron
+from torch import nn
 
 
 class M(nn.Module):

--- a/test_paiir.py
+++ b/test_paiir.py
@@ -18,8 +18,12 @@ class SimpleCNN(nn.Module):
         self.conv1 = nn.Conv2d(1, 1, 3, padding=1)
         self.relu = nn.ReLU()
         self.conv2 = nn.Conv2d(1, 1, 3, padding=1)
-        self.conv1.weight.data = torch.arange(1, 10, dtype=torch.float32).reshape(1, 1, 3, 3)
-        self.conv2.weight.data = torch.arange(10, 19, dtype=torch.float32).reshape(1, 1, 3, 3)
+        self.conv1.weight.data = torch.arange(1, 10, dtype=torch.float32).reshape(
+            1, 1, 3, 3
+        )
+        self.conv2.weight.data = torch.arange(10, 19, dtype=torch.float32).reshape(
+            1, 1, 3, 3
+        )
         print("conv1 weight:", self.conv1.weight)
         print("conv2 weight:", self.conv2.weight)
 

--- a/test_paiir.py
+++ b/test_paiir.py
@@ -1,13 +1,8 @@
-import pytest
 import torch
-from paicorelib import DataSign, DataWidth
-from spikingjelly.activation_based import neuron as sj
 from torch import Tensor, nn
 
 from paibox.backendv2.mapper import Mapper
-from paibox.paiir import CompileConfig, PAIIRGraph, compile_to_paiir
-from paibox.paiir.exceptions import UnsupportedOpError, UnsupportedOpWarning
-from paibox.paiir.op_node import AccumulateOp, ConcatOp, SequentialOp
+from paibox.paiir import compile_to_paiir
 
 
 def make_img_3ch_32x32() -> Tensor:

--- a/test_paiir.py
+++ b/test_paiir.py
@@ -1,0 +1,37 @@
+import pytest
+import torch
+from paicorelib import DataSign, DataWidth
+from spikingjelly.activation_based import neuron as sj
+from torch import Tensor, nn
+
+from paibox.backendv2.mapper import Mapper
+from paibox.paiir import CompileConfig, PAIIRGraph, compile_to_paiir
+from paibox.paiir.exceptions import UnsupportedOpError, UnsupportedOpWarning
+from paibox.paiir.op_node import AccumulateOp, ConcatOp, SequentialOp
+
+
+def make_img_3ch_32x32() -> Tensor:
+    """3-channel 32x32 image, standard larger input."""
+    return torch.randn(1, 3, 10, 10)
+
+
+class SimpleCNN(nn.Module):
+    """Conv-ReLU-Conv: minimal ANN without classifier head."""
+
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 8, 3, padding=1)
+        self.relu = nn.ReLU()
+        self.conv2 = nn.Conv2d(8, 16, 3, padding=1)
+
+    def forward(self, x):
+        x = self.relu(self.conv1(x))
+        return self.conv2(x)
+
+
+graph = compile_to_paiir(SimpleCNN(), make_img_3ch_32x32())
+
+print(graph.summary())
+
+mapper = Mapper()
+mapper.compile(graph)

--- a/test_paiir.py
+++ b/test_paiir.py
@@ -15,9 +15,13 @@ class SimpleCNN(nn.Module):
 
     def __init__(self):
         super().__init__()
-        self.conv1 = nn.Conv2d(3, 8, 3, padding=1)
+        self.conv1 = nn.Conv2d(1, 1, 3, padding=1)
         self.relu = nn.ReLU()
-        self.conv2 = nn.Conv2d(8, 16, 3, padding=1)
+        self.conv2 = nn.Conv2d(1, 1, 3, padding=1)
+        self.conv1.weight.data = torch.arange(1, 10, dtype=torch.float32).reshape(1, 1, 3, 3)
+        self.conv2.weight.data = torch.arange(10, 19, dtype=torch.float32).reshape(1, 1, 3, 3)
+        print("conv1 weight:", self.conv1.weight)
+        print("conv2 weight:", self.conv2.weight)
 
     def forward(self, x):
         x = self.relu(self.conv1(x))

--- a/tests/backendv2/test_routing_v2_allocation.py
+++ b/tests/backendv2/test_routing_v2_allocation.py
@@ -1,0 +1,257 @@
+import pytest
+from unittest.mock import MagicMock, call, patch, PropertyMock
+import numpy as np
+
+from paibox.backendv2.routing import RoutingGroup
+from paibox.backendv2.neuron import NeuronType
+from paicorelib import WeightCompressType
+
+# 模拟导入 (防止环境缺失)
+from paibox.backendv2.weight import Weight
+from paibox.backendv2.neuron import OfflineNeuronPlacement
+from paibox.backendv2.coreplacement import OfflineCorePlamentV2
+from paicorelib import OfflineCoreRegV2
+
+class TestRoutingGroupAllocation:
+
+    @pytest.fixture
+    def mock_deps(self):
+        """Mock external dependencies."""
+        with patch('paibox.backendv2.routing.get_raw_weights') as mock_get_weights, \
+             patch('paibox.backendv2.routing.Weight') as mock_weight_cls, \
+             patch('paibox.backendv2.routing.OfflineNeuronPlacement') as mock_neu_placement_cls, \
+             patch('paibox.backendv2.routing.OfflineCorePlamentV2') as mock_core_placement_cls, \
+             patch('paibox.backendv2.routing.OfflineCoreRegV2') as mock_reg_v2_cls:
+            
+            # [修复 1] 正确模拟 Pydantic 的 model_fields
+            # 让 model_fields 表现为一个字典，这样 .keys() 就能正常工作
+            mock_fields = {
+                'weight_width': MagicMock(), 
+                'snn_ann': MagicMock(), 
+                'neuron_number': MagicMock()
+            }
+            mock_reg_v2_cls.model_fields = mock_fields
+            
+            yield mock_weight_cls, mock_neu_placement_cls, mock_core_placement_cls, mock_reg_v2_cls, mock_get_weights
+
+    def create_mock_neuron(self, weight_width=1, core_config_id=1, config_obj=None):
+        """Helper to create a mock neuron."""
+        neu = MagicMock()
+        attrs = MagicMock()
+        attrs.weight_compress = None 
+        # 默认让 attrs 相等，方便测试 Half 逻辑
+        attrs.__eq__.return_value = True 
+        neu.attrs_part2.return_value = attrs
+        
+        if config_obj:
+            config = config_obj
+        else:
+            config = MagicMock()
+            config.weight_width = weight_width
+            config.snn_ann = 1 
+            config._id = core_config_id 
+            # 默认 Config 比较基于 ID (模拟不同对象)
+            config.__eq__.side_effect = lambda other: config._id == getattr(other, '_id', -1)
+        
+        neu.core_config.return_value = config
+        
+        return neu, attrs, config
+
+    def _setup_core_mock_list_behavior(self, core_mock):
+        """Helper: 让 Core.neus 表现得像一个列表 (支持 append 和 len)"""
+        real_list = []
+        mock_list = MagicMock()
+        mock_list.__len__.side_effect = lambda: len(real_list)
+        mock_list.append.side_effect = lambda x: real_list.append(x)
+        mock_list.__iter__.side_effect = lambda: iter(real_list)
+        # 确保布尔值为 True (只要列表不为空) 或者根据 len 动态判断
+        # MagicMock 默认 bool 可能是 False，这里显式绑定 len
+        core_mock.neus = mock_list
+        return real_list
+
+    def test_allocate_single_neuron_success(self, mock_deps):
+        """Test basic allocation."""
+        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = mock_deps
+        
+        MockGetWeights.return_value = np.zeros((1, 10), dtype=np.int8)
+        
+        rg = RoutingGroup()
+        rg.lcn = 1
+        neu1, attrs1, config1 = self.create_mock_neuron(weight_width=8)
+        
+        rg.raw_neus = [neu1]
+        rg.input_list = [MagicMock()]
+        rg.dests = {neu1: MagicMock(lcn=1)}
+        
+        # Setup Core
+        core_instance = MockCorePlacement.return_value
+        self._setup_core_mock_list_behavior(core_instance) # [修复 3]
+        core_instance.weights = []
+        core_instance.neu_weight_map = {}
+        core_instance.n_sram_required.return_value = 0 
+        
+        # Setup Weight
+        w_dense = MagicMock()
+        w_sparse = MagicMock()
+        w_dense.n_sram_required.return_value = 100
+        w_sparse.n_sram_required.return_value = 200 
+        MockWeight.side_effect = [w_dense, w_sparse]
+        
+        # Setup NeuronPlacement
+        neu_place_instance = MockNeuPlacement.return_value
+        neu_place_instance.n_sram_required.return_value = 50
+        
+        rg.allocate_neurons()
+        
+        assert len(rg.core_placements) == 1
+        assert MockWeight.call_args_list[0][0][2] == 8 
+        assert attrs1.weight_compress == WeightCompressType.DENSE
+        
+        # 验证是否正确提取了 weight_width
+        assert MockRegV2.call_args.kwargs.get('weight_width') == 8
+
+    def test_grouping_logic(self, mock_deps):
+        """Test grouping."""
+        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = mock_deps
+        
+        MockGetWeights.return_value = np.zeros((2, 10), dtype=np.int8)
+        rg = RoutingGroup()
+        rg.lcn = 1
+        
+        # 使用不同的 config ID，确保分为两组
+        neu1, _, cfg1 = self.create_mock_neuron(core_config_id=1)
+        neu2, _, cfg2 = self.create_mock_neuron(core_config_id=2)
+        
+        rg.raw_neus = [neu1, neu2]
+        rg.input_list = [MagicMock()] * 10
+        rg.dests = {
+            neu1: MagicMock(lcn=1),
+            neu2: MagicMock(lcn=1)
+        }
+        
+        # Setup Core & List Behavior
+        core_mock = MockCorePlacement.return_value
+        core_mock.n_sram_required.return_value = 0
+        self._setup_core_mock_list_behavior(core_mock) # [修复 3] 必须模拟列表，否则 len=0 导致不保存
+        
+        # Weight / Placement return values
+        MockWeight.return_value.n_sram_required.return_value = 10
+        MockNeuPlacement.return_value.n_sram_required.return_value = 10
+
+        rg.allocate_neurons()
+        
+        assert len(rg.core_placements) == 2
+        assert MockRegV2.call_count == 2
+
+    def test_overflow_creates_new_core_with_inheritance(self, mock_deps):
+        """Test overflow."""
+        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = mock_deps
+        
+        MockGetWeights.return_value = np.zeros((2, 10), dtype=np.int8)
+        rg = RoutingGroup()
+        rg.lcn = 1
+        
+        # 同一组 (config ID 相同)
+        neu1, _, cfg1 = self.create_mock_neuron(weight_width=4, core_config_id=1)
+        # 显式传入 cfg1 确保对象相等性万无一失
+        neu2, _, _ = self.create_mock_neuron(weight_width=4, config_obj=cfg1)
+        
+        rg.raw_neus = [neu1, neu2]
+        rg.input_list = [MagicMock()]
+        rg.dests = {neu1: MagicMock(lcn=1), neu2: MagicMock(lcn=1)}
+        
+        # Setup Cores
+        core_1 = MagicMock()
+        self._setup_core_mock_list_behavior(core_1)
+        # 第一次检查返回0（放入neu1），第二次检查返回2500（放入neu2前检测），加上neu2导致溢出
+        core_1.n_sram_required.side_effect = [0, 2500] 
+        
+        core_2 = MagicMock()
+        self._setup_core_mock_list_behavior(core_2)
+        core_2.n_sram_required.return_value = 0
+        
+        MockCorePlacement.side_effect = [core_1, core_2]
+        
+        # Weight / Placement
+        MockWeight.return_value.n_sram_required.return_value = 2000
+        
+        np_mock = MagicMock()
+        np_mock.n_sram_required.return_value = 50
+        MockNeuPlacement.return_value = np_mock
+        
+        rg.allocate_neurons()
+        
+        assert len(rg.core_placements) == 2
+        assert rg.core_placements[0] == core_1
+        assert rg.core_placements[1] == core_2
+        # Neu2 溢出到新 Core，必须强制为 FULL
+        assert np_mock.neuron_type == NeuronType.FULL
+
+    def test_half_neuron_optimization(self, mock_deps):
+        """Test Half Neuron assignment."""
+        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = mock_deps
+        
+        MockGetWeights.return_value = np.zeros((2, 10), dtype=np.int8)
+        rg = RoutingGroup()
+        rg.lcn = 1
+        
+        # [修复 2] 关键：必须使用同一个 Config 对象，否则它们会被分到不同组，Half 优化不生效
+        neu1, attrs1, cfg1 = self.create_mock_neuron()
+        neu2, attrs2, _ = self.create_mock_neuron(config_obj=cfg1)
+        
+        # 确保 attrs 相等
+        attrs1.__eq__.return_value = True
+        attrs2.__eq__.return_value = True 
+        
+        rg.raw_neus = [neu1, neu2]
+        rg.dests = {neu1: MagicMock(lcn=1), neu2: MagicMock(lcn=1)}
+        rg.input_list = [MagicMock()]
+        
+        # Setup Core
+        core_mock = MockCorePlacement.return_value
+        core_mock.n_sram_required.return_value = 0
+        self._setup_core_mock_list_behavior(core_mock) # [修复 3]
+        
+        MockWeight.return_value.n_sram_required.return_value = 10
+        
+        # 两个不同的 Placement 实例，用于验证类型
+        p1 = MagicMock()
+        p1.n_sram_required.return_value = 10
+        p2 = MagicMock()
+        p2.n_sram_required.return_value = 10
+        MockNeuPlacement.side_effect = [p1, p2]
+        
+        rg.allocate_neurons()
+        
+        assert p1.neuron_type == NeuronType.FULL
+        assert p2.neuron_type == NeuronType.HALF
+
+    def test_weight_compression_selection(self, mock_deps):
+        """Test optimal weight compression."""
+        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = mock_deps
+        
+        MockGetWeights.return_value = np.zeros((1, 10), dtype=np.int8)
+        rg = RoutingGroup()
+        rg.lcn = 1
+        neu1, attrs1, _ = self.create_mock_neuron(weight_width=2)
+        
+        rg.raw_neus = [neu1]
+        rg.dests = {neu1: MagicMock(lcn=1)}
+        rg.input_list = [MagicMock()]
+        
+        core_mock = MockCorePlacement.return_value
+        core_mock.n_sram_required.return_value = 0
+        self._setup_core_mock_list_behavior(core_mock)
+        
+        MockNeuPlacement.return_value.n_sram_required.return_value = 10
+        
+        w_dense = MagicMock()
+        w_dense.n_sram_required.return_value = 100
+        w_sparse = MagicMock()
+        w_sparse.n_sram_required.return_value = 50 
+        MockWeight.side_effect = [w_dense, w_sparse]
+        
+        rg.allocate_neurons()
+        
+        assert attrs1.weight_compress == WeightCompressType.SPARSE
+        assert MockWeight.call_args_list[0][0][2] == 2

--- a/tests/backendv2/test_routing_v2_allocation.py
+++ b/tests/backendv2/test_routing_v2_allocation.py
@@ -1,60 +1,68 @@
-import pytest
-from unittest.mock import MagicMock, call, patch, PropertyMock
-import numpy as np
+from unittest.mock import MagicMock, PropertyMock, call, patch
 
+import numpy as np
+import pytest
+from paicorelib import OfflineCoreRegV2, WeightCompressType
+
+from paibox.backendv2.coreplacement import OfflineCorePlamentV2
+from paibox.backendv2.neuron import NeuronType, OfflineNeuronPlacement
 from paibox.backendv2.routing import RoutingGroup
-from paibox.backendv2.neuron import NeuronType
-from paicorelib import WeightCompressType
 
 # 模拟导入 (防止环境缺失)
 from paibox.backendv2.weight import Weight
-from paibox.backendv2.neuron import OfflineNeuronPlacement
-from paibox.backendv2.coreplacement import OfflineCorePlamentV2
-from paicorelib import OfflineCoreRegV2
+
 
 class TestRoutingGroupAllocation:
 
     @pytest.fixture
     def mock_deps(self):
         """Mock external dependencies."""
-        with patch('paibox.backendv2.routing.get_raw_weights') as mock_get_weights, \
-             patch('paibox.backendv2.routing.Weight') as mock_weight_cls, \
-             patch('paibox.backendv2.routing.OfflineNeuronPlacement') as mock_neu_placement_cls, \
-             patch('paibox.backendv2.routing.OfflineCorePlamentV2') as mock_core_placement_cls, \
-             patch('paibox.backendv2.routing.OfflineCoreRegV2') as mock_reg_v2_cls:
-            
+        with (
+            patch("paibox.backendv2.routing.get_raw_weights") as mock_get_weights,
+            patch("paibox.backendv2.routing.Weight") as mock_weight_cls,
+            patch(
+                "paibox.backendv2.routing.OfflineNeuronPlacement"
+            ) as mock_neu_placement_cls,
+            patch(
+                "paibox.backendv2.routing.OfflineCorePlamentV2"
+            ) as mock_core_placement_cls,
+            patch("paibox.backendv2.routing.OfflineCoreRegV2") as mock_reg_v2_cls,
+        ):
+
             # [修复 1] 正确模拟 Pydantic 的 model_fields
             # 让 model_fields 表现为一个字典，这样 .keys() 就能正常工作
             mock_fields = {
-                'weight_width': MagicMock(), 
-                'snn_ann': MagicMock(), 
-                'neuron_number': MagicMock()
+                "weight_width": MagicMock(),
+                "snn_ann": MagicMock(),
+                "neuron_number": MagicMock(),
             }
             mock_reg_v2_cls.model_fields = mock_fields
-            
+
             yield mock_weight_cls, mock_neu_placement_cls, mock_core_placement_cls, mock_reg_v2_cls, mock_get_weights
 
     def create_mock_neuron(self, weight_width=1, core_config_id=1, config_obj=None):
         """Helper to create a mock neuron."""
         neu = MagicMock()
         attrs = MagicMock()
-        attrs.weight_compress = None 
+        attrs.weight_compress = None
         # 默认让 attrs 相等，方便测试 Half 逻辑
-        attrs.__eq__.return_value = True 
+        attrs.__eq__.return_value = True
         neu.attrs_part2.return_value = attrs
-        
+
         if config_obj:
             config = config_obj
         else:
             config = MagicMock()
             config.weight_width = weight_width
-            config.snn_ann = 1 
-            config._id = core_config_id 
+            config.snn_ann = 1
+            config._id = core_config_id
             # 默认 Config 比较基于 ID (模拟不同对象)
-            config.__eq__.side_effect = lambda other: config._id == getattr(other, '_id', -1)
-        
+            config.__eq__.side_effect = lambda other: config._id == getattr(
+                other, "_id", -1
+            )
+
         neu.core_config.return_value = config
-        
+
         return neu, attrs, config
 
     def _setup_core_mock_list_behavior(self, core_mock):
@@ -71,116 +79,121 @@ class TestRoutingGroupAllocation:
 
     def test_allocate_single_neuron_success(self, mock_deps):
         """Test basic allocation."""
-        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = mock_deps
-        
+        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = (
+            mock_deps
+        )
+
         MockGetWeights.return_value = np.zeros((1, 10), dtype=np.int8)
-        
+
         rg = RoutingGroup()
         rg.lcn = 1
         neu1, attrs1, config1 = self.create_mock_neuron(weight_width=8)
-        
+
         rg.raw_neus = [neu1]
         rg.input_list = [MagicMock()]
         rg.dests = {neu1: MagicMock(lcn=1)}
-        
+
         # Setup Core
         core_instance = MockCorePlacement.return_value
-        self._setup_core_mock_list_behavior(core_instance) # [修复 3]
+        self._setup_core_mock_list_behavior(core_instance)  # [修复 3]
         core_instance.weights = []
         core_instance.neu_weight_map = {}
-        core_instance.n_sram_required.return_value = 0 
-        
+        core_instance.n_sram_required.return_value = 0
+
         # Setup Weight
         w_dense = MagicMock()
         w_sparse = MagicMock()
         w_dense.n_sram_required.return_value = 100
-        w_sparse.n_sram_required.return_value = 200 
+        w_sparse.n_sram_required.return_value = 200
         MockWeight.side_effect = [w_dense, w_sparse]
-        
+
         # Setup NeuronPlacement
         neu_place_instance = MockNeuPlacement.return_value
         neu_place_instance.n_sram_required.return_value = 50
-        
+
         rg.allocate_neurons()
-        
+
         assert len(rg.core_placements) == 1
-        assert MockWeight.call_args_list[0][0][2] == 8 
+        assert MockWeight.call_args_list[0][0][2] == 8
         assert attrs1.weight_compress == WeightCompressType.DENSE
-        
+
         # 验证是否正确提取了 weight_width
-        assert MockRegV2.call_args.kwargs.get('weight_width') == 8
+        assert MockRegV2.call_args.kwargs.get("weight_width") == 8
 
     def test_grouping_logic(self, mock_deps):
         """Test grouping."""
-        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = mock_deps
-        
+        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = (
+            mock_deps
+        )
+
         MockGetWeights.return_value = np.zeros((2, 10), dtype=np.int8)
         rg = RoutingGroup()
         rg.lcn = 1
-        
+
         # 使用不同的 config ID，确保分为两组
         neu1, _, cfg1 = self.create_mock_neuron(core_config_id=1)
         neu2, _, cfg2 = self.create_mock_neuron(core_config_id=2)
-        
+
         rg.raw_neus = [neu1, neu2]
         rg.input_list = [MagicMock()] * 10
-        rg.dests = {
-            neu1: MagicMock(lcn=1),
-            neu2: MagicMock(lcn=1)
-        }
-        
+        rg.dests = {neu1: MagicMock(lcn=1), neu2: MagicMock(lcn=1)}
+
         # Setup Core & List Behavior
         core_mock = MockCorePlacement.return_value
         core_mock.n_sram_required.return_value = 0
-        self._setup_core_mock_list_behavior(core_mock) # [修复 3] 必须模拟列表，否则 len=0 导致不保存
-        
+        self._setup_core_mock_list_behavior(
+            core_mock
+        )  # [修复 3] 必须模拟列表，否则 len=0 导致不保存
+
         # Weight / Placement return values
         MockWeight.return_value.n_sram_required.return_value = 10
         MockNeuPlacement.return_value.n_sram_required.return_value = 10
 
         rg.allocate_neurons()
-        
+
         assert len(rg.core_placements) == 2
         assert MockRegV2.call_count == 2
 
     def test_overflow_creates_new_core_with_inheritance(self, mock_deps):
         """Test overflow."""
-        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = mock_deps
-        
+        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = (
+            mock_deps
+        )
+
         MockGetWeights.return_value = np.zeros((2, 10), dtype=np.int8)
         rg = RoutingGroup()
         rg.lcn = 1
-        
+
         # 同一组 (config ID 相同)
         neu1, _, cfg1 = self.create_mock_neuron(weight_width=4, core_config_id=1)
         # 显式传入 cfg1 确保对象相等性万无一失
         neu2, _, _ = self.create_mock_neuron(weight_width=4, config_obj=cfg1)
-        
+
         rg.raw_neus = [neu1, neu2]
         rg.input_list = [MagicMock()]
         rg.dests = {neu1: MagicMock(lcn=1), neu2: MagicMock(lcn=1)}
-        
+
         # Setup Cores
         core_1 = MagicMock()
         self._setup_core_mock_list_behavior(core_1)
         # 第一次检查返回0（放入neu1），第二次检查返回2500（放入neu2前检测），加上neu2导致溢出
-        core_1.n_sram_required.side_effect = [0, 2500] 
-        
+        core_1.n_sram_required.side_effect = [0, 2500]
+
         core_2 = MagicMock()
         self._setup_core_mock_list_behavior(core_2)
         core_2.n_sram_required.return_value = 0
-        
+
         MockCorePlacement.side_effect = [core_1, core_2]
-        
+
         # Weight / Placement
         MockWeight.return_value.n_sram_required.return_value = 2000
-        
+
         np_mock = MagicMock()
         np_mock.n_sram_required.return_value = 50
         MockNeuPlacement.return_value = np_mock
-        
+
         rg.allocate_neurons()
-        
+
         assert len(rg.core_placements) == 2
         assert rg.core_placements[0] == core_1
         assert rg.core_placements[1] == core_2
@@ -189,69 +202,73 @@ class TestRoutingGroupAllocation:
 
     def test_half_neuron_optimization(self, mock_deps):
         """Test Half Neuron assignment."""
-        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = mock_deps
-        
+        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = (
+            mock_deps
+        )
+
         MockGetWeights.return_value = np.zeros((2, 10), dtype=np.int8)
         rg = RoutingGroup()
         rg.lcn = 1
-        
+
         # [修复 2] 关键：必须使用同一个 Config 对象，否则它们会被分到不同组，Half 优化不生效
         neu1, attrs1, cfg1 = self.create_mock_neuron()
         neu2, attrs2, _ = self.create_mock_neuron(config_obj=cfg1)
-        
+
         # 确保 attrs 相等
         attrs1.__eq__.return_value = True
-        attrs2.__eq__.return_value = True 
-        
+        attrs2.__eq__.return_value = True
+
         rg.raw_neus = [neu1, neu2]
         rg.dests = {neu1: MagicMock(lcn=1), neu2: MagicMock(lcn=1)}
         rg.input_list = [MagicMock()]
-        
+
         # Setup Core
         core_mock = MockCorePlacement.return_value
         core_mock.n_sram_required.return_value = 0
-        self._setup_core_mock_list_behavior(core_mock) # [修复 3]
-        
+        self._setup_core_mock_list_behavior(core_mock)  # [修复 3]
+
         MockWeight.return_value.n_sram_required.return_value = 10
-        
+
         # 两个不同的 Placement 实例，用于验证类型
         p1 = MagicMock()
         p1.n_sram_required.return_value = 10
         p2 = MagicMock()
         p2.n_sram_required.return_value = 10
         MockNeuPlacement.side_effect = [p1, p2]
-        
+
         rg.allocate_neurons()
-        
+
         assert p1.neuron_type == NeuronType.FULL
         assert p2.neuron_type == NeuronType.HALF
 
     def test_weight_compression_selection(self, mock_deps):
         """Test optimal weight compression."""
-        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = mock_deps
-        
+        MockWeight, MockNeuPlacement, MockCorePlacement, MockRegV2, MockGetWeights = (
+            mock_deps
+        )
+
         MockGetWeights.return_value = np.zeros((1, 10), dtype=np.int8)
         rg = RoutingGroup()
         rg.lcn = 1
         neu1, attrs1, _ = self.create_mock_neuron(weight_width=2)
-        
+
         rg.raw_neus = [neu1]
         rg.dests = {neu1: MagicMock(lcn=1)}
         rg.input_list = [MagicMock()]
-        
+
         core_mock = MockCorePlacement.return_value
         core_mock.n_sram_required.return_value = 0
         self._setup_core_mock_list_behavior(core_mock)
-        
+
         MockNeuPlacement.return_value.n_sram_required.return_value = 10
-        
+
         w_dense = MagicMock()
         w_dense.n_sram_required.return_value = 100
         w_sparse = MagicMock()
-        w_sparse.n_sram_required.return_value = 50 
+        w_sparse.n_sram_required.return_value = 50
         MockWeight.side_effect = [w_dense, w_sparse]
-        
+
         rg.allocate_neurons()
-        
+
         assert attrs1.weight_compress == WeightCompressType.SPARSE
         assert MockWeight.call_args_list[0][0][2] == 2

--- a/tests/backendv2/test_routing_v2_allocation.py
+++ b/tests/backendv2/test_routing_v2_allocation.py
@@ -1,19 +1,16 @@
-from unittest.mock import MagicMock, PropertyMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-from paicorelib import OfflineCoreRegV2, WeightCompressType
+from paicorelib import WeightCompressType
 
-from paibox.backendv2.coreplacement import OfflineCorePlamentV2
-from paibox.backendv2.neuron import NeuronType, OfflineNeuronPlacement
+from paibox.backendv2.neuron import NeuronType
 from paibox.backendv2.routing import RoutingGroup
 
 # 模拟导入 (防止环境缺失)
-from paibox.backendv2.weight import Weight
 
 
 class TestRoutingGroupAllocation:
-
     @pytest.fixture
     def mock_deps(self):
         """Mock external dependencies."""
@@ -28,7 +25,6 @@ class TestRoutingGroupAllocation:
             ) as mock_core_placement_cls,
             patch("paibox.backendv2.routing.OfflineCoreRegV2") as mock_reg_v2_cls,
         ):
-
             # [修复 1] 正确模拟 Pydantic 的 model_fields
             # 让 model_fields 表现为一个字典，这样 .keys() 就能正常工作
             mock_fields = {
@@ -38,7 +34,13 @@ class TestRoutingGroupAllocation:
             }
             mock_reg_v2_cls.model_fields = mock_fields
 
-            yield mock_weight_cls, mock_neu_placement_cls, mock_core_placement_cls, mock_reg_v2_cls, mock_get_weights
+            yield (
+                mock_weight_cls,
+                mock_neu_placement_cls,
+                mock_core_placement_cls,
+                mock_reg_v2_cls,
+                mock_get_weights,
+            )
 
     def create_mock_neuron(self, weight_width=1, core_config_id=1, config_obj=None):
         """Helper to create a mock neuron."""

--- a/tests/backendv2/test_routing_v2_raw_weights.py
+++ b/tests/backendv2/test_routing_v2_raw_weights.py
@@ -1,0 +1,155 @@
+import numpy as np
+import paicorelib
+import torch
+from torch import nn
+
+for name, value in {
+    "LUT_ACTIVATION_DTYPE": np.int8,
+    "LUT_POTENTIAL_DTYPE": np.int8,
+    "LUTActivationType": np.ndarray,
+    "LUTPotentialType": np.ndarray,
+}.items():
+    if not hasattr(paicorelib, name):
+        setattr(paicorelib, name, value)
+
+from paibox.backendv2.neuron import InputElem, Neuron
+from paibox.backendv2.op_node import CoreOpNode, CustomIndex, InNode
+from paibox.backendv2.routing import get_raw_weights
+from paibox.paiir import (
+    ANNNodeV25,
+    AccumulateOp,
+    LutReLU,
+    StandaloneActOp,
+    StandaloneCompOp,
+)
+
+
+def _configure_raw_node(raw_node):
+    raw_node.core_params.tick_start = 1
+    raw_node.core_params.tick_duration = 0
+    raw_node.core_params.tick_initial = 1
+    return raw_node
+
+
+def _input_elems(node: InNode) -> list[InputElem]:
+    return [InputElem(node, CustomIndex(i)) for i in range(node.shape.numel())]
+
+
+def _neurons(node: CoreOpNode) -> list[Neuron]:
+    return [Neuron(node, CustomIndex(i)) for i in range(node.shape.numel())]
+
+
+def test_get_raw_weights_linear_with_unconnected_inputs():
+    source = InNode("src", (1, 4))
+    unrelated = InNode("other", (1, 2))
+
+    linear = _configure_raw_node(StandaloneCompOp(nn.Linear(4, 3, bias=False)))
+    with torch.no_grad():
+        linear.comp.weight.copy_(
+            torch.tensor(
+                [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+                dtype=torch.float32,
+            )
+        )
+
+    linear.output_shape = (1, 3)
+    target = CoreOpNode("linear", linear, linear.output_shape)
+    target.predecessors = [source]
+
+    weights = get_raw_weights(_neurons(target), _input_elems(source) + _input_elems(unrelated))
+
+    expected = np.array(
+        [
+            [1, 2, 3, 4, 0, 0],
+            [5, 6, 7, 8, 0, 0],
+            [9, 10, 11, 12, 0, 0],
+        ],
+        dtype=np.int32,
+    )
+    np.testing.assert_array_equal(weights, expected)
+
+
+def test_get_raw_weights_conv2d():
+    source = InNode("img", (1, 1, 3, 3))
+
+    conv = _configure_raw_node(StandaloneCompOp(nn.Conv2d(1, 1, 2, bias=False)))
+    with torch.no_grad():
+        conv.comp.weight.copy_(torch.tensor([[[[1, 2], [3, 4]]]], dtype=torch.float32))
+
+    conv.output_shape = (1, 1, 2, 2)
+    target = CoreOpNode("conv", conv, conv.output_shape)
+    target.predecessors = [source]
+
+    weights = get_raw_weights(_neurons(target), _input_elems(source))
+
+    expected = np.array(
+        [
+            [1, 2, 0, 3, 4, 0, 0, 0, 0],
+            [0, 1, 2, 0, 3, 4, 0, 0, 0],
+            [0, 0, 0, 1, 2, 0, 3, 4, 0],
+            [0, 0, 0, 0, 1, 2, 0, 3, 4],
+        ],
+        dtype=np.int32,
+    )
+    np.testing.assert_array_equal(weights, expected)
+
+
+def test_get_raw_weights_pool2d():
+    source = InNode("pool_src", (1, 1, 3, 3))
+
+    pool = _configure_raw_node(StandaloneCompOp(nn.AvgPool2d(2, stride=1)))
+    pool.output_shape = (1, 1, 2, 2)
+    target = CoreOpNode("pool", pool, pool.output_shape)
+    target.predecessors = [source]
+
+    weights = get_raw_weights(_neurons(target), _input_elems(source))
+
+    expected = np.array(
+        [
+            [1, 1, 0, 1, 1, 0, 0, 0, 0],
+            [0, 1, 1, 0, 1, 1, 0, 0, 0],
+            [0, 0, 0, 1, 1, 0, 1, 1, 0],
+            [0, 0, 0, 0, 1, 1, 0, 1, 1],
+        ],
+        dtype=np.int32,
+    )
+    np.testing.assert_array_equal(weights, expected)
+
+
+def test_get_raw_weights_standalone_activation_identity():
+    source = InNode("act_src", (1, 4))
+
+    act = _configure_raw_node(StandaloneActOp(ANNNodeV25(lut=LutReLU())))
+    act.output_shape = (1, 4)
+    target = CoreOpNode("act", act, act.output_shape)
+    target.predecessors = [source]
+
+    weights = get_raw_weights(_neurons(target), _input_elems(source))
+
+    np.testing.assert_array_equal(weights, np.eye(4, dtype=np.int32))
+
+
+def test_get_raw_weights_accumulate_respects_negative_branch_sign():
+    source_a = InNode("a", (1, 2))
+    source_b = InNode("b", (1, 2))
+
+    acc = _configure_raw_node(
+        AccumulateOp(
+            comps=[nn.Linear(2, 2, bias=False), nn.Linear(2, 2, bias=False)],
+            act=ANNNodeV25(lut=LutReLU()),
+            op_signs=(1, -1),
+        )
+    )
+    with torch.no_grad():
+        acc.comps[0].weight.copy_(torch.tensor([[1, 2], [3, 4]], dtype=torch.float32))
+        acc.comps[1].weight.copy_(torch.tensor([[5, 6], [7, 8]], dtype=torch.float32))
+
+    acc.output_shape = (1, 2)
+    target = CoreOpNode("acc", acc, acc.output_shape)
+    target.predecessors = [source_a, source_b]
+
+    input_elems = _input_elems(source_a) + _input_elems(source_b)
+    weights = get_raw_weights(_neurons(target), input_elems)
+
+    expected = np.array([[1, 2, -5, -6], [3, 4, -7, -8]], dtype=np.int32)
+    np.testing.assert_array_equal(weights, expected)

--- a/tests/backendv2/test_routing_v2_raw_weights.py
+++ b/tests/backendv2/test_routing_v2_raw_weights.py
@@ -16,8 +16,8 @@ from paibox.backendv2.neuron import InputElem, Neuron
 from paibox.backendv2.op_node import CoreOpNode, CustomIndex, InNode
 from paibox.backendv2.routing import get_raw_weights
 from paibox.paiir import (
-    ANNNodeV25,
     AccumulateOp,
+    ANNNodeV25,
     LutReLU,
     StandaloneActOp,
     StandaloneCompOp,
@@ -56,7 +56,9 @@ def test_get_raw_weights_linear_with_unconnected_inputs():
     target = CoreOpNode("linear", linear, linear.output_shape)
     target.predecessors = [source]
 
-    weights = get_raw_weights(_neurons(target), _input_elems(source) + _input_elems(unrelated))
+    weights = get_raw_weights(
+        _neurons(target), _input_elems(source) + _input_elems(unrelated)
+    )
 
     expected = np.array(
         [


### PR DESCRIPTION
## Summary

This PR introduces the first end-to-end `backendv2` pipeline on top of `PAIIRGraph`, covering:

- node adaptation from `PAIIRGraph` to backend-specific structures
- routing-group construction and topological routing
- offline core placement and SRAM-aware neuron/weight allocation
- frame export for hardware deployment
- raw-weight extraction for `Linear` / `Conv2d` / `Pool` paths

## Main Changes

- Add `paibox/backendv2/` core modules:
  - `op_node.py`: convert `PAIIRGraph` nodes into backendv2 input/core-op nodes
  - `routing.py`: build path-level weight matrices, routing-group logic, destination assignment, and allocation flow
  - `coreplacement.py`: offline core placement, weight address assignment, and frame packaging
  - `route_solver.py`: route solving
  - `mapper.py`: end-to-end backendv2 compile/export entry
  - `core_config.py`, `neuron.py`, `weight.py`, `rg_build.py`: backend config, neuron packaging, weight packaging, and routing-group helpers

- Switch backendv2 graph input from legacy graph-module assumptions to `PAIIRGraph`
  - backendv2 now consumes `InputNode` / `OfflineCoreOp` / `OutputNode`-style IR structure
  - align frontend core config generation with `PAIIR` offline-core params and LUT data

- Implement raw weight expansion support for backend routing
  - support dense matrix extraction for `Linear`
  - support unfolded dense connectivity for `Conv2d`
  - support implicit connectivity matrix generation for pooling ops
  - support signed path composition for accumulate/subtract-style inputs

- Add export support
  - export frame text files
  - export C header files for frame arrays

- Add tests for backendv2 behavior
  - routing-group allocation behavior
  - raw-weight extraction for linear / conv / pool / standalone act / accumulate cases

- Make `LutData` hashable/frozen in `PAIIR` calc params so backend-side config objects can participate in stable comparison/grouping