### PR TITLE
Feat(backendv2): enable weight skew based weight reuse

### DIFF
--- a/paibox/backendv2/core_config.py
+++ b/paibox/backendv2/core_config.py
@@ -46,11 +46,11 @@ class Backend_Core_Config:
     lcn: LCN_EX = LCN_EX.LCN_1X
     target_lcn: LCN_EX = LCN_EX.LCN_1X
     axon_skew: int = 0
-    add_potential: AddPotentialMode = AddPotentialMode.NORMAL
 
 
 @dataclass(frozen=True)
 class Frontend_Core_Config:
+    add_potential: AddPotentialMode = AddPotentialMode.NORMAL
     snn_ann: SNNMode = SNNMode.SNN
     max_pooling: PoolingMode = PoolingMode.AVERAGE
     zero_output: ZeroOutputMode = ZeroOutputMode.DISABLE
@@ -77,7 +77,7 @@ def to_core_reg(
         name=f"core_reg_at_({coord.x},{coord.y})",
         snn_ann=frontend_conf.snn_ann,
         max_pooling=frontend_conf.max_pooling,
-        add_potential=backend_conf.add_potential,
+        add_potential=frontend_conf.add_potential,
         zero_output=frontend_conf.zero_output,
         input_sign=frontend_conf.input_sign,
         input_width=frontend_conf.input_width,

--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -79,6 +79,18 @@ class CorePlacement:
     def set_auto_core_config(self) -> None:
         pass
 
+    @abstractmethod
+    def n_sram_required(self) -> int:
+        pass
+
+    @abstractmethod
+    def neuron_sram_required(self) -> int:
+        pass
+
+    @abstractmethod
+    def weight_sram_required(self) -> int:
+        pass
+
 
 class OfflineCorePlacementV2(CorePlacement):
     def __init__(
@@ -97,6 +109,18 @@ class OfflineCorePlacementV2(CorePlacement):
         n_sram = 0
         for neu in self.neus:
             n_sram += neu.n_sram_required()
+        for weight in self.weights:
+            n_sram += weight.n_sram_required()
+        return n_sram
+
+    def neuron_sram_required(self) -> int:
+        n_sram = 0
+        for neu in self.neus:
+            n_sram += neu.n_sram_required()
+        return n_sram
+
+    def weight_sram_required(self) -> int:
+        n_sram = 0
         for weight in self.weights:
             n_sram += weight.n_sram_required()
         return n_sram

--- a/paibox/backendv2/get_weight.py
+++ b/paibox/backendv2/get_weight.py
@@ -1,0 +1,715 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import numpy as np
+import torch
+from paicorelib import (
+    AddPotentialMode,
+    DataWidth,
+    WeightCompressType,
+)
+from rich.progress import track
+from torch import Tensor, nn
+from torch.nn import functional as F
+
+from ..paiir import (
+    AccumulateOp,
+    PotentialAddOp,
+    SequentialOp,
+    StandaloneActOp,
+    StandaloneCompOp,
+)
+from .op_node import (
+    CoreOpNode,
+    Neuron,
+    SourceElem,
+    SourceNode,
+)
+from .weight import Weight
+
+
+def feature_shape(shape: torch.Size | tuple[int, ...]) -> tuple[int, ...]:
+    # Backend weight extraction works on feature dimensions only.
+    # The leading batch dimension is stripped and must stay equal to 1.
+    feature_shape = tuple(shape)
+    if len(feature_shape) > 1:
+        batch = feature_shape[0]
+        if batch != 1:
+            raise NotImplementedError(
+                f"Only batch size 1 is supported, but got shape {feature_shape}."
+            )
+        feature_shape = feature_shape[1:]
+
+    return feature_shape
+
+
+def to_nd_tuple(value: int | tuple[int, ...], ndim: int) -> tuple[int, ...]:
+    if isinstance(value, tuple):
+        if len(value) != ndim:
+            raise ValueError(f"Expected a tuple of length {ndim}, but got {value}.")
+        return value
+
+    return (value,) * ndim
+
+
+def ensure_target_components(target: CoreOpNode) -> None:
+    # Lazily reconstruct per-predecessor comps/weights so routing can
+    # query them even if node initialization did not populate them yet.
+    if not target.predecessors:
+        return
+
+    if len(target.comps) == len(target.predecessors) and len(target.weights) == len(
+        target.predecessors
+    ):
+        return
+
+    raw_node = target.raw_node
+    if isinstance(raw_node, SequentialOp):
+        target.comps = [raw_node.comp]
+    elif isinstance(raw_node, AccumulateOp):
+        target.comps = list(raw_node.comps)
+    elif isinstance(raw_node, StandaloneCompOp):
+        target.comps = [raw_node.comp]
+    elif isinstance(raw_node, StandaloneActOp):
+        target.comps = [None]
+    elif isinstance(raw_node, PotentialAddOp):
+        target.comps = [None] * len(raw_node.signs)
+    else:
+        raise NotImplementedError(f"Unsupported node type: {type(raw_node)}")
+
+    raw_weights = raw_node.weights
+    if raw_weights is None:
+        target.weights = [None] * len(target.comps)
+    else:
+        target.weights = list(raw_weights)
+
+
+def path_signs(target: CoreOpNode) -> list[int]:
+    # Accumulate/Add nodes may encode subtraction through per-path signs.
+    raw_node = target.raw_node
+    if isinstance(raw_node, (AccumulateOp, PotentialAddOp)):
+        return list(raw_node.signs)
+
+    return [1] * len(target.predecessors)
+
+
+def direct_weight_matrix(
+    weight: Tensor,
+    input_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+    sign: int,
+) -> np.ndarray:
+    # Linear/identity-like paths already expose a dense [out, in] matrix.
+    matrix = np.asarray(weight.detach().cpu(), dtype=np.int32)
+    n_input = int(np.prod(input_shape))
+    n_output = int(np.prod(output_shape))
+
+    if matrix.shape != (n_output, n_input):
+        raise ValueError(
+            f"Direct weight shape mismatch: expected {(n_output, n_input)}, got {matrix.shape}."
+        )
+
+    if sign != 1:
+        matrix = sign * matrix
+
+    return matrix
+
+
+def identity_weight_matrix(
+    input_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+    sign: int,
+) -> np.ndarray:
+    # Activation-only / add-only paths do not own raw parameter tensors, but
+    # backend routing still needs their implicit identity connectivity.
+    n_input = int(np.prod(input_shape))
+    n_output = int(np.prod(output_shape))
+    if n_input != n_output:
+        raise ValueError(
+            f"Identity path shape mismatch: input has {n_input} elems, output has {n_output}."
+        )
+
+    matrix = np.eye(n_output, dtype=np.int32)
+    if sign != 1:
+        matrix *= sign
+
+    return matrix
+
+
+def unfold_input_indices_2d(
+    channels: int,
+    spatial_shape: tuple[int, int],
+    kernel_size: tuple[int, int],
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+) -> torch.Tensor:
+    # Build a lookup table from each sliding-window position back to the
+    # flattened input indices. Zero means "came from padding".
+    height, width = spatial_shape
+    n_input = channels * height * width
+    input_ids = torch.arange(1, n_input + 1, dtype=torch.float64).reshape(
+        1, channels, height, width
+    )
+    patches = F.unfold(
+        input_ids,
+        kernel_size=kernel_size,
+        dilation=dilation,
+        padding=padding,
+        stride=stride,
+    )
+    return patches.to(torch.int64).squeeze(0)
+
+
+def conv2d_weight_matrix(
+    weight: Tensor,
+    input_shape: tuple[int, int, int],
+    output_shape: tuple[int, int, int],
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+    groups: int,
+    sign: int,
+) -> np.ndarray:
+    # Expand a Conv2d kernel into a full dense matrix with shape [out, in],
+    # where rows are flattened output neurons and columns are flattened inputs.
+    in_channels, height, width = input_shape
+    out_channels, out_height, out_width = output_shape
+    kernel = np.asarray(weight.detach().cpu(), dtype=np.int32)
+    _, in_channels_per_group, kernel_height, kernel_width = kernel.shape
+
+    if in_channels != in_channels_per_group * groups:
+        raise ValueError(
+            f"Conv groups mismatch: input channels {in_channels}, kernel channels {in_channels_per_group}, groups {groups}."
+        )
+
+    out_channels_per_group = out_channels // groups
+    out_size = out_height * out_width
+    n_input = in_channels * height * width
+    matrix = np.zeros((out_channels * out_size, n_input), dtype=np.int32)
+
+    patches = (
+        unfold_input_indices_2d(
+            in_channels,
+            (height, width),
+            (kernel_height, kernel_width),
+            stride,
+            padding,
+            dilation,
+        )
+        .cpu()
+        .numpy()
+    )
+
+    if patches.shape[1] != out_size:
+        raise ValueError(
+            f"Conv unfold mismatch: expected {out_size} output positions, got {patches.shape[1]}."
+        )
+
+    row_offsets = np.tile(
+        np.arange(out_size, dtype=np.int64),
+        in_channels_per_group * kernel_height * kernel_width,
+    )
+
+    for out_channel in range(out_channels):
+        group_idx = out_channel // out_channels_per_group
+        patch_start = group_idx * in_channels_per_group * kernel_height * kernel_width
+        patch_end = patch_start + in_channels_per_group * kernel_height * kernel_width
+
+        # Scatter each kernel coefficient to the input positions that feed the
+        # corresponding flattened output locations.
+        flat_cols = patches[patch_start:patch_end].reshape(-1)
+        valid = flat_cols > 0
+        flat_rows = row_offsets[valid]
+        flat_values = np.repeat(kernel[out_channel].reshape(-1), out_size)[valid]
+        matrix[out_channel * out_size + flat_rows, flat_cols[valid] - 1] = flat_values
+
+    if sign != 1:
+        matrix *= sign
+
+    return matrix
+
+
+def pool2d_weight_matrix(
+    channels: int,
+    input_shape: tuple[int, int, int],
+    output_shape: tuple[int, int, int],
+    kernel_size: tuple[int, int],
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+    sign: int,
+) -> np.ndarray:
+    # Pooling has no explicit weight tensor, but connectivity still forms a
+    # dense [out, in] matrix. Every valid input in the pooling window gets 1.
+    in_channels, height, width = input_shape
+    out_channels, out_height, out_width = output_shape
+    if in_channels != channels or out_channels != channels:
+        raise ValueError(
+            f"Pooling channel mismatch: input={in_channels}, output={out_channels}, channels={channels}."
+        )
+
+    out_size = out_height * out_width
+    n_input = in_channels * height * width
+    matrix = np.zeros((out_channels * out_size, n_input), dtype=np.int32)
+
+    patches = (
+        unfold_input_indices_2d(
+            in_channels,
+            (height, width),
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+        )
+        .cpu()
+        .numpy()
+    )
+
+    if patches.shape[1] != out_size:
+        raise ValueError(
+            f"Pooling unfold mismatch: expected {out_size} output positions, got {patches.shape[1]}."
+        )
+
+    kernel_elems = int(np.prod(kernel_size))
+    row_offsets = np.tile(np.arange(out_size, dtype=np.int64), kernel_elems)
+
+    for channel in range(channels):
+        patch_start = channel * kernel_elems
+        patch_end = patch_start + kernel_elems
+
+        flat_cols = patches[patch_start:patch_end].reshape(-1)
+        valid = flat_cols > 0
+        matrix[channel * out_size + row_offsets[valid], flat_cols[valid] - 1] = sign
+
+    return matrix
+
+
+def conv1d_weight_matrix(
+    weight: Tensor,
+    input_shape: tuple[int, int],
+    output_shape: tuple[int, int],
+    stride: tuple[int],
+    padding: tuple[int],
+    dilation: tuple[int],
+    groups: int,
+    sign: int,
+) -> np.ndarray:
+    # Reuse the 2D expansion path by treating 1D signals as H=1 feature maps.
+    in_channels, in_length = input_shape
+    out_channels, out_length = output_shape
+    kernel = weight.reshape(weight.shape[0], weight.shape[1], 1, weight.shape[2])
+    return conv2d_weight_matrix(
+        kernel,
+        (in_channels, 1, in_length),
+        (out_channels, 1, out_length),
+        (1, stride[0]),
+        (0, padding[0]),
+        (1, dilation[0]),
+        groups,
+        sign,
+    )
+
+
+def pool1d_weight_matrix(
+    channels: int,
+    input_shape: tuple[int, int],
+    output_shape: tuple[int, int],
+    kernel_size: tuple[int],
+    stride: tuple[int],
+    padding: tuple[int],
+    dilation: tuple[int],
+    sign: int,
+) -> np.ndarray:
+    # Reuse the 2D pooling expansion path by treating 1D signals as H=1 maps.
+    in_channels, in_length = input_shape
+    out_channels, out_length = output_shape
+    return pool2d_weight_matrix(
+        channels,
+        (in_channels, 1, in_length),
+        (out_channels, 1, out_length),
+        (1, kernel_size[0]),
+        (1, stride[0]),
+        (0, padding[0]),
+        (1, dilation[0]),
+        sign,
+    )
+
+
+def expanded_path_weight_matrix(
+    predecessor: SourceNode,
+    target: CoreOpNode,
+    comp: Optional[nn.Module],
+    weight: Optional[Tensor],
+    sign: int,
+) -> np.ndarray:
+    # Convert one predecessor path into a dense [out, in] matrix, choosing
+    # the correct expansion strategy from the comp type.
+    input_shape = feature_shape(predecessor.shape)
+    output_shape = feature_shape(target.shape)
+
+    if comp is None:
+        return identity_weight_matrix(input_shape, output_shape, sign)
+
+    if weight is not None and (isinstance(comp, nn.Linear) or weight.ndim == 2):
+        return direct_weight_matrix(weight, input_shape, output_shape, sign)
+
+    if isinstance(comp, nn.Conv1d):
+        assert weight is not None
+        return conv1d_weight_matrix(
+            weight,
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.stride, 1),
+            to_nd_tuple(comp.padding, 1),
+            to_nd_tuple(comp.dilation, 1),
+            comp.groups,
+            sign,
+        )
+
+    if isinstance(comp, nn.Conv2d):
+        print(
+            f"Expanding Conv2d weight from {input_shape} to {output_shape} with stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}, groups={comp.groups}."
+        )
+        return conv2d_weight_matrix(
+            weight,
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.stride, 2),
+            to_nd_tuple(comp.padding, 2),
+            to_nd_tuple(comp.dilation, 2),
+            comp.groups,
+            sign,
+        )
+
+    if isinstance(comp, nn.MaxPool1d):
+        if comp.ceil_mode:
+            raise NotImplementedError("MaxPool1d with ceil_mode=True is not supported.")
+
+        return pool1d_weight_matrix(
+            input_shape[0],
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.kernel_size, 1),
+            to_nd_tuple(comp.stride or comp.kernel_size, 1),
+            to_nd_tuple(comp.padding, 1),
+            to_nd_tuple(comp.dilation, 1),
+            sign,
+        )
+
+    if isinstance(comp, nn.AvgPool1d):
+        if comp.ceil_mode:
+            raise NotImplementedError("AvgPool1d with ceil_mode=True is not supported.")
+
+        return pool1d_weight_matrix(
+            input_shape[0],
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.kernel_size, 1),
+            to_nd_tuple(comp.stride or comp.kernel_size, 1),
+            to_nd_tuple(comp.padding, 1),
+            (1,),
+            sign,
+        )
+
+    if isinstance(comp, nn.MaxPool2d):
+        if comp.ceil_mode:
+            raise NotImplementedError("MaxPool2d with ceil_mode=True is not supported.")
+
+        return pool2d_weight_matrix(
+            input_shape[0],
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.kernel_size, 2),
+            to_nd_tuple(comp.stride or comp.kernel_size, 2),
+            to_nd_tuple(comp.padding, 2),
+            to_nd_tuple(comp.dilation, 2),
+            sign,
+        )
+
+    if isinstance(comp, nn.AvgPool2d):
+        if comp.ceil_mode:
+            raise NotImplementedError("AvgPool2d with ceil_mode=True is not supported.")
+
+        return pool2d_weight_matrix(
+            input_shape[0],
+            input_shape,
+            output_shape,
+            to_nd_tuple(comp.kernel_size, 2),
+            to_nd_tuple(comp.stride or comp.kernel_size, 2),
+            to_nd_tuple(comp.padding, 2),
+            (1, 1),
+            sign,
+        )
+
+    raise NotImplementedError(
+        f"Unsupported weight expansion for comp {type(comp)} with weight {type(weight)}."
+    )
+
+
+def build_weights(
+    raw_neus: list[Neuron],
+    input_neus: list[SourceElem],
+    target_cache: dict[CoreOpNode, dict[SourceNode, np.ndarray]],
+    weights: np.ndarray,
+) -> None:
+    """
+    根据 raw_neus 和 input_neus，从 target_cache 中提取权重矩阵，填充到 weights。
+
+    参数：
+        raw_neus: List[Neuron]
+        input_neus: List[Neuron]
+        target_cache: Dict[target -> Dict[target -> np.ndarray]]
+        weights: np.ndarray (shape: [len(raw_neus), len(input_neus)])
+    """
+    input_group = defaultdict(list)
+
+    for j, elem in enumerate(input_neus):
+        input_group[elem.target].append((j, elem.index.idx))
+
+    input_map = {}
+
+    for tgt, elems in input_group.items():
+        js = np.fromiter((j for j, _ in elems), dtype=np.int64)
+        idxs = np.fromiter((idx for _, idx in elems), dtype=np.int64)
+        input_map[tgt] = (js, idxs)
+
+    for i, neu in enumerate(raw_neus):
+        path_matrices = target_cache.get(neu.target)
+        if path_matrices is None:
+            continue
+
+        neu_idx = neu.index.idx
+
+        for tgt, (js, idxs) in input_map.items():
+            matrix = path_matrices.get(tgt)
+            if matrix is None:
+                continue
+
+            weights[i, js] = matrix[neu_idx, idxs]
+
+
+def build_weights_fully_vectorized(
+    raw_neus: list[Neuron],
+    input_neus: list[SourceElem],
+    target_cache: dict[CoreOpNode, dict[SourceNode, np.ndarray]],
+    weights: np.ndarray,
+) -> None:
+
+    # 1. 对输入神经元进行分组 (保持一维数组)
+    input_group = defaultdict(list)
+    for j, elem in enumerate(input_neus):
+        input_group[elem.target].append((j, elem.index.idx))
+
+    input_map = {}
+    for tgt, elems in input_group.items():
+        js = np.fromiter((j for j, _ in elems), dtype=np.int64)
+        idxs = np.fromiter((idx for _, idx in elems), dtype=np.int64)
+        input_map[tgt] = (js, idxs)
+
+    # 2. 对输出神经元进行分组 (转换为列向量，为广播做准备)
+    output_group = defaultdict(list)
+    for i, neu in enumerate(raw_neus):
+        output_group[neu.target].append((i, neu.index.idx))
+
+    output_map = {}
+    for tgt, elems in output_group.items():
+        # np.newaxis (或 None) 将 1D 数组转为 2D 列向量，shape 变为 (N, 1)
+        i_arr = np.fromiter((i for i, _ in elems), dtype=np.int64)[:, np.newaxis]
+        neu_idx_arr = np.fromiter((idx for _, idx in elems), dtype=np.int64)[
+            :, np.newaxis
+        ]
+        output_map[tgt] = (i_arr, neu_idx_arr)
+
+    # 3. 基于 target 类型组合进行块级别的高级索引赋值
+    for out_tgt, (is_col, neu_idxs_col) in output_map.items():
+        path_matrices = target_cache.get(out_tgt)
+        if path_matrices is None:
+            continue
+
+        for in_tgt, (js_row, in_idxs_row) in input_map.items():
+            matrix = path_matrices.get(in_tgt)
+            if matrix is None:
+                continue
+
+            # 【魔法在这里】：
+            # is_col 是 (N, 1)，js_row 是 (M,)
+            # NumPy 会自动将其广播为一个 N x M 的网格坐标
+            # 同理，neu_idxs_col 和 in_idxs_row 也会广播，从 matrix 中提取对应的 N x M 子矩阵
+            weights[is_col, js_row] = matrix[neu_idxs_col, in_idxs_row]
+
+
+def get_raw_weights(raw_neus: list[Neuron], input_neus: list[SourceElem]) -> np.ndarray:
+    # Return a dense routing-group weight matrix with shape
+    # [number of output neurons, number of input elements].
+    n_output = len(raw_neus)
+    n_input = len(input_neus)
+    weights = np.zeros((n_output, n_input), dtype=np.int32)
+
+    # Cache expanded matrices per target node and predecessor node because
+    # many raw neurons share the same source/target pair.
+    target_cache: dict[CoreOpNode, dict[SourceNode, np.ndarray]] = {}
+
+    for neu in raw_neus:
+        target = neu.target
+        if target in target_cache:
+            continue
+
+        ensure_target_components(target)
+        signs = path_signs(target)
+        path_matrices: dict[SourceNode, np.ndarray] = {}
+
+        for predecessor, comp, weight, sign in zip(
+            target.predecessors,
+            target.comps,
+            target.weights,
+            signs,
+        ):
+            # Each predecessor contributes one dense [target_out, pred_out] block.
+            matrix = expanded_path_weight_matrix(
+                predecessor,
+                target,
+                comp,
+                weight,
+                sign,
+            )
+            if predecessor in path_matrices:
+                path_matrices[predecessor] = path_matrices[predecessor] + matrix
+            else:
+                path_matrices[predecessor] = matrix
+
+        target_cache[target] = path_matrices
+
+    build_weights_fully_vectorized(
+        raw_neus,
+        input_neus,
+        target_cache,
+        weights,
+    )
+    return weights
+
+
+def choose_weight_strategy(
+    weight_of_neu: np.ndarray,
+    weight_width: DataWidth,
+    input_width: DataWidth,
+    add_potential: AddPotentialMode,
+) -> Tuple[Weight, WeightCompressType]:
+    w_dense = Weight(
+        weight_of_neu,
+        WeightCompressType.DENSE,
+        weight_width,
+        input_width,
+        add_potential,
+    )
+    w_sparse = Weight(
+        weight_of_neu,
+        WeightCompressType.SPARSE,
+        weight_width,
+        input_width,
+        add_potential,
+    )
+
+    if w_sparse.n_sram_required() < w_dense.n_sram_required():
+        return w_sparse, WeightCompressType.SPARSE
+    else:
+        return w_dense, WeightCompressType.DENSE
+
+
+@dataclass
+class weight_info:
+    index: int  # 对应 base weight 的索引
+    offset: int  # 左移了多少位
+
+
+def group_shift_weights_optimized(
+    raw_weights: list[np.ndarray],
+) -> Tuple[List[weight_info], List[np.ndarray]]:
+    if not raw_weights:
+        return [], []
+
+    # 1. 预转换成 2D 矩阵以利用向量化计算偏移量
+    # 注意：假设 raw_weights 中的 ndarray 长度一致
+    matrix = np.vstack(raw_weights)
+    n_weights, n_axons = matrix.shape
+    dtype = matrix.dtype
+
+    # 2. 向量化查找第一个非零索引 (offset)
+    # mask 标记非零位置，argmax 返回第一个 True 的索引
+    mask = matrix != 0
+    has_nonzero = mask.any(axis=1)
+    # 如果全为 0，offset 默认为 0
+    offsets = np.where(has_nonzero, mask.argmax(axis=1), 0)
+
+    key_to_index = {}
+    base_weights = []
+    infos = []
+
+    # 预分配一个全零数组模板，减少循环内的 np.zeros 调用
+    zero_template = np.zeros(n_axons, dtype=dtype)
+
+    for i in track(
+        range(n_weights),
+        description=f"weight optimization",
+        total=len(range(n_weights)),
+    ):
+        row = matrix[i]
+        offset = int(offsets[i])
+
+        # 3. 构造 Base 权重
+        if not has_nonzero[i]:
+            base = zero_template.copy()
+        else:
+            # 这里的切片和赋值是高效的
+            base = np.zeros(n_axons, dtype=dtype)
+            base[: n_axons - offset] = row[offset:]
+
+        # 4. 关键：使用 tobytes() 作为字典的键，比 tuple() 快一个数量级
+        key = base.tobytes()
+
+        if key not in key_to_index:
+            idx = len(base_weights)
+            key_to_index[key] = idx
+            base_weights.append(base)
+        else:
+            idx = key_to_index[key]
+
+        infos.append(weight_info(index=idx, offset=offset))
+
+    return infos, base_weights
+
+
+def reorder_by_base_weight(
+    group_items: list[tuple[Neuron, np.ndarray]], weights_info: List[weight_info]
+) -> Tuple[list[tuple[Neuron, np.ndarray]], List[weight_info]]:
+    """
+    按 base weight（weights_info.index）对 group_items 做稳定分组重排
+
+    参数：
+        group_items: List[Any]
+        weights_info: List[weight_info]
+
+    返回：
+        reordered_items: List[Any]
+        reordered_infos: List[weight_info]
+    """
+
+    # 分桶（稳定）
+    buckets = defaultdict(list)
+
+    for item, info in zip(group_items, weights_info):
+        buckets[info.index].append((item, info))
+
+    # 按 base index 顺序拼接
+    reordered_items = []
+    reordered_infos = []
+
+    for base_idx in sorted(buckets.keys()):
+        for item, info in buckets[base_idx]:
+            reordered_items.append(item)
+            reordered_infos.append(info)
+
+    return reordered_items, reordered_infos

--- a/paibox/backendv2/get_weight.py
+++ b/paibox/backendv2/get_weight.py
@@ -653,7 +653,7 @@ def group_shift_weights_optimized(
 
     for i in track(
         range(n_weights),
-        description=f"weight optimization",
+        description="weight optimization",
         total=len(range(n_weights)),
     ):
         row = matrix[i]

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -7,10 +7,10 @@ from paicorelib import LCN_EX, AERPacketZXYCopy, CoordXY, FrameArrayType
 
 from paibox.paiir import PAIIRGraph
 
-from .op_node import CoreOpNode, InNode, build_nodes
-from .rg_build import build_routing_groups
+from .op_node import SourceNode, build_nodes
+from .rg_build import build_groups
 from .route_solver import route_solve
-from .routing import RoutingGroup, toposort_for_rg
+from .routing import ReorderGroup, RoutingGroup, toposort_for_rg
 
 
 def export_single_framearray(
@@ -37,34 +37,43 @@ def export_framearray_to_bit(
 
 class Mapper:
     def __init__(self):
+        self.groups: list[RoutingGroup | ReorderGroup] = []
         self.routing_groups: list[RoutingGroup] = []
-        self.nodes: list[CoreOpNode | InNode] = []
+        self.nodes: list[SourceNode] = []
         self.output_routing_group: RoutingGroup = RoutingGroup([], [])
         self.output_routing_group._base_coord = CoordXY(0, 0)
         self.output_routing_group._multicast_config = AERPacketZXYCopy(z=0, x=0, y=0)
 
     def generate_routing_groups(self, pai_graph: PAIIRGraph):
         self.nodes = build_nodes(pai_graph)
-        self.routing_groups = build_routing_groups(self.nodes)
+        self.groups = build_groups(self.nodes)
 
     def set_rough_dest(self):
         # determine which routing group each neuron sends to
-        for rg in self.routing_groups:
-            rg.set_lcn()
-            for neu in rg.raw_neus:
-                for dest_rg in self.routing_groups:
+        for group in self.groups:
+            group.set_lcn()
+            for neu in group.raw_neus:
+                # print(f"\nSetting rough dest for neuron {neu} in group {group.name}:")
+                dest_found = False
+                for dest_grp in self.groups:
+                    # print(f"\tChecking if neuron {neu} sends to group {dest_grp.name}")
+                    # print(f"Group {dest_grp.name} has input set: {dest_grp.input_set}")
                     # use set to accelerate lookup
-                    if neu in dest_rg.input_set:
-                        rg.dests[neu] = dest_rg
+                    if neu in dest_grp.input_set:
+                        # print(f"\tDest Found: Neuron {neu} sends to group {dest_grp.name}")
+                        dest_found = True
+                        group.dests[neu] = dest_grp
                         break
-                rg.dests[neu] = self.output_routing_group
-                self.output_routing_group.input_list.append(neu)
+                if not dest_found:
+                    self.output_routing_group.input_list.append(neu)
+                    group.dests[neu] = self.output_routing_group
 
         self.output_routing_group.input_set = set(self.output_routing_group.input_list)
+        # print("Output Routing Group Input List:", self.output_routing_group.input_list)
         self.output_routing_group.lcn = LCN_EX.LCN_128X
 
     def routing(self):
-        self.routing_groups, next_rg_group = toposort_for_rg(self.routing_groups)
+        self.routing_groups, next_rg_group = toposort_for_rg(self.groups)
 
         areas = [rg.n_core_required for rg in self.routing_groups]
         copy_configs, coords = route_solve(
@@ -168,27 +177,27 @@ class Mapper:
         # determine raw_neus in routing groups, other properties remain unset
         self.generate_routing_groups(pai_graph)
 
-        print(self.routing_groups)
+        print(self.groups)
 
         # determine which rg each neuron sends to
         # dests and input_list set
         # other properties remain unset
         self.set_rough_dest()
 
-        for rg in self.routing_groups:
+        for rg in self.groups:
             rg.allocate_neurons()
 
-        for rg in self.routing_groups:
+        for rg in self.groups:
             print(rg.info())
 
         # set core placements' coord, and generate detailed dest info for each neuron
         self.routing()
 
-        for rg in self.routing_groups:
+        for rg in self.groups:
             print(rg.info())
 
         self.set_detail_dest()
-        for rg in self.routing_groups:
+        for rg in self.groups:
             print(rg.routing_summary())
 
         self.set_auto_core_config()

--- a/paibox/backendv2/neuron.py
+++ b/paibox/backendv2/neuron.py
@@ -14,56 +14,9 @@ from paicorelib import (
     OfflineNeuFoldedAttrsV2Part2,
     OfflineNeuFullAttrsV2Part1,
     OfflineNeuFullAttrsV2Part2,
-    OutputType,
 )
 
-from .core_config import Frontend_Core_Config
-from .op_node import CoreOpNode, CustomIndex, InNode
-
-
-class Neuron:
-    def __init__(self, target: CoreOpNode, index: CustomIndex):
-        self.target = target
-        self.index = index
-
-    def attrs_part2(self) -> OfflineNeuFullAttrsV2Part2:
-        return self.target.attrs_part2(self.index.idx)
-
-    def output_type(self) -> OutputType:
-        return self.target.output_type()
-
-    def core_config(self) -> Frontend_Core_Config:
-        return self.target.core_config()
-
-    def __hash__(self) -> int:
-        return hash((self.index, self.target))
-
-    def __eq__(self, value: "Neuron") -> bool:
-        return self.index == value.index and self.target is value.target
-
-    def __str__(self) -> str:
-        return f"{self.target.name}[{self.index.idx}]"
-
-    def __repr__(self) -> str:
-        return self.__str__()
-
-
-class InputElem:
-    def __init__(self, target: InNode, index: CustomIndex):
-        self.target = target
-        self.index = index
-
-    def __hash__(self) -> int:
-        return hash((self.index, self.target))
-
-    def __eq__(self, value: "InputElem") -> bool:
-        return self.index == value.index and self.target is value.target
-
-    def __str__(self) -> str:
-        return f"{self.target.name}[{self.index.idx}]"
-
-    def __repr__(self) -> str:
-        return self.__str__()
+from .op_node import Neuron
 
 
 class NeuronPlacement:

--- a/paibox/backendv2/op_node.py
+++ b/paibox/backendv2/op_node.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Generic, List, Optional, TypeVar, Union
 
 import torch
 from paicorelib import (
@@ -18,6 +18,7 @@ from ..paiir import (
     OutputNode,
     PAIIRGraph,
     PotentialAddOp,
+    ReshapeOp,
     SequentialOp,
     StandaloneActOp,
     StandaloneCompOp,
@@ -47,6 +48,7 @@ def get_frontend_core_conf(
         assert lut_data is None, "lut_data should not be provided for SNN mode"
 
     return Frontend_Core_Config(
+        add_potential=core_params.add_potential,
         snn_ann=core_params.snn_mode,
         max_pooling=core_params.pooling_mode,
         zero_output=core_params.zero_output,
@@ -63,42 +65,85 @@ def get_frontend_core_conf(
     )
 
 
-class InNode:
-    def __init__(self, name: str, shape: tuple[int, ...]):
+# 定义 Raw Node 的类型变量
+T_Raw = TypeVar("T_Raw")
+
+
+class BaseNode(Generic[T_Raw]):
+    """所有 Graph 节点的基类"""
+
+    def __init__(self, name: str, shape: tuple[int, ...], raw_node: T_Raw):
         self.name = name
         self.shape = torch.Size(shape)
-        self.successors: list[CoreOpNode] = []
-
-        # Note: InNodes don't have predecessors since they represent external inputs, but we keep the attribute for uniformity
-        self.predecessors: list[CoreOpNode | InNode] = []
+        self.raw_node = raw_node
+        self.successors: List["DestNode"] = []
+        self.predecessors: List["SourceNode"] = []
 
     def __hash__(self) -> int:
         return hash(id(self))
 
-    def __str__(self) -> str:
-        return f"InputNode({self.name})"
-
     def __repr__(self) -> str:
-        return self.__str__()
+        return f"{self.__class__.__name__}({self.name})"
+
+    def __str__(self) -> str:
+        return self.__repr__()
 
 
-class CoreOpNode:
-    def __init__(self, name: str, raw_node: OfflineCoreOp, shape: tuple[int, ...]):
-        self.name = name
-        self.raw_node = raw_node
-        self.shape = torch.Size(shape)
-        self.successors: list[CoreOpNode] = []
-        self.predecessors: list[CoreOpNode | InNode] = []
+class InNode(BaseNode["InputNode"]):
+    def __init__(self, name: str, raw_node: "InputNode", shape: tuple[int, ...]):
+        super().__init__(name, shape, raw_node)
+
+
+class OutNode(BaseNode["OutputNode"]):
+    def __init__(self, name: str, raw_node: "OutputNode", shape: tuple[int, ...]):
+        super().__init__(name, shape, raw_node)
+
+
+class ReorderNode(BaseNode["ReshapeOp"]):
+    def __init__(self, name: str, raw_node: "ReshapeOp", shape: tuple[int, ...]):
+        super().__init__(name, shape, raw_node)
+
+    def get_reorder_info(self) -> dict["SourceElem", "ReorderElem"]:
+        if isinstance(self.raw_node, ReshapeOp):
+            assert (
+                len(self.predecessors) == 1
+            ), "ReshapeNode should have exactly one predecessor"
+            pred = self.predecessors[0]
+            pred_len = pred.shape.numel()
+            assert (
+                pred_len == self.shape.numel()
+            ), "Total number of elements must match for reshape"
+            reorder_map: dict["SourceElem", "ReorderElem"] = {}
+            for i in range(pred_len):
+                pred_elem = get_elem(pred, i)
+                reorder_elem = ReorderElem(self, CustomIndex(i))
+                reorder_map[pred_elem] = reorder_elem
+            return reorder_map
+        else:
+            raise NotImplementedError(
+                f"Unsupported node type for ReorderNode: {type(self.raw_node)}"
+            )
+
+
+class CoreOpNode(BaseNode["OfflineCoreOp"]):
+    def __init__(self, name: str, raw_node: "OfflineCoreOp", shape: tuple[int, ...]):
+        super().__init__(name, shape, raw_node)
         self.comps: list[Optional[nn.Module]] = []
         self.weights: list[Optional[Tensor]] = []
+        # 初始化前端配置
+        lut_data: Optional[LutData] = None
+        if isinstance(raw_node, SequentialOp):
+            lut = raw_node.act.lut
+            if lut is not None:
+                lut_data = lut.export_lut()
+
+        self.frontend_core_config: "Frontend_Core_Config" = get_frontend_core_conf(
+            raw_node.core_params, lut_data
+        )
+        print(f"lut data for node {self.name}: {lut_data}")
         self.set_comps_and_weights()
 
-        self.frontend_core_config: Frontend_Core_Config = get_frontend_core_conf(
-            raw_node.core_params, raw_node.lut_data
-        )
-
     def set_comps_and_weights(self) -> None:
-        """Set self.comps based on the type of raw_node."""
         if isinstance(self.raw_node, SequentialOp):
             self.comps = [self.raw_node.comp]
         elif isinstance(self.raw_node, AccumulateOp):
@@ -113,32 +158,19 @@ class CoreOpNode:
             raise NotImplementedError(f"Unsupported node type: {type(self.raw_node)}")
 
         weights = self.raw_node.weights
-        print(
-            f"Setting comps and weights for node {self.name} \n\tcomps: {self.comps} \n\traw weights: {weights}"
-        )
         if weights is not None:
             self.weights = list(weights)
         else:
             self.weights = [None] * len(self.comps)
 
-    def __hash__(self) -> int:
-        return hash(id(self))
-
-    def __str__(self) -> str:
-        return f"CoreOpNode({self.name})"
-
-    def __repr__(self) -> str:
-        return self.__str__()
-
-    def attrs_part2(self, idx=0) -> OfflineNeuFullAttrsV2Part2:
+    def attrs_part2(self, idx: int = 0) -> "OfflineNeuFullAttrsV2Part2":
         neu_attrs = self.raw_node.neuron_params
-
         if isinstance(neu_attrs.leak_v, torch.Tensor):
             assert self.shape[0] == 1, "Batch size > 1 not supported for tensor leak_v"
             out_channel = self.shape[1]
             assert (
                 neu_attrs.leak_v.numel() == out_channel
-            ), "leak_v tensor size must match output channels"
+            ), "leak_v tensor size mismatch"
             cur_channel = idx // (self.shape.numel() // self.shape[1])
             leak_v = neu_attrs.leak_v[cur_channel].item()
         else:
@@ -162,41 +194,136 @@ class CoreOpNode:
             vjt_initial=round(neu_attrs.init_v),
         )
 
-    def output_type(self) -> OutputType:
-        neu_attrs = self.raw_node.neuron_params
-        return neu_attrs.output_type
+    def output_type(self) -> "OutputType":
+        return self.raw_node.neuron_params.output_type
 
-    def core_config(self) -> Frontend_Core_Config:
+    def core_config(self) -> "Frontend_Core_Config":
         return self.frontend_core_config
 
 
-def build_nodes(graph: PAIIRGraph) -> list[CoreOpNode | InNode]:
-    nodes: list[CoreOpNode | InNode] = []
-    nodes_map: dict[str, CoreOpNode | InNode] = {}
+# 类型定义 1：包含三个 Node
+SourceNode = Union[InNode, ReorderNode, CoreOpNode]
+# 类型定义 2：不包含 Input
+DestNode = Union[ReorderNode, CoreOpNode]
+
+AllNode = Union[InNode, ReorderNode, CoreOpNode, OutNode]
+
+
+T = TypeVar("T")
+
+
+class BaseElem(Generic[T]):
+    def __init__(self, target: T, index: "CustomIndex"):
+        self.target = target
+        self.index = index
+
+    def __hash__(self) -> int:
+        # 统一的哈希逻辑
+        return hash((self.index, self.target))
+
+    def __eq__(self, value: object) -> bool:
+        # 统一的相等判断逻辑
+        if not isinstance(value, type(self)):
+            return False
+        return self.index == value.index and self.target is value.target
+
+    def __str__(self) -> str:
+        # 假设所有 target 都有 .name 属性
+        return f"{getattr(self.target, 'name', 'Unknown')}[{self.index.idx}]"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+# --- 子类实现 ---
+
+
+class PaddingElem(BaseElem["None"]):
+    def __init__(self, index: "CustomIndex"):
+        pass
+
+
+class Neuron(BaseElem["CoreOpNode"]):
+    # 仅保留 Neuron 特有的方法
+    def attrs_part2(self) -> "OfflineNeuFullAttrsV2Part2":
+        return self.target.attrs_part2(self.index.idx)
+
+    def output_type(self) -> "OutputType":
+        return self.target.output_type()
+
+    def core_config(self) -> "Frontend_Core_Config":
+        return self.target.core_config()
+
+
+class ReorderElem(BaseElem["ReorderNode"]):
+    # 如果没有特有方法，直接 pass 即可
+    pass
+
+
+class InputElem(BaseElem["InNode"]):
+    pass
+
+
+AllElem = Union[Neuron, ReorderElem, InputElem]
+SourceElem = AllElem
+CoreElem = Union[Neuron, ReorderElem]
+
+
+def get_elem(Node: BaseNode, idx: int) -> "SourceElem":
+    if isinstance(Node, InNode):
+        return InputElem(Node, CustomIndex(idx))
+    elif isinstance(Node, ReorderNode):
+        return ReorderElem(Node, CustomIndex(idx))
+    elif isinstance(Node, CoreOpNode):
+        return Neuron(Node, CustomIndex(idx))
+    else:
+        raise NotImplementedError(f"Unsupported node type: {type(Node)}")
+
+
+def build_nodes(graph: PAIIRGraph) -> list[SourceNode]:
+    nodes: list[AllNode] = []
+    nodes_map: dict[str, AllNode] = {}
     for raw_node in graph.nodes.values():
         if isinstance(raw_node, OfflineCoreOp):
             node = CoreOpNode(raw_node.name, raw_node, raw_node.output_shape)
         elif isinstance(raw_node, InputNode):
-            node = InNode(raw_node.name, raw_node.shape)
+            node = InNode(raw_node.name, raw_node, raw_node.shape)
         elif isinstance(raw_node, OutputNode):
-            pass
+            node = OutNode(raw_node.name, raw_node, raw_node.shape)
+        elif isinstance(raw_node, ReshapeOp):
+            node = ReorderNode(raw_node.name, raw_node, raw_node.output_shape)
         else:
             raise NotImplementedError(f"Unsupported node type: {type(raw_node)}")
         nodes_map[raw_node.name] = node
         nodes.append(node)
 
     for node_name, cur_node in nodes_map.items():
+        if isinstance(cur_node, OutNode):
+            continue
         succ_node_names = graph.successors(node_name)
         for succ_name in succ_node_names:
             succ_node = nodes_map[succ_name]
-            assert isinstance(
-                succ_node, (CoreOpNode)
-            ), "Only CoreOpNode can be a successor of other node"
+            if isinstance(succ_node, OutNode):
+                continue
+            assert isinstance(succ_node, DestNode)
             cur_node.successors.append(succ_node)
-        if isinstance(cur_node, CoreOpNode):
+        if isinstance(cur_node, CoreOpNode | ReorderNode):
             pred_node_names = graph.predecessors(node_name)
             for pred_name in pred_node_names:
                 pred_node = nodes_map[pred_name]
+                if isinstance(pred_node, OutNode):
+                    raise ValueError(
+                        f"CoreOpNode {cur_node.name} has OutNode {pred_node.name} as predecessor"
+                    )
                 cur_node.predecessors.append(pred_node)
 
-    return nodes
+    filtered_nodes = [node for node in nodes if not isinstance(node, OutNode)]
+
+    for node in filtered_nodes:
+        print(f"Node {node.name}({node.shape}):")
+        print(f"\tPredecessors: {[pred.name for pred in node.predecessors]}")
+        print(f"\tSuccessors: {[succ.name for succ in node.successors]}")
+
+    # raise NotImplementedError("Not support output node")
+
+    return filtered_nodes

--- a/paibox/backendv2/rg_build.py
+++ b/paibox/backendv2/rg_build.py
@@ -1,5 +1,4 @@
 from .op_node import (
-    BaseNode,
     CoreOpNode,
     CustomIndex,
     DestNode,

--- a/paibox/backendv2/rg_build.py
+++ b/paibox/backendv2/rg_build.py
@@ -1,6 +1,28 @@
-from .neuron import InputElem, Neuron
-from .op_node import CoreOpNode, CustomIndex, InNode
-from .routing import RoutingGroup
+from .op_node import (
+    BaseNode,
+    CoreOpNode,
+    CustomIndex,
+    DestNode,
+    InNode,
+    InputElem,
+    Neuron,
+    ReorderElem,
+    ReorderNode,
+    SourceElem,
+    SourceNode,
+    get_elem,
+)
+from .routing import ReorderGroup, RoutingGroup
+
+
+def gen_elems(node: SourceNode) -> list[SourceElem]:
+    elems: list[SourceElem] = []
+    # flatten the shape to get total number of neurons
+    num_elem = node.shape.numel()
+    for idx in range(num_elem):
+        elem: SourceElem = get_elem(node, idx)
+        elems.append(elem)
+    return elems
 
 
 def gen_neurons(node: CoreOpNode) -> list[Neuron]:
@@ -23,34 +45,51 @@ def gen_ioelements(node: InNode) -> list[InputElem]:
     return ioelements
 
 
-def build_routing_group(
-    nodes: set[CoreOpNode], input_nodes: set[CoreOpNode | InNode]
-) -> RoutingGroup:
-    # Placeholder implementation
+def gen_reorder_elems(node: ReorderNode) -> list[ReorderElem]:
+    elems: list[ReorderElem] = []
+    # flatten the shape to get total number of neurons
+    num_elem = node.shape.numel()
+    for idx in range(num_elem):
+        elem: ReorderElem = ReorderElem(target=node, index=CustomIndex(idx))
+        elems.append(elem)
+    return elems
 
+
+def build_routing_group(
+    nodes: set[CoreOpNode], input_nodes: set[SourceNode]
+) -> RoutingGroup:
     raw_neus: list[Neuron] = []
     for node in nodes:
         raw_neus.extend(gen_neurons(node))
-    input_list: list[Neuron | InputElem] = []
+    input_list: list[SourceElem] = []
     for in_node in input_nodes:
-        if isinstance(in_node, CoreOpNode):
-            input_list.extend(gen_neurons(in_node))
-        elif isinstance(in_node, InNode):
-            input_list.extend(gen_ioelements(in_node))
+        input_list.extend(gen_elems(in_node))
     rg = RoutingGroup(raw_neus, input_list, nodes, input_nodes)
-    # Logic to build a routing group from nodes goes here
     return rg
 
 
-def build_routing_groups(nodes: list[CoreOpNode | InNode]) -> list[RoutingGroup]:
+def build_reorder_group(
+    nodes: set[ReorderNode], input_nodes: set[SourceNode]
+) -> ReorderGroup:
+    raw_neus: list[ReorderElem] = []
+    for node in nodes:
+        raw_neus.extend(gen_reorder_elems(node))
+    input_list: list[SourceElem] = []
+    for in_node in input_nodes:
+        input_list.extend(gen_elems(in_node))
+    rg = ReorderGroup(raw_neus, input_list, nodes, input_nodes)
+    return rg
+
+
+def build_groups(nodes: list[SourceNode]) -> list[ReorderGroup | RoutingGroup]:
     # Placeholder implementation
-    routing_groups: list[RoutingGroup] = []
+    groups: list[ReorderGroup | RoutingGroup] = []
     # Logic to build routing groups from nodes goes here
-    node_sets: list[set[CoreOpNode]] = []
+    node_sets: list[set[DestNode]] = []
     for node in nodes:
         if len(node.successors) > 0:
             node_sets.append(set(node.successors))
-        if isinstance(node, CoreOpNode):
+        if isinstance(node, DestNode):
             node_sets.append({node})
 
     while True:
@@ -69,13 +108,31 @@ def build_routing_groups(nodes: list[CoreOpNode | InNode]) -> list[RoutingGroup]
     print(f"Identified {len(node_sets)} routing groups.")
     print(node_sets)
 
-    routing_groups: list[RoutingGroup] = []
-
     for node_set in node_sets:
-        input_nodes: set[CoreOpNode | InNode] = set()
+        input_nodes: set[SourceNode] = set()
+        reorder_node_set: set[ReorderNode] = set()
+        routing_node_set: set[CoreOpNode] = set()
+        print(f"\nProcessing node set {node_set} for group building:")
         for node in node_set:
+            print(f"\tProcessing node {node} in group building:")
+            print(f"\t\tPredecessors: {node.predecessors}")
+            print(f"\t\tSuccessors: {node.successors}")
+            if isinstance(node, ReorderNode):
+                reorder_node_set.add(node)
+            elif isinstance(node, CoreOpNode):
+                routing_node_set.add(node)
             input_nodes.update(node.predecessors)
-        rg = build_routing_group(node_set, input_nodes)
-        routing_groups.append(rg)
+        print("Group input nodes:", input_nodes)
+        is_reorder = len(reorder_node_set) == 1 and len(routing_node_set) == 0
+        is_routing = len(reorder_node_set) == 0 and len(routing_node_set) > 0
 
-    return routing_groups
+        assert is_reorder ^ is_routing, "Invalid group type."
+
+        if is_reorder:
+            group = build_reorder_group(reorder_node_set, input_nodes)
+        else:
+            group = build_routing_group(routing_node_set, input_nodes)
+
+        groups.append(group)
+
+    return groups

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Optional
+from abc import abstractmethod
+from typing import List, Optional
 
 import numpy as np
-import torch
 from paicorelib import (
     LCN_EX,
+    AddPotentialMode,
     AERPacketZXYCopy,
     CoordXY,
     DataWidth,
@@ -13,518 +14,182 @@ from paicorelib import (
     NeuronType,
     OfflineNeuDestInfoV2,
     OfflineNeuFullAttrsV2Part1,
+    OfflineNeuFullAttrsV2Part2,
     WeightCompressType,
     find_coordxy_shortest_path,
 )
-from torch import Tensor, nn
-from torch.nn import functional as F
+from rich.progress import track
 
-from ..paiir import (
-    AccumulateOp,
-    PotentialAddOp,
-    SequentialOp,
-    StandaloneActOp,
-    StandaloneCompOp,
-)
 from .core_config import Backend_Core_Config, Frontend_Core_Config
 from .coreplacement import (
     CorePlacement,
     EmptyOfflineCorePlacementV2,
     OfflineCorePlacementV2,
 )
-from .neuron import InputElem, Neuron, OfflineNeuronPlacement
-from .op_node import CoreOpNode, InNode
-from .weight import Weight
+from .get_weight import (
+    choose_weight_strategy,
+    get_raw_weights,
+    group_shift_weights_optimized,
+    reorder_by_base_weight,
+    weight_info,
+)
+from .neuron import OfflineNeuronPlacement
+from .op_node import (
+    CoreOpNode,
+    Neuron,
+    ReorderElem,
+    ReorderNode,
+    SourceElem,
+    SourceNode,
+)
 
 FANIN_BASE = 512
 
 
-def feature_shape(shape: torch.Size | tuple[int, ...]) -> tuple[int, ...]:
-    # Backend weight extraction works on feature dimensions only.
-    # The leading batch dimension is stripped and must stay equal to 1.
-    feature_shape = tuple(shape)
-    if len(feature_shape) > 1:
-        batch = feature_shape[0]
-        if batch != 1:
-            raise NotImplementedError(
-                f"Only batch size 1 is supported, but got shape {feature_shape}."
-            )
-        feature_shape = feature_shape[1:]
+class Group:
+    def __init__(self):
+        self.dests: dict[Neuron | ReorderElem, "RoutingGroup|ReorderGroup"] = {}
 
-    return feature_shape
+    def set_lcn(self) -> None:
+        pass
 
+    def allocate_neurons(self) -> None:
+        pass
 
-def to_nd_tuple(value: int | tuple[int, ...], ndim: int) -> tuple[int, ...]:
-    if isinstance(value, tuple):
-        if len(value) != ndim:
-            raise ValueError(f"Expected a tuple of length {ndim}, but got {value}.")
-        return value
-
-    return (value,) * ndim
+    @abstractmethod
+    def get_lcn(self, _: Neuron | ReorderElem) -> LCN_EX:
+        pass
 
 
-def ensure_target_components(target: CoreOpNode) -> None:
-    # Lazily reconstruct per-predecessor comps/weights so routing can
-    # query them even if node initialization did not populate them yet.
-    if not target.predecessors:
-        return
+class ReorderGroup(Group):
+    reorder_group_counter = 0
 
-    if len(target.comps) == len(target.predecessors) and len(target.weights) == len(
-        target.predecessors
+    def __init__(
+        self,
+        raw_neus: list[ReorderElem],
+        input_list: list[SourceElem],
+        nodes: Optional[set[ReorderNode]] = None,
+        input_nodes: Optional[set[SourceNode]] = None,
     ):
-        return
+        super().__init__()
+        self.id: int = type(self).reorder_group_counter
+        type(self).reorder_group_counter += 1
+        self.name: str = f"ReorderG_{self.id}"
 
-    raw_node = target.raw_node
-    if isinstance(raw_node, SequentialOp):
-        target.comps = [raw_node.comp]
-    elif isinstance(raw_node, AccumulateOp):
-        target.comps = list(raw_node.comps)
-    elif isinstance(raw_node, StandaloneCompOp):
-        target.comps = [raw_node.comp]
-    elif isinstance(raw_node, StandaloneActOp):
-        target.comps = [None]
-    elif isinstance(raw_node, PotentialAddOp):
-        target.comps = [None] * len(raw_node.signs)
-    else:
-        raise NotImplementedError(f"Unsupported node type: {type(raw_node)}")
-
-    raw_weights = raw_node.weights
-    if raw_weights is None:
-        target.weights = [None] * len(target.comps)
-    else:
-        target.weights = list(raw_weights)
-
-
-def path_signs(target: CoreOpNode) -> list[int]:
-    # Accumulate/Add nodes may encode subtraction through per-path signs.
-    raw_node = target.raw_node
-    if isinstance(raw_node, (AccumulateOp, PotentialAddOp)):
-        return list(raw_node.signs)
-
-    return [1] * len(target.predecessors)
-
-
-def direct_weight_matrix(
-    weight: Tensor,
-    input_shape: tuple[int, ...],
-    output_shape: tuple[int, ...],
-    sign: int,
-) -> np.ndarray:
-    # Linear/identity-like paths already expose a dense [out, in] matrix.
-    matrix = np.asarray(weight.detach().cpu(), dtype=np.int32)
-    n_input = int(np.prod(input_shape))
-    n_output = int(np.prod(output_shape))
-
-    if matrix.shape != (n_output, n_input):
-        raise ValueError(
-            f"Direct weight shape mismatch: expected {(n_output, n_input)}, got {matrix.shape}."
+        self.nodes: Optional[set[ReorderNode]] = nodes
+        self.input_nodes: Optional[set[SourceNode]] = input_nodes
+        self.input_set: set[SourceElem] = set(input_list)
+        self.raw_neus: list[ReorderElem] = raw_neus
+        self.input_list: list[SourceElem] = (
+            input_list  # input_list can be reordered later
         )
+        self.input_set: set[SourceElem] = set(input_list)
 
-    if sign != 1:
-        matrix = sign * matrix
+        # set by mapper.set_rough_dest()
+        # self.dests: dict[ReorderElem, "RoutingGroup|ReorderGroup"] = {}
 
-    return matrix
+        assert len(raw_neus) == len(
+            input_list
+        ), "raw_neus and input_list must have the same length for ReorderGroup"
+        self.reorder_map: dict[SourceElem, ReorderElem] = dict()
+        self.set_reorder_map()
 
+    def set_reorder_map(self) -> None:
+        assert self.nodes is not None, "nodes must be provided for ReorderGroup"
+        for node in self.nodes:
+            reorder_map = node.get_reorder_info()
+            self.reorder_map.update(reorder_map)
+        assert (
+            set(self.reorder_map.keys()) == self.input_set
+        ), "reorder_map keys must match input_set"
+        assert set(self.reorder_map.values()) == set(
+            self.raw_neus
+        ), "reorder_map values must match raw_neus"
 
-def identity_weight_matrix(
-    input_shape: tuple[int, ...],
-    output_shape: tuple[int, ...],
-    sign: int,
-) -> np.ndarray:
-    # Activation-only / add-only paths do not own raw parameter tensors, but
-    # backend routing still needs their implicit identity connectivity.
-    n_input = int(np.prod(input_shape))
-    n_output = int(np.prod(output_shape))
-    if n_input != n_output:
-        raise ValueError(
-            f"Identity path shape mismatch: input has {n_input} elems, output has {n_output}."
-        )
+    def reorder_axon(self, elem: ReorderElem | Neuron) -> SourceElem:
+        out_elem = self.reorder_map[elem]
+        return self.get_axon(out_elem)
 
-    matrix = np.eye(n_output, dtype=np.int32)
-    if sign != 1:
-        matrix *= sign
+    def get_axon(self, elem: ReorderElem) -> SourceElem:
+        dest_group = self.dests[elem]
+        if isinstance(dest_group, ReorderGroup):
+            return dest_group.reorder_axon(elem)
+        return elem
 
-    return matrix
+    def reorder_dest(self, elem: ReorderElem | Neuron) -> "RoutingGroup":
+        out_elem = self.reorder_map[elem]
+        return self.get_dest(out_elem)
 
+    def get_dest(self, elem: ReorderElem) -> "RoutingGroup":
+        dest_group = self.dests[elem]
+        if isinstance(dest_group, ReorderGroup):
+            return dest_group.reorder_dest(self.reorder_map[elem])
+        return dest_group
 
-def unfold_input_indices_2d(
-    channels: int,
-    spatial_shape: tuple[int, int],
-    kernel_size: tuple[int, int],
-    stride: tuple[int, int],
-    padding: tuple[int, int],
-    dilation: tuple[int, int],
-) -> torch.Tensor:
-    # Build a lookup table from each sliding-window position back to the
-    # flattened input indices. Zero means "came from padding".
-    height, width = spatial_shape
-    n_input = channels * height * width
-    input_ids = torch.arange(1, n_input + 1, dtype=torch.float64).reshape(
-        1, channels, height, width
-    )
-    patches = F.unfold(
-        input_ids,
-        kernel_size=kernel_size,
-        dilation=dilation,
-        padding=padding,
-        stride=stride,
-    )
-    return patches.to(torch.int64).squeeze(0)
+    def reorder_dest_info(
+        self, elem: ReorderElem | Neuron
+    ) -> tuple["RoutingGroup", int]:
+        out_elem = self.reorder_map[elem]
+        return self.get_dest_info(out_elem)
 
+    def get_dest_info(self, elem: ReorderElem | Neuron) -> tuple["RoutingGroup", int]:
+        dest_group = self.dests[elem]
+        if isinstance(dest_group, ReorderGroup):
+            return dest_group.reorder_dest_info(elem)
+        return dest_group, dest_group.input_list.index(elem)
 
-def conv2d_weight_matrix(
-    weight: Tensor,
-    input_shape: tuple[int, int, int],
-    output_shape: tuple[int, int, int],
-    stride: tuple[int, int],
-    padding: tuple[int, int],
-    dilation: tuple[int, int],
-    groups: int,
-    sign: int,
-) -> np.ndarray:
-    # Expand a Conv2d kernel into a full dense matrix with shape [out, in],
-    # where rows are flattened output neurons and columns are flattened inputs.
-    in_channels, height, width = input_shape
-    out_channels, out_height, out_width = output_shape
-    kernel = np.asarray(weight.detach().cpu(), dtype=np.int32)
-    _, in_channels_per_group, kernel_height, kernel_width = kernel.shape
+    def info(self) -> str:
+        info_str = f"{self.name}:\n"
+        # if too many dests, only show first 3 and last 3
+        dest_strs = []
+        for neu in self.raw_neus:
+            dest_rg, index = self.get_dest_info(neu)
+            dest_strs.append(f"{str(neu)} -> {dest_rg.name}[{index}]")
+        if len(dest_strs) > 6:
+            dest_strs = dest_strs[:3] + ["..."] + dest_strs[-3:]
+        info_str += f"  Number of Neurons: {len(self.raw_neus)}\n"
+        info_str += f"  Number of Inputs: {len(self.input_list)}\n"
+        info_str += "  Dests:\n    " + "\n    ".join(dest_strs) + "\n"
+        return info_str
 
-    if in_channels != in_channels_per_group * groups:
-        raise ValueError(
-            f"Conv groups mismatch: input channels {in_channels}, kernel channels {in_channels_per_group}, groups {groups}."
-        )
+    def routing_summary(self) -> str:
+        summary_str = f"Reorder Group {self.name} No Summary\n"
+        return summary_str
 
-    out_channels_per_group = out_channels // groups
-    out_size = out_height * out_width
-    n_input = in_channels * height * width
-    matrix = np.zeros((out_channels * out_size, n_input), dtype=np.int32)
+    def __hash__(self):
+        # use hash of each raw_neu to identify routing group
+        return hash(tuple(sorted([hash(neu) for neu in self.raw_neus])))
 
-    patches = (
-        unfold_input_indices_2d(
-            in_channels,
-            (height, width),
-            (kernel_height, kernel_width),
-            stride,
-            padding,
-            dilation,
-        )
-        .cpu()
-        .numpy()
-    )
+    def __str__(self) -> str:
+        neu_strs = [str(neu) for neu in self.raw_neus]
+        # if too many neurons, only show first 3 and last 3
+        if len(neu_strs) > 6:
+            neu_strs = neu_strs[:3] + ["..."] + neu_strs[-3:]
+        # if too many inputs, only show first 3 and last 3
+        input_strs = [str(neu) for neu in self.input_list]
+        if len(input_strs) > 6:
+            input_strs = input_strs[:3] + ["..."] + input_strs[-3:]
+        return f"\n{self.name}(\nraw_neus=[{', '.join(neu_strs)}], \ninput_list=[{', '.join(input_strs)}])\n"
 
-    if patches.shape[1] != out_size:
-        raise ValueError(
-            f"Conv unfold mismatch: expected {out_size} output positions, got {patches.shape[1]}."
-        )
-
-    row_offsets = np.tile(
-        np.arange(out_size, dtype=np.int64),
-        in_channels_per_group * kernel_height * kernel_width,
-    )
-
-    for out_channel in range(out_channels):
-        group_idx = out_channel // out_channels_per_group
-        patch_start = group_idx * in_channels_per_group * kernel_height * kernel_width
-        patch_end = patch_start + in_channels_per_group * kernel_height * kernel_width
-
-        # Scatter each kernel coefficient to the input positions that feed the
-        # corresponding flattened output locations.
-        flat_cols = patches[patch_start:patch_end].reshape(-1)
-        valid = flat_cols > 0
-        flat_rows = row_offsets[valid]
-        flat_values = np.repeat(kernel[out_channel].reshape(-1), out_size)[valid]
-        matrix[out_channel * out_size + flat_rows, flat_cols[valid] - 1] = flat_values
-
-    if sign != 1:
-        matrix *= sign
-
-    return matrix
+    def __repr__(self) -> str:
+        return self.__str__()
 
 
-def pool2d_weight_matrix(
-    channels: int,
-    input_shape: tuple[int, int, int],
-    output_shape: tuple[int, int, int],
-    kernel_size: tuple[int, int],
-    stride: tuple[int, int],
-    padding: tuple[int, int],
-    dilation: tuple[int, int],
-    sign: int,
-) -> np.ndarray:
-    # Pooling has no explicit weight tensor, but connectivity still forms a
-    # dense [out, in] matrix. Every valid input in the pooling window gets 1.
-    in_channels, height, width = input_shape
-    out_channels, out_height, out_width = output_shape
-    if in_channels != channels or out_channels != channels:
-        raise ValueError(
-            f"Pooling channel mismatch: input={in_channels}, output={out_channels}, channels={channels}."
-        )
-
-    out_size = out_height * out_width
-    n_input = in_channels * height * width
-    matrix = np.zeros((out_channels * out_size, n_input), dtype=np.int32)
-
-    patches = (
-        unfold_input_indices_2d(
-            in_channels,
-            (height, width),
-            kernel_size,
-            stride,
-            padding,
-            dilation,
-        )
-        .cpu()
-        .numpy()
-    )
-
-    if patches.shape[1] != out_size:
-        raise ValueError(
-            f"Pooling unfold mismatch: expected {out_size} output positions, got {patches.shape[1]}."
-        )
-
-    kernel_elems = int(np.prod(kernel_size))
-    row_offsets = np.tile(np.arange(out_size, dtype=np.int64), kernel_elems)
-
-    for channel in range(channels):
-        patch_start = channel * kernel_elems
-        patch_end = patch_start + kernel_elems
-
-        flat_cols = patches[patch_start:patch_end].reshape(-1)
-        valid = flat_cols > 0
-        matrix[channel * out_size + row_offsets[valid], flat_cols[valid] - 1] = sign
-
-    return matrix
-
-
-def conv1d_weight_matrix(
-    weight: Tensor,
-    input_shape: tuple[int, int],
-    output_shape: tuple[int, int],
-    stride: tuple[int],
-    padding: tuple[int],
-    dilation: tuple[int],
-    groups: int,
-    sign: int,
-) -> np.ndarray:
-    # Reuse the 2D expansion path by treating 1D signals as H=1 feature maps.
-    in_channels, in_length = input_shape
-    out_channels, out_length = output_shape
-    kernel = weight.reshape(weight.shape[0], weight.shape[1], 1, weight.shape[2])
-    return conv2d_weight_matrix(
-        kernel,
-        (in_channels, 1, in_length),
-        (out_channels, 1, out_length),
-        (1, stride[0]),
-        (0, padding[0]),
-        (1, dilation[0]),
-        groups,
-        sign,
-    )
-
-
-def pool1d_weight_matrix(
-    channels: int,
-    input_shape: tuple[int, int],
-    output_shape: tuple[int, int],
-    kernel_size: tuple[int],
-    stride: tuple[int],
-    padding: tuple[int],
-    dilation: tuple[int],
-    sign: int,
-) -> np.ndarray:
-    # Reuse the 2D pooling expansion path by treating 1D signals as H=1 maps.
-    in_channels, in_length = input_shape
-    out_channels, out_length = output_shape
-    return pool2d_weight_matrix(
-        channels,
-        (in_channels, 1, in_length),
-        (out_channels, 1, out_length),
-        (1, kernel_size[0]),
-        (1, stride[0]),
-        (0, padding[0]),
-        (1, dilation[0]),
-        sign,
-    )
-
-
-def expanded_path_weight_matrix(
-    predecessor: CoreOpNode | InNode,
-    target: CoreOpNode,
-    comp: Optional[nn.Module],
-    weight: Optional[Tensor],
-    sign: int,
-) -> np.ndarray:
-    # Convert one predecessor path into a dense [out, in] matrix, choosing
-    # the correct expansion strategy from the comp type.
-    input_shape = feature_shape(predecessor.shape)
-    output_shape = feature_shape(target.shape)
-
-    if comp is None:
-        return identity_weight_matrix(input_shape, output_shape, sign)
-
-    if weight is not None and (isinstance(comp, nn.Linear) or weight.ndim == 2):
-        return direct_weight_matrix(weight, input_shape, output_shape, sign)
-
-    if isinstance(comp, nn.Conv1d):
-        return conv1d_weight_matrix(
-            weight,
-            input_shape,
-            output_shape,
-            to_nd_tuple(comp.stride, 1),
-            to_nd_tuple(comp.padding, 1),
-            to_nd_tuple(comp.dilation, 1),
-            comp.groups,
-            sign,
-        )
-
-    if isinstance(comp, nn.Conv2d):
-        return conv2d_weight_matrix(
-            weight,
-            input_shape,
-            output_shape,
-            to_nd_tuple(comp.stride, 2),
-            to_nd_tuple(comp.padding, 2),
-            to_nd_tuple(comp.dilation, 2),
-            comp.groups,
-            sign,
-        )
-
-    if isinstance(comp, nn.MaxPool1d):
-        if comp.ceil_mode:
-            raise NotImplementedError("MaxPool1d with ceil_mode=True is not supported.")
-
-        return pool1d_weight_matrix(
-            input_shape[0],
-            input_shape,
-            output_shape,
-            to_nd_tuple(comp.kernel_size, 1),
-            to_nd_tuple(comp.stride or comp.kernel_size, 1),
-            to_nd_tuple(comp.padding, 1),
-            to_nd_tuple(comp.dilation, 1),
-            sign,
-        )
-
-    if isinstance(comp, nn.AvgPool1d):
-        if comp.ceil_mode:
-            raise NotImplementedError("AvgPool1d with ceil_mode=True is not supported.")
-
-        return pool1d_weight_matrix(
-            input_shape[0],
-            input_shape,
-            output_shape,
-            to_nd_tuple(comp.kernel_size, 1),
-            to_nd_tuple(comp.stride or comp.kernel_size, 1),
-            to_nd_tuple(comp.padding, 1),
-            (1,),
-            sign,
-        )
-
-    if isinstance(comp, nn.MaxPool2d):
-        if comp.ceil_mode:
-            raise NotImplementedError("MaxPool2d with ceil_mode=True is not supported.")
-
-        return pool2d_weight_matrix(
-            input_shape[0],
-            input_shape,
-            output_shape,
-            to_nd_tuple(comp.kernel_size, 2),
-            to_nd_tuple(comp.stride or comp.kernel_size, 2),
-            to_nd_tuple(comp.padding, 2),
-            to_nd_tuple(comp.dilation, 2),
-            sign,
-        )
-
-    if isinstance(comp, nn.AvgPool2d):
-        if comp.ceil_mode:
-            raise NotImplementedError("AvgPool2d with ceil_mode=True is not supported.")
-
-        return pool2d_weight_matrix(
-            input_shape[0],
-            input_shape,
-            output_shape,
-            to_nd_tuple(comp.kernel_size, 2),
-            to_nd_tuple(comp.stride or comp.kernel_size, 2),
-            to_nd_tuple(comp.padding, 2),
-            (1, 1),
-            sign,
-        )
-
-    raise NotImplementedError(
-        f"Unsupported weight expansion for comp {type(comp)} with weight {type(weight)}."
-    )
-
-
-def get_raw_weights(
-    raw_neus: list[Neuron], input_neus: list[Neuron | InputElem]
-) -> np.ndarray:
-    # Return a dense routing-group weight matrix with shape
-    # [number of output neurons, number of input elements].
-    n_output = len(raw_neus)
-    n_input = len(input_neus)
-    weights = np.zeros((n_output, n_input), dtype=np.int32)
-
-    # Cache expanded matrices per target node and predecessor node because
-    # many raw neurons share the same source/target pair.
-    target_cache: dict[CoreOpNode, dict[CoreOpNode | InNode, np.ndarray]] = {}
-
-    for neu in raw_neus:
-        target = neu.target
-        if target in target_cache:
-            continue
-
-        ensure_target_components(target)
-        signs = path_signs(target)
-        path_matrices: dict[CoreOpNode | InNode, np.ndarray] = {}
-
-        for predecessor, comp, weight, sign in zip(
-            target.predecessors,
-            target.comps,
-            target.weights,
-            signs,
-        ):
-            # Each predecessor contributes one dense [target_out, pred_out] block.
-            matrix = expanded_path_weight_matrix(
-                predecessor,
-                target,
-                comp,
-                weight,
-                sign,
-            )
-            if predecessor in path_matrices:
-                path_matrices[predecessor] = path_matrices[predecessor] + matrix
-            else:
-                path_matrices[predecessor] = matrix
-
-        target_cache[target] = path_matrices
-
-    for i, neu in enumerate(raw_neus):
-        path_matrices = target_cache[neu.target]
-        for j, elem in enumerate(input_neus):
-            matrix = path_matrices.get(elem.target)
-            if matrix is None:
-                # No edge from this input node to the current output neuron.
-                continue
-
-            # Both neuron and input indices are already flattened indices.
-            weights[i, j] = matrix[neu.index.idx, elem.index.idx]
-
-    return weights
-
-
-class RoutingGroup:
-    _counter = 0
+class RoutingGroup(Group):
+    routing_group_counter = 0
 
     # core_blocks in the same routing group share the same following properties
     # lcn, input_sign, input_width
     def __init__(
         self,
         raw_neus: list[Neuron],
-        input_list: list[Neuron | InputElem],
+        input_list: list[SourceElem],
         nodes: Optional[set[CoreOpNode]] = None,
-        input_nodes: Optional[set[CoreOpNode | InNode]] = None,
+        input_nodes: Optional[set[SourceNode]] = None,
     ):
-        self.id: int = type(self)._counter
-        type(self)._counter += 1
+        super().__init__()
+        self.id: int = type(self).routing_group_counter
+        type(self).routing_group_counter += 1
         self.name: str = f"RG_{self.id}"
 
         # for better optimization, if nodes and input_nodes are provided,
@@ -535,16 +200,20 @@ class RoutingGroup:
 
         # set by generate_routing_groups
         self.raw_neus: list[Neuron] = raw_neus
-        self.input_list: list[Neuron | InputElem] = (
+        self.input_list: list[SourceElem] = (
             input_list  # input_list can be reordered later
         )
-        self.input_set: set[Neuron | InputElem] = set(input_list)
+        self.input_set: set[SourceElem] = set(input_list)
 
         # set by mapper.set_rough_dest()
-        self.dests: dict[Neuron, "RoutingGroup"] = {}
+        # self.dests: dict[Neuron, "RoutingGroup|ReorderGroup"] = {}
         self.lcn: LCN_EX = LCN_EX.LCN_1X
 
         # self.core_blocks: list[CoreBlock] = []
+        self.last_full_attrs: Optional[OfflineNeuFullAttrsV2Part2] = None
+        self.last_dest_group: Optional[RoutingGroup] = None
+        self.last_dest_index: Optional[int] = None
+
         self.core_placements: list[CorePlacement] = []
         self.n_core_required: int = -1
 
@@ -552,19 +221,293 @@ class RoutingGroup:
         self.assigned_cores: dict[CoordXY, CorePlacement] = {}
         self._multicast_config: Optional[AERPacketZXYCopy] = None
         self._base_coord: Optional[CoordXY] = None
+        self.input_bit_num: int = 0
 
     def set_lcn(self):
         input_widths: set[DataWidth] = set(
             [neu.core_config().input_width for neu in self.raw_neus]
         )
+        add_potentials: set[AddPotentialMode] = set(
+            [neu.core_config().add_potential for neu in self.raw_neus]
+        )
         assert (
-            len(input_widths) == 1
-        ), "All neurons in the routing group must have the same input width."
-        # if input width, input sign weight are different, need to split routing group before calling this function
-        input_width = input_widths.pop()
-        max_axon_addr = len(self.input_list) * (2**input_width)
+            len(add_potentials) == 1
+        ), "All neurons in the routing group must have the same add potential mode."
+        add_potential = add_potentials.pop()
+        if add_potential == AddPotentialMode.NORMAL:
+            assert (
+                len(input_widths) == 1
+            ), "All neurons in the routing group must have the same input width."
+            # if input width, input sign weight are different, need to split routing group before calling this function
+            input_width = input_widths.pop()
+            self.input_bit_num = 2**input_width
+        else:
+            # if add potential mode is not normal
+            self.input_bit_num = 32  # use 32 bit to transmit potential value
+            max_axon_addr = len(self.input_list) * 32
+
+        max_axon_addr = len(self.input_list) * self.input_bit_num
         lcn = ((max_axon_addr - 1) // FANIN_BASE).bit_length()
         self.lcn = LCN_EX(lcn)
+
+    def get_axon(self, neu: Neuron) -> SourceElem:
+        dest_group = self.dests[neu]
+        if isinstance(dest_group, ReorderGroup):
+            return dest_group.reorder_axon(neu)
+        return neu
+
+    def get_dest_info(self, neu: Neuron) -> tuple["RoutingGroup", int]:
+        dest_group = self.dests[neu]
+        if isinstance(dest_group, ReorderGroup):
+            return dest_group.reorder_dest_info(neu)
+        return dest_group, dest_group.input_list.index(neu)
+
+    def get_dest(self, neu: Neuron) -> "RoutingGroup":
+        dest_group = self.dests[neu]
+        if isinstance(dest_group, ReorderGroup):
+            return dest_group.reorder_dest(neu)
+        return dest_group
+
+    def try_store_neuron(
+        self,
+        neu: Neuron,
+        stored_base_weight: dict[int, tuple[int, WeightCompressType]],
+        current_core: OfflineCorePlacementV2,
+        weight_info: weight_info,
+        base_weights: List[np.ndarray],
+        frontend_core_conf: Frontend_Core_Config,
+        backend_core_conf: Backend_Core_Config,
+    ) -> OfflineCorePlacementV2:
+        # print("\ttrying to store neuron", neu)
+        attrs_part2 = neu.attrs_part2()
+        # Weight Strategy
+        if weight_info.index not in stored_base_weight:
+            # 这个 base weight 还没有存储过，需要存储
+            current_weight_width = frontend_core_conf.weight_width
+            base_weight = base_weights[weight_info.index]
+            current_weight_width = frontend_core_conf.weight_width
+            selected_weight, weight_compress = choose_weight_strategy(
+                base_weight,
+                current_weight_width,
+                frontend_core_conf.input_width,
+                frontend_core_conf.add_potential,
+            )
+            weight_sram_req = selected_weight.n_sram_required()
+            attrs_part2.weight_compress = weight_compress
+            if weight_sram_req > 4096:
+                raise NotImplementedError(
+                    f"Base weight {weight_info.index} requires {weight_sram_req} SRAM lines, which exceeds the limit."
+                )
+            elif current_core.n_sram_required() + weight_sram_req > 4096:
+                # 当前 core 放不下了，需要换 core
+                if len(current_core.neus) > 0:
+                    # print(f"0: current_core({id(current_core)})_sram: {current_core.n_sram_required()}")
+                    # print(f"allocate a new core")
+                    self.core_placements.append(current_core)
+                current_core = OfflineCorePlacementV2(
+                    frontend_core_conf, backend_core_conf
+                )
+                self.last_full_attrs = None  # 换 core 了，之前的 neuron attrs 不算了
+                stored_base_weight.clear()  # 换 core 了，之前存储的 base weight 不算了
+            # print(
+            #     f"Storing base weight {weight_info.index} in core {id(current_core)} with compression {weight_compress} cost {weight_sram_req} SRAM lines."
+            # )
+            current_core.weights.append(selected_weight)
+            stored_base_weight[weight_info.index] = (
+                len(current_core.weights) - 1,
+                weight_compress,
+            )  # 存储这个 base weight 的位置和压缩方式
+
+        # 这个 neu 的 base weight 已经存储过了，直接复用
+        base_weight_idx, weight_compress = stored_base_weight[weight_info.index]
+        attrs_part2.weight_compress = weight_compress
+        neuron_type = (
+            NeuronType.HALF if attrs_part2 == self.last_full_attrs else NeuronType.FULL
+        )
+        output_type = neu.output_type()
+
+        input_width = frontend_core_conf.input_width
+        weight_skew = weight_info.offset * (2**input_width)
+        attrs_part1 = OfflineNeuFullAttrsV2Part1(
+            weight_skew=weight_skew,
+            weight_address_start=0,  # 之后会统一设置
+            weight_address_end=0,  # 之后会统一设置
+            fold_type=FoldType.UNFOLDED,
+            neuron_type=neuron_type,
+            output_type=output_type,
+        )
+        neu_placement = OfflineNeuronPlacement([neu], attrs_part1, attrs_part2)
+        neu_sram_req = neu_placement.n_sram_required()
+        if neu_sram_req > 4096:
+            raise NotImplementedError(
+                f"Neuron {neu} requires {neu_sram_req} SRAM lines, which exceeds the limit."
+            )
+        elif current_core.n_sram_required() + neu_sram_req > 4096:
+            if len(current_core.neus) == 0:
+                raise NotImplementedError(
+                    f"Neuron {neu} with its weight cannot fit into an empty core."
+                )
+            self.core_placements.append(current_core)
+            # print(f"1: current_core({id(current_core)})_sram: {current_core.n_sram_required()}")
+            # print(f"allocate a new core")
+            current_core = OfflineCorePlacementV2(frontend_core_conf, backend_core_conf)
+            self.last_full_attrs = None  # 换 core 了，之前的 neuron attrs 不算了
+            stored_base_weight.clear()  # 换 core 了，之前存储的 base weight 不算了
+            return self.try_store_neuron(
+                neu,
+                stored_base_weight,
+                current_core,
+                weight_info,
+                base_weights,
+                frontend_core_conf,
+                backend_core_conf,
+            )
+        else:
+            if neuron_type == NeuronType.FULL:
+                self.last_full_attrs = attrs_part2
+            current_core.neus.append(neu_placement)
+            # current_core.weights.append(selected_weight)  # weight 已经存储过了，不需要重复存储
+            idx = len(current_core.neus) - 1
+            current_core.neu_weight_map[idx] = (
+                base_weight_idx  # 这个 neu 使用的 weight 是 base_weight_idx
+            )
+        return current_core
+
+    def place_neurons_optimal(
+        self,
+        frontend_core_conf: Frontend_Core_Config,
+        backend_core_conf: Backend_Core_Config,
+        group_items: list[tuple[Neuron, np.ndarray]],
+        block_id: int = 0,
+    ):
+        weights_of_group = [item[1] for item in group_items]
+        weight_infos, base_weights = group_shift_weights_optimized(weights_of_group)
+        # reorder group_items making the ones with the same base weight together, to improve weight storage efficiency
+        reordered_items, reordered_infos = reorder_by_base_weight(
+            group_items, weight_infos
+        )
+
+        # with open(f"{self.name}_weight_base.txt", "w") as f:
+        #     for weight in base_weights:
+        #         f.write(" ".join(map(str, weight)) + "\n")
+        #     for info in reordered_infos:
+        #         f.write(f"index: {info.index}, offset: {info.offset}\n")
+
+        current_core = OfflineCorePlacementV2(frontend_core_conf, backend_core_conf)
+        self.last_full_attrs = None
+        stored_base_weight: dict[int, tuple[int, WeightCompressType]] = (
+            {}
+        )  # map from base weight index to the index of core's weight list where it's stored
+
+        description = f"allocating {self.name} block [{block_id}]"
+        for (neu, weight_of_neu), weight_info in track(
+            zip(reordered_items, reordered_infos),
+            description=description,
+            total=len(reordered_items),  # 明确指定总数，确保进度条计算准确
+        ):
+            current_core = self.try_store_neuron(
+                neu,
+                stored_base_weight,
+                current_core,
+                weight_info,
+                base_weights,
+                frontend_core_conf,
+                backend_core_conf,
+            )
+        if len(current_core.neus) > 0:
+            self.core_placements.append(current_core)
+
+    def place_neurons_raw(
+        self,
+        frontend_core_conf: Frontend_Core_Config,
+        backend_core_conf: Backend_Core_Config,
+        group_items: list[tuple[Neuron, np.ndarray]],
+    ):
+        current_core = OfflineCorePlacementV2(frontend_core_conf, backend_core_conf)
+
+        self.last_full_attrs = None
+
+        for neu, weight_of_neu in group_items:
+            attrs_part2 = neu.attrs_part2()
+
+            # Weight Strategy
+            current_weight_width = frontend_core_conf.weight_width
+            selected_weight, attrs_part2.weight_compress = choose_weight_strategy(
+                weight_of_neu,
+                current_weight_width,
+                frontend_core_conf.input_width,
+                frontend_core_conf.add_potential,
+            )
+
+            neuron_type = (
+                NeuronType.HALF
+                if attrs_part2 == self.last_full_attrs
+                else NeuronType.FULL
+            )
+            output_type = neu.output_type()
+            attrs_part1 = OfflineNeuFullAttrsV2Part1(
+                weight_skew=0,
+                weight_address_start=0,
+                weight_address_end=0,
+                fold_type=FoldType.UNFOLDED,
+                neuron_type=neuron_type,
+                output_type=output_type,
+            )
+            neu_placement = OfflineNeuronPlacement([neu], attrs_part1, attrs_part2)
+
+            # SRAM Check
+            neu_sram_req = neu_placement.n_sram_required()
+            weight_sram_req = selected_weight.n_sram_required()
+            total_req = neu_sram_req + weight_sram_req
+
+            if total_req > 4096:
+                raise NotImplementedError(
+                    f"Neuron {neu} with its weight requires {total_req} SRAM lines."
+                )
+
+            if current_core.n_sram_required() + total_req > 4096:
+                if len(current_core.neus) > 0:
+                    self.core_placements.append(current_core)
+
+                # Create new core with inheritance
+                current_core = OfflineCorePlacementV2(
+                    frontend_core_conf, backend_core_conf
+                )
+                neuron_type = NeuronType.FULL
+                neu_placement.neu_attrs_part1.neuron_type = NeuronType.FULL
+                self.last_full_attrs = attrs_part2
+
+            elif neuron_type == NeuronType.FULL:
+                self.last_full_attrs = attrs_part2
+
+            # print(f"Neuron {neu} assigned type {neu_placement.neuron_type}.")
+            current_core.neus.append(neu_placement)
+            current_core.weights.append(selected_weight)
+
+            idx = len(current_core.neus) - 1
+            current_core.neu_weight_map[idx] = idx
+
+        if len(current_core.neus) > 0:
+            self.core_placements.append(current_core)
+
+    def cached_dest_info(self, neu: Neuron) -> tuple["RoutingGroup", int]:
+        use_cache = False
+        if self.last_dest_group is not None and self.last_dest_index is not None:
+            dest_axon = self.get_axon(neu)
+            next_index = self.last_dest_index + 1
+            if next_index < len(self.last_dest_group.input_list):
+                if self.last_dest_group.input_list[next_index] == dest_axon:
+                    use_cache = True
+                    self.last_dest_index = next_index
+
+        if not use_cache:
+            self.last_dest_group, self.last_dest_index = self.get_dest_info(neu)
+
+        assert (
+            self.last_dest_group is not None and self.last_dest_index is not None
+        ), "Dest group and index should not be None after calling get_dest_info."
+
+        return self.last_dest_group, self.last_dest_index
 
     def allocate_neurons(self):
         """core placement generation"""
@@ -572,7 +515,20 @@ class RoutingGroup:
         # all the attrs in neu_attrs_part2 are valid except weight compress, you should set weight compress according to your weight storage strategy
         # inherited core_config are valid except weight_width, you can set weight_width larger than or equal to the original value for optimization
 
+        if self.nodes is not None and self.input_nodes is not None:
+            node = list(self.nodes)[0]
+            # print(f"kernel weight from node {node.name}:\n", node.weights[0])
+
         weights = get_raw_weights(self.raw_neus, self.input_list)
+
+        # print(f"weight of routing group {self.name}:\n", weights)
+        print(f"weight shape of routing group {self.name}: {weights.shape}")
+
+        # print compelet weights into file for debug
+        # with open(f"{self.name}_weights.txt", "w") as f:
+        #     weights_transposed = weights.T
+        #     for row in weights_transposed:
+        #         f.write(" ".join(map(str, row)) + "\n")
 
         print(
             f"Allocating neurons for Routing Group {self.name} with {len(self.raw_neus)} neurons."
@@ -585,9 +541,10 @@ class RoutingGroup:
         ] = {}
         for i, neu in enumerate(self.raw_neus):
             frontend_core_conf = neu.core_config()
+            dest_rg = self.get_dest(neu)
             backend_core_conf = Backend_Core_Config(
                 lcn=self.lcn,
-                target_lcn=self.dests[neu].lcn,
+                target_lcn=dest_rg.lcn,
             )
             weight_of_neu = weights[i]
             key = (frontend_core_conf, backend_core_conf)
@@ -596,83 +553,25 @@ class RoutingGroup:
             core_groups[key].append((neu, weight_of_neu))
 
         self.core_placements: list[CorePlacement] = []
+        print(f"grouping finished, number of core groups: {len(core_groups)}")
 
         # 2. Allocation Phase
-        for key, group_items in core_groups.items():
+        for i, (key, group_items) in enumerate(core_groups.items()):
+            # print(f"\n\nAllocating group with frontend_core_conf={key[0]}")
+            # print(f"backend_core_conf={key[1]}")
+            # print(f"Neu of this group: {[str(item[0]) for item in group_items]}")
+            print(f"Number of neurons in this group: {len(group_items)}")
             frontend_core_conf, backend_core_conf = key
             # Initialize the first core for the current group
             current_core = OfflineCorePlacementV2(frontend_core_conf, backend_core_conf)
 
-            last_full_attrs = None
-
-            for neu, weight_of_neu in group_items:
-                attrs_part2 = neu.attrs_part2()
-
-                # Weight Strategy
-                current_weight_width = frontend_core_conf.weight_width
-                w_dense = Weight(
-                    weight_of_neu, WeightCompressType.DENSE, current_weight_width
-                )
-                w_sparse = Weight(
-                    weight_of_neu, WeightCompressType.SPARSE, current_weight_width
-                )
-
-                if w_sparse.n_sram_required() < w_dense.n_sram_required():
-                    selected_weight = w_sparse
-                    attrs_part2.weight_compress = WeightCompressType.SPARSE
-                else:
-                    selected_weight = w_dense
-                    attrs_part2.weight_compress = WeightCompressType.DENSE
-
-                neuron_type = (
-                    NeuronType.HALF
-                    if attrs_part2 == last_full_attrs
-                    else NeuronType.FULL
-                )
-                output_type = neu.output_type()
-                attrs_part1 = OfflineNeuFullAttrsV2Part1(
-                    weight_skew=0,
-                    weight_address_start=0,
-                    weight_address_end=0,
-                    fold_type=FoldType.UNFOLDED,
-                    neuron_type=neuron_type,
-                    output_type=output_type,
-                )
-                neu_placement = OfflineNeuronPlacement([neu], attrs_part1, attrs_part2)
-
-                # SRAM Check
-                neu_sram_req = neu_placement.n_sram_required()
-                weight_sram_req = selected_weight.n_sram_required()
-                total_req = neu_sram_req + weight_sram_req
-
-                if total_req > 4096:
-                    raise NotImplementedError(
-                        f"Neuron {neu} with its weight requires {total_req} SRAM lines."
-                    )
-
-                if current_core.n_sram_required() + total_req > 4096:
-                    self.core_placements.append(current_core)
-
-                    # Create new core with inheritance
-                    current_core = OfflineCorePlacementV2(
-                        frontend_core_conf, backend_core_conf
-                    )
-                    neuron_type = NeuronType.FULL
-                    neu_placement.neu_attrs_part1.neuron_type = NeuronType.FULL
-                    last_full_attrs = attrs_part2
-
-                elif neuron_type == NeuronType.FULL:
-                    last_full_attrs = attrs_part2
-
-                # print(f"Neuron {neu} assigned type {neu_placement.neuron_type}.")
-                current_core.neus.append(neu_placement)
-                current_core.weights.append(selected_weight)
-
-                idx = len(current_core.neus) - 1
-                current_core.neu_weight_map[idx] = idx
-
-            if len(current_core.neus) > 0:
-                self.core_placements.append(current_core)
+            self.last_full_attrs = None
+            self.place_neurons_optimal(
+                frontend_core_conf, backend_core_conf, group_items, i
+            )
+            print(
+                f"Number of cores after allocating this group: {len(self.core_placements)}"
+            )
 
         self.n_core_required = len(self.core_placements)
 
@@ -699,15 +598,14 @@ class RoutingGroup:
                 # for folded neuron placement, it may contain multiple raw_neus
                 # but we only need to set dest_info for the first raw_neu
                 main_neu = neu_placement.raw_neus[0]
-                dest_routing_group = self.dests[main_neu]
 
+                dest_routing_group, axon_addr_logic = self.cached_dest_info(main_neu)
                 dest_coord = dest_routing_group.base_coord
                 coord_copy = dest_routing_group.multicast_config
-                axon_addr_logic = dest_routing_group.input_list.index(main_neu)
 
                 # the input width of all cores in dest routing group should be the same,
                 # so we can use the output width of this core as the input width of dest routing group
-                axon_addr_count = axon_addr_logic * (2**core_placement.output_width)
+                axon_addr_count = axon_addr_logic * dest_routing_group.input_bit_num
 
                 addr_axon = axon_addr_count % FANIN_BASE
                 tick_relative = axon_addr_count // FANIN_BASE
@@ -765,9 +663,15 @@ class RoutingGroup:
         info_str = f"{self.name}:\n"
         # if too many dests, only show first 3 and last 3
         dest_strs = []
-        for neu, dest_rg in self.dests.items():
-            dest_strs.append(f"{str(neu)} -> {dest_rg.name}")
-        if len(dest_strs) > 6:
+        if len(self.raw_neus) > 6:
+            print_neus = self.raw_neus[:3] + self.raw_neus[-3:]
+        else:
+            print_neus = self.raw_neus
+
+        for i, neu in enumerate(print_neus):
+            dest_rg, index = self.get_dest_info(neu)
+            dest_strs.append(f"{str(neu)} -> {dest_rg.name}[{index}]")
+        if len(self.raw_neus) > 6:
             dest_strs = dest_strs[:3] + ["..."] + dest_strs[-3:]
         info_str += f"  Number of Neurons: {len(self.raw_neus)}\n"
         info_str += f"  Number of Inputs: {len(self.input_list)}\n"
@@ -786,21 +690,36 @@ class RoutingGroup:
             summary_str += f"  Core Placement {i} at {core_placement.coord}:\n"
             summary_str += f"    Number of Neurons: {len(core_placement.neus)}\n"
             summary_str += f"    Number of Weights: {len(core_placement.weights)}\n"
+            summary_str += (
+                f"    Neuron SRAM Required: {core_placement.neuron_sram_required()}\n"
+            )
+            summary_str += (
+                f"    Weight SRAM Required: {core_placement.weight_sram_required()}\n"
+            )
+            summary_str += (
+                f"    Total SRAM Required: {core_placement.n_sram_required()}\n"
+            )
         return summary_str
 
 
 def toposort_for_rg(
-    routing_groups: list[RoutingGroup],
+    groups: list[ReorderGroup | RoutingGroup],
 ) -> tuple[list[RoutingGroup], dict[int, list[int]]]:
     """topological sort for routing groups based on their dests"""
     from collections import defaultdict, deque
 
+    routing_groups = [rg for rg in groups if isinstance(rg, RoutingGroup)]
+
     indegree = {rg: 0 for rg in routing_groups}
+
+    for rg in indegree.keys():
+        print(f"Routing Group {rg.name} has indegree {indegree[rg]} before sorting.")
     graph = defaultdict(list)
 
     for rg in routing_groups:
-        for dest_rg in rg.dests.values():
-            if dest_rg not in routing_groups:
+        for neu in rg.raw_neus:
+            dest_rg = rg.get_dest(neu)
+            if dest_rg not in routing_groups or dest_rg == rg:
                 continue
             graph[rg].append(dest_rg)
             indegree[dest_rg] += 1

--- a/paibox/backendv2/weight.py
+++ b/paibox/backendv2/weight.py
@@ -4,6 +4,7 @@ from typing import Union
 
 import numpy as np
 from paicorelib import (
+    AddPotentialMode,
     DataWidth,
     FrameArrayType,
     OfflineFrameGenV2,
@@ -24,13 +25,27 @@ class Weight:
         data: Union[np.ndarray, list[int]],
         compress_type: WeightCompressType,
         weight_width: DataWidth,
+        input_width: DataWidth,
+        AddPotential: AddPotentialMode = AddPotentialMode.NORMAL,
     ):
+        if AddPotential == AddPotentialMode.DIRECT_ADD:
+            # in direct add mode, weight width should be at least 4 bit to avoid overflow
+            weight_width = DataWidth.WIDTH_1BIT
+            input_width = DataWidth.WIDTH_32BIT
+            if isinstance(data, list):
+                data = np.array(data, dtype=np.int16)
+            data = data.astype(np.int16)  # ensure weight is in int16 to avoid overflow
+            data = np.repeat(
+                data, 32
+            )  # each one in original weight repeat 32 times to form mask for direct add mode
+
         if isinstance(data, np.ndarray):
             self.raw_weights: list[int] = data.tolist()
         else:
             self.raw_weights: list[int] = list(data)
 
         self.weight_width = weight_width
+        self.input_width = input_width
 
         self.compress: bool = (
             compress_type == WeightCompressType.SPARSE
@@ -59,6 +74,7 @@ class Weight:
     def to_package(self) -> FrameArrayType:
         frames = OfflineFrameGenV2.gen_config_frame3_weight_pkg(
             weight=np.array(self.processed_weights),
+            input_width=self.input_width,
             weight_width=self.weight_width,
             csc_compress=self.compress,
         )

--- a/paibox/paiir/__init__.py
+++ b/paibox/paiir/__init__.py
@@ -56,6 +56,7 @@ from .ir import (
     PAIIRGraph,
     PAIIRNode,
     PotentialAddOp,
+    ReshapeOp,
     SequentialOp,
     SignalDomain,
     StandaloneActOp,


### PR DESCRIPTION
## Summary

This PR introduces weight-skew-aware allocation in `backendv2` so neurons with shifted but otherwise identical weights can reuse a shared base weight instead of storing duplicated weight data per neuron.

To support this flow, the backend now centralizes raw-weight extraction, threads `ReshapeOp` through reorder-aware routing, and carries `add_potential` / input-width semantics into weight packing and core register generation.

## Changes

- add `paibox/backendv2/get_weight.py` to expand raw weights for linear / conv / pooling / add paths and centralize weight compression selection
- add `ReorderNode` / `ReorderGroup` support so `ReshapeOp` can participate in backend routing and destination lookup
- group neurons by base weight and apply per-neuron `weight_skew` during core placement to reuse stored weights more efficiently
- move `add_potential` handling into `Frontend_Core_Config` and update weight packing / register generation for direct-add mode
- add SRAM accounting helpers to make core placement summaries more explicit

## Impact

- reduces repeated weight storage for shifted weight patterns
- keeps reorder / reshape edges consistent during downstream axon-address resolution
- aligns direct-add paths with the correct input-width and weight-serialization behavior