### PR TITLE
Refactor(paiir): clean up lowering flow & AvgPool semantics

### DIFF
--- a/docs/paiir_backend_guide.md
+++ b/docs/paiir_backend_guide.md
@@ -182,7 +182,7 @@ validate_deployable_graph(graph)
 计算图容器，管理节点和有向边。
 
 ```python
-from paibox.paiir import PAIIRGraph
+from paibox.paiir.ir.graph import PAIIRGraph
 
 graph.name: str                        # 图名称
 graph.nodes: dict[str, PAIIRNode]      # 节点字典，key = 节点名
@@ -192,7 +192,7 @@ graph.edges: list[Edge]                # 有向边列表
 ### Edge
 
 ```python
-from paibox.paiir import Edge
+from paibox.paiir.ir.graph import Edge
 
 @dataclass(frozen=True)
 class Edge:
@@ -262,7 +262,8 @@ out_edges: list[Edge] = graph.outgoing_edges("node_name")
 ### 遍历模式
 
 ```python
-from paibox.paiir import OfflineCoreOp, InputNode, OutputNode
+from paibox.paiir.ir.ir_base import InputNode, OutputNode
+from paibox.paiir.ir.op_node import OfflineCoreOp
 
 # 按拓扑序遍历，筛选 OfflineCoreOp
 for name in graph.topo_sort():
@@ -413,7 +414,7 @@ SNN 模式下 `lut_data` 为 `None`。
 #### SequentialOp
 
 ```python
-from paibox.paiir import SequentialOp
+from paibox.paiir.ir.op_node import SequentialOp
 
 seq: SequentialOp
 seq.comp: nn.Module        # 计算模块（Conv2d / Linear / MaxPool2d / AvgPool2d 等）
@@ -426,7 +427,7 @@ seq.lut_data               # LutData | None（含 AvgPool LUT 补偿）
 #### AccumulateOp
 
 ```python
-from paibox.paiir import AccumulateOp
+from paibox.paiir.ir.op_node import AccumulateOp
 
 acc: AccumulateOp
 acc.comps: nn.ModuleList   # 计算模块列表
@@ -450,7 +451,7 @@ acc.lut_data               # LutData | None
 #### PotentialAddOp
 
 ```python
-from paibox.paiir import PotentialAddOp
+from paibox.paiir.ir.add_ops import PotentialAddOp
 
 add: PotentialAddOp
 add.signs: tuple[int, ...]  # 输入符号
@@ -469,7 +470,7 @@ add.weights                  # None（无原始参数）
 #### ConcatOp
 
 ```python
-from paibox.paiir import ConcatOp
+from paibox.paiir.ir.op_node import ConcatOp
 
 cat: ConcatOp
 cat.dim: int  # 拼接维度（通常为 1，即 channel 维）
@@ -485,15 +486,9 @@ input_names = graph.predecessors(cat.name)  # 已按 dst_port 排序
 ### 示例 1：提取部署所需的全部核信息
 
 ```python
-from paibox.paiir import (
-    compile_to_paiir,
-    OfflineCoreOp,
-    SequentialOp,
-    AccumulateOp,
-    ConcatOp,
-    InputNode,
-    OutputNode,
-)
+from paibox.paiir import compile_to_paiir
+from paibox.paiir.ir.ir_base import InputNode, OutputNode
+from paibox.paiir.ir.op_node import AccumulateOp, ConcatOp, OfflineCoreOp, SequentialOp
 
 
 def extract_cores(graph):

--- a/paibox/backendv2/core_config.py
+++ b/paibox/backendv2/core_config.py
@@ -14,7 +14,7 @@ from paicorelib import (
     ZeroOutputMode,
 )
 
-from paibox.paiir import LutData
+from paibox.paiir.ir.calc_params import LutData
 
 TEST_DEST_CORE = CoordXY(0, 0)
 

--- a/paibox/backendv2/get_weight.py
+++ b/paibox/backendv2/get_weight.py
@@ -15,7 +15,7 @@ from rich.progress import track
 from torch import Tensor, nn
 from torch.nn import functional as F
 
-from ..paiir import (
+from ..paiir.ir import (
     AccumulateOp,
     PotentialAddOp,
     SequentialOp,

--- a/paibox/backendv2/op_node.py
+++ b/paibox/backendv2/op_node.py
@@ -9,15 +9,13 @@ from paicorelib import (
 )
 from torch import Tensor, nn
 
-from ..paiir import (
+from ..paiir.ir.add_ops import PotentialAddOp
+from ..paiir.ir.calc_params import LutData, OfflineCoreParams
+from ..paiir.ir.graph import PAIIRGraph
+from ..paiir.ir.ir_base import InputNode, OutputNode
+from ..paiir.ir.op_node import (
     AccumulateOp,
-    InputNode,
-    LutData,
     OfflineCoreOp,
-    OfflineCoreParams,
-    OutputNode,
-    PAIIRGraph,
-    PotentialAddOp,
     ReshapeOp,
     SequentialOp,
     StandaloneActOp,

--- a/paibox/paiir/__init__.py
+++ b/paibox/paiir/__init__.py
@@ -26,52 +26,22 @@ Quick start::
 # Chip-accurate operators and IR entities (public API)
 from .ir import (
     ANNNodeV25,
-    AddOperandKind,
-    AddOperandSpec,
-    AccumulateOp,
-    CPUOp,
-    ConcatOp,
     CoreNeuronV25,
-    Edge,
-    GeneralAddOp,
     IFNodeV25,
-    InputNode,
     LIFNodeV25,
     LutActivation,
     LutAdaptiveActivation,
     LutCustom,
-    LutData,
     LutLinear,
     LutReLU,
     LutSigmoid,
     LutSoftsign,
     LutTanh,
-    NeuronParams,
-    OfflineCoreOp,
-    OfflineCoreParams,
-    OnlineCoreOp,
-    OnlineCoreParams,
-    OpNode,
-    OutputNode,
     PAIIRGraph,
-    PAIIRNode,
-    PotentialAddOp,
-    ReshapeOp,
-    SequentialOp,
-    SignalDomain,
-    StandaloneActOp,
-    StandaloneCompOp,
 )
 
-# Data format inference and compile pipeline
-from .pipeline import (
-    CompileConfig,
-    DataFormat,
-    compile_to_paiir,
-    infer_output_format,
-    infer_weight_format,
-    merge_data_formats,
-)
+# Compile entrypoints
+from .pipeline import CompileConfig, compile_to_paiir
 
 # Conversion entrypoints
 from .lowering import register_neuron, torch_to_paiir
@@ -90,38 +60,8 @@ __all__ = [
     "LutSigmoid",
     "LutTanh",
     "LutSoftsign",
-    # IR base types
-    "PAIIRNode",
-    "InputNode",
-    "OutputNode",
     # Graph
-    "Edge",
     "PAIIRGraph",
-    # Core operator IR nodes
-    "AddOperandKind",
-    "AddOperandSpec",
-    "GeneralAddOp",
-    "OpNode",
-    "OfflineCoreOp",
-    "SequentialOp",
-    "AccumulateOp",
-    "PotentialAddOp",
-    "ConcatOp",
-    "StandaloneCompOp",
-    "StandaloneActOp",
-    "SignalDomain",
-    "OnlineCoreOp",
-    "CPUOp",
-    # Parameters
-    "LutData",
-    "OfflineCoreParams",
-    "NeuronParams",
-    "OnlineCoreParams",
-    # Data format inference
-    "DataFormat",
-    "infer_output_format",
-    "infer_weight_format",
-    "merge_data_formats",
     # Conversion and passes
     "register_neuron",
     "torch_to_paiir",

--- a/paibox/paiir/ir/op_node.py
+++ b/paibox/paiir/ir/op_node.py
@@ -15,7 +15,7 @@ Add-specific IR nodes live in :mod:`paibox.paiir.ir.add_ops`.
 """
 
 from collections.abc import Callable, Sequence
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import torch
 from paicorelib import OutputType, PoolingMode
@@ -24,6 +24,10 @@ from torch import Tensor, nn
 from .calc_params import LutData, NeuronParams, OfflineCoreParams, OnlineCoreParams
 from .core_neuron import CoreNeuronV25
 from .ir_base import PAIIRNode
+from .reshape_semantics import materialize_logical_layout
+
+if TYPE_CHECKING:
+    from ..pipeline.avgpool.metadata import AvgPoolDeployMetadata
 
 __all__ = [
     "OpNode",
@@ -46,6 +50,39 @@ def _ensure_float(x: Tensor) -> Tensor:
     but PyTorch conv/linear require floating-point tensors.
     """
     return x if x.is_floating_point() else x.to(torch.float32)
+
+
+def _run_comp(comp: nn.Module, x: Tensor) -> Tensor:
+    """Execute one compute module with the closest chip-side dtype semantics.
+
+    MaxPool preserves its discrete VALUE-domain code directly on chip, and
+    PyTorch supports integer execution for some MaxPool kernels on CPU. Keep
+    the incoming dtype where possible so standalone/preceding-value MaxPool
+    simulation does not spuriously widen into float.
+
+    ``MaxPool1d`` is a special case on the current PyTorch CPU build: integer
+    ``Byte``/``Char`` inputs raise ``NotImplementedError``. For that case we
+    execute the pool in float32 and cast the exact max values back to the
+    original integer dtype.
+
+    Other compute ops such as Conv/Linear still require floating-point tensors
+    in PyTorch and therefore use :func:`_ensure_float`.
+    """
+    if isinstance(comp, nn.MaxPool1d):
+        if x.is_floating_point():
+            return comp(x)
+        return comp(x.to(torch.float32)).to(x.dtype)
+
+    if isinstance(comp, nn.MaxPool2d):
+        return comp(x)
+    return comp(_ensure_float(x))
+
+
+def _prepare_act_input(act: CoreNeuronV25, x: Tensor) -> Tensor:
+    """Normalize activation input into a membrane-safe dtype when needed."""
+    if act.lut is None and not x.is_floating_point():
+        return x.to(torch.int32)
+    return x
 
 
 def _get_bias(comp: nn.Module) -> Tensor | None:
@@ -229,7 +266,7 @@ class SequentialOp(OfflineCoreOp):
 
     comp: nn.Module
     act: CoreNeuronV25
-    avgpool_deploy_metadata: object | None
+    avgpool_deploy_metadata: "AvgPoolDeployMetadata | None"
 
     def __init__(self, comp: nn.Module, act: CoreNeuronV25) -> None:
         core_params = OfflineCoreParams()
@@ -242,7 +279,7 @@ class SequentialOp(OfflineCoreOp):
         self.avgpool_deploy_metadata = None
 
     def forward(self, x: Tensor) -> Tensor:
-        return self.act(self.comp(_ensure_float(x)))
+        return self.act(_prepare_act_input(self.act, _run_comp(self.comp, x)))
 
     @property
     def weights(self) -> list[Tensor] | None:
@@ -314,11 +351,11 @@ class AccumulateOp(OfflineCoreOp):
     def forward(self, *xs: Tensor) -> Tensor:
         acc: Tensor | None = None
         for sign, op, x in zip(self.signs, self.comps, xs):
-            term = sign * op(_ensure_float(x))
+            term = sign * _run_comp(op, x)
             acc = term if acc is None else acc + term
 
         assert acc is not None, "AccumulateOp requires at least one input"
-        return self.act(acc)
+        return self.act(_prepare_act_input(self.act, acc))
 
     @property
     def weights(self) -> list[Tensor] | None:
@@ -412,6 +449,9 @@ class ReshapeOp(RoutingOp):
         self.shape_fn = shape_fn
 
     def forward(self, x: Tensor) -> Tensor:
+        if len(self.input_dims) == 1:
+            x = materialize_logical_layout(x, self.input_dims[0])
+
         if self.shape_fn is None:
             return x.flatten()
 
@@ -444,7 +484,7 @@ class StandaloneCompOp(OfflineCoreOp):
         self.comp = comp
 
     def forward(self, x: Tensor) -> Tensor:
-        return self.comp(_ensure_float(x))
+        return _run_comp(self.comp, x)
 
     @property
     def weights(self) -> list[Tensor] | None:
@@ -487,13 +527,11 @@ class StandaloneActOp(OfflineCoreOp):
         self.act = act
 
     def forward(self, x: Tensor) -> Tensor:
-        if self.act.lut is None and not x.is_floating_point():
-            # Standalone spike neurons integrate into a signed membrane domain
-            # even when the predecessor emits unsigned VALUEs (for example
-            # split-core AvgPool). Cast here so membrane initialization and
-            # FLOOR/negative-threshold handling do not inherit an unsigned dtype.
-            x = x.to(torch.int32)
-        return self.act(x)
+        # Standalone spike neurons integrate into a signed membrane domain
+        # even when the predecessor emits unsigned VALUEs (for example
+        # split-core AvgPool). Cast here so membrane initialization and
+        # FLOOR/negative-threshold handling do not inherit a narrow integer dtype.
+        return self.act(_prepare_act_input(self.act, x))
 
     @property
     def lut_data(self) -> LutData | None:

--- a/paibox/paiir/ir/reshape_semantics.py
+++ b/paibox/paiir/ir/reshape_semantics.py
@@ -1,0 +1,95 @@
+"""Shared reshape-like semantics used across lowering, IR, and backend code.
+
+This module intentionally stays small and function-oriented. It centralizes
+target classification and pure shape/dims helpers for reshape-like operators
+without introducing another object layer.
+"""
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+from torch import Tensor, nn
+
+__all__ = [
+    "FLATTEN_FUNCTION_TARGETS",
+    "RESHAPE_FUNCTION_TARGETS",
+    "RESHAPE_LEAF_MODULE_TYPES",
+    "RESHAPE_METHOD_NAMES",
+    "SQUEEZE_FUNCTION_TARGETS",
+    "UNSQUEEZE_FUNCTION_TARGETS",
+    "flatten_nested_values",
+    "is_dims_reset_target",
+    "is_identity_dims",
+    "is_identity_repeat_values",
+    "is_squeeze_target",
+    "is_unsqueeze_target",
+    "materialize_logical_layout",
+    "shape_after_dims",
+]
+
+FLATTEN_FUNCTION_TARGETS = (torch.flatten,)
+SQUEEZE_FUNCTION_TARGETS = (torch.squeeze,)
+UNSQUEEZE_FUNCTION_TARGETS = (torch.unsqueeze,)
+RESHAPE_FUNCTION_TARGETS = (torch.reshape,)
+RESHAPE_METHOD_NAMES = frozenset({"flatten", "reshape", "view", "view_as"})
+RESHAPE_LEAF_MODULE_TYPES = (nn.Flatten,)
+
+
+def is_unsqueeze_target(target: Any) -> bool:
+    return target == "unsqueeze" or target in UNSQUEEZE_FUNCTION_TARGETS
+
+
+def is_squeeze_target(target: Any) -> bool:
+    return target == "squeeze" or target in SQUEEZE_FUNCTION_TARGETS
+
+
+def is_dims_reset_target(target: Any) -> bool:
+    return (
+        target in RESHAPE_METHOD_NAMES
+        or is_unsqueeze_target(target)
+        or is_squeeze_target(target)
+    )
+
+
+def flatten_nested_values(values: Iterable[Any]) -> tuple[Any, ...]:
+    flattened: list[Any] = []
+
+    def _flatten(value: Any) -> None:
+        if isinstance(value, (tuple, list, torch.Size)):
+            for item in value:
+                _flatten(item)
+            return
+        flattened.append(value)
+
+    for value in values:
+        _flatten(value)
+
+    return tuple(flattened)
+
+
+def is_identity_repeat_values(values: Iterable[Any]) -> bool:
+    flattened = flatten_nested_values(values)
+    return bool(flattened) and all(
+        isinstance(value, int) and value == 1 for value in flattened
+    )
+
+
+def is_identity_dims(dims: tuple[int, ...]) -> bool:
+    return not dims or dims == tuple(range(len(dims)))
+
+
+def shape_after_dims(
+    shape: tuple[int, ...] | torch.Size, dims: tuple[int, ...]
+) -> tuple[int, ...] | None:
+    if not shape or not dims or len(shape) != len(dims):
+        return None
+    if sorted(dims) != list(range(len(dims))):
+        return None
+    return tuple(shape[axis] for axis in dims)
+
+
+def materialize_logical_layout(x: Tensor, dims: tuple[int, ...]) -> Tensor:
+    """Apply a pending logical axis permutation when metadata requires it."""
+    if is_identity_dims(dims) or x.dim() != len(dims):
+        return x
+    return x.permute(*dims)

--- a/paibox/paiir/ir/reshape_semantics.py
+++ b/paibox/paiir/ir/reshape_semantics.py
@@ -4,6 +4,7 @@ This module intentionally stays small and function-oriented. It centralizes
 target classification and pure shape/dims helpers for reshape-like operators
 without introducing another object layer.
 """
+
 from collections.abc import Iterable
 from typing import Any
 

--- a/paibox/paiir/lowering/conv_lowering.py
+++ b/paibox/paiir/lowering/conv_lowering.py
@@ -1,0 +1,310 @@
+"""Conv-family lowering helpers for both module-form and function-form convs."""
+
+from __future__ import annotations
+
+import operator
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from torch import Tensor, fx, nn
+
+from ..ir.op_node import StandaloneCompOp
+
+__all__ = [
+    "ConvSpec",
+    "build_conv_ir_node",
+    "extract_functional_conv_spec",
+    "extract_module_conv_spec",
+]
+
+
+@dataclass(frozen=True)
+class ConvSpec:
+    """Normalized conv-family lowering result independent of FX source form."""
+
+    input_node: fx.Node
+    module: nn.Conv1d | nn.Conv2d
+    aux_nodes: frozenset[fx.Node] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True)
+class _FunctionalConvLoweringSpec:
+    target_name: str
+    spatial_ndim: int
+
+
+_FUNCTIONAL_CONV_SPECS = {
+    "conv1d": _FunctionalConvLoweringSpec("conv1d", 1),
+    "conv2d": _FunctionalConvLoweringSpec("conv2d", 2),
+}
+
+
+def _get_functional_conv_spec(target: Any) -> _FunctionalConvLoweringSpec | None:
+    return _FUNCTIONAL_CONV_SPECS.get(getattr(target, "__name__", ""))
+
+
+def extract_module_conv_spec(
+    node: fx.Node, module: nn.Module
+) -> ConvSpec | None:
+    if not isinstance(module, (nn.Conv1d, nn.Conv2d)):
+        return None
+    if not node.args or not isinstance(node.args[0], fx.Node):
+        return None
+    return ConvSpec(node.args[0], module)
+
+
+def _is_dtype_getattr(node: fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target is getattr
+        and len(node.args) >= 2
+        and node.args[1] == "dtype"
+    )
+
+
+def _resolve_attr_value(gm: fx.GraphModule, target: str) -> Any:
+    value: Any = gm
+    for atom in target.split("."):
+        value = getattr(value, atom)
+    return value
+
+
+def _get_call_arg(node: fx.Node, index: int, name: str, default: Any = None) -> Any:
+    if len(node.args) > index:
+        return node.args[index]
+    return node.kwargs.get(name, default)
+
+
+def _infer_normalize_arg_type(value: Any) -> Any:
+    if isinstance(value, fx.Node):
+        return Tensor
+    if isinstance(value, tuple):
+        return tuple(type(item) for item in value)
+    if isinstance(value, list):
+        return list[Any]
+    return type(value)
+
+
+def _get_normalized_call_kwargs(
+    node: fx.Node, root: fx.GraphModule
+) -> dict[str, Any] | None:
+    arg_types = tuple(_infer_normalize_arg_type(arg) for arg in node.args)
+    try:
+        normalized = node.normalized_arguments(
+            root, arg_types=arg_types, normalize_to_only_use_kwargs=True
+        )
+    except RuntimeError:
+        return None
+
+    if normalized is None:
+        return None
+
+    return dict(normalized.kwargs)
+
+
+def _resolve_to_aux_nodes(
+    gm: fx.GraphModule, node: fx.Node
+) -> tuple[set[fx.Node] | None, bool]:
+    extra_nodes = {node}
+    for arg in (*node.args[1:], *node.kwargs.values()):
+        if isinstance(arg, fx.Node) and _is_dtype_getattr(arg):
+            extra_nodes.add(arg)
+            continue
+        if isinstance(arg, fx.Node):
+            resolved, extra = _resolve_constant_value(gm, arg)
+            if resolved is None:
+                return None, False
+            extra_nodes |= extra
+    return extra_nodes, True
+
+
+def _resolve_constant_value(
+    gm: fx.GraphModule, value: Any
+) -> tuple[Any | None, set[fx.Node]]:
+    if isinstance(value, fx.Node):
+        if value.op == "get_attr":
+            return _resolve_attr_value(gm, str(value.target)), {value}
+        if value.op == "call_method" and value.target == "to" and value.args:
+            resolved, nodes = _resolve_constant_value(gm, value.args[0])
+            if resolved is None:
+                return None, set()
+
+            extra_nodes, ok = _resolve_to_aux_nodes(gm, value)
+            if not ok or extra_nodes is None:
+                return None, set()
+            return resolved, nodes | extra_nodes
+        if value.op == "call_function" and value.target in (operator.mul, torch.mul):
+            lhs, lhs_nodes = _resolve_constant_value(gm, value.args[0])
+            rhs, rhs_nodes = _resolve_constant_value(gm, value.args[1])
+            if lhs is None or rhs is None:
+                return None, set()
+            return lhs * rhs, lhs_nodes | rhs_nodes | {value}
+        return None, set()
+
+    if isinstance(value, (Tensor, int, float)):
+        return value, set()
+
+    return None, set()
+
+
+def _match_quantized_functional_conv_weight_expr(
+    gm: fx.GraphModule, value: Any
+) -> tuple[Tensor, Tensor | float | int | None, set[fx.Node]] | None:
+    """Match the quantized-weight expression used by customer functional convs."""
+    if isinstance(value, fx.Node):
+        if value.op == "get_attr":
+            resolved = _resolve_attr_value(gm, str(value.target))
+            if isinstance(resolved, Tensor):
+                return resolved.detach().clone(), None, {value}
+            return None
+
+        if value.op == "call_method" and value.target == "to" and value.args:
+            extracted = _match_quantized_functional_conv_weight_expr(gm, value.args[0])
+            if extracted is None:
+                return None
+            weight, scale, nodes = extracted
+            extra_nodes, ok = _resolve_to_aux_nodes(gm, value)
+            if not ok or extra_nodes is None:
+                return None
+            return weight, scale, nodes | extra_nodes
+
+        if value.op == "call_function" and value.target in (operator.mul, torch.mul):
+            lhs = _match_quantized_functional_conv_weight_expr(gm, value.args[0])
+            rhs = _match_quantized_functional_conv_weight_expr(gm, value.args[1])
+            lhs_const, lhs_nodes = _resolve_constant_value(gm, value.args[0])
+            rhs_const, rhs_nodes = _resolve_constant_value(gm, value.args[1])
+
+            if lhs is not None and rhs_const is not None:
+                weight, scale, nodes = lhs
+                merged_scale = rhs_const if scale is None else scale * rhs_const
+                return weight, merged_scale, nodes | rhs_nodes | {value}
+
+            if rhs is not None and lhs_const is not None:
+                weight, scale, nodes = rhs
+                merged_scale = lhs_const if scale is None else scale * lhs_const
+                return weight, merged_scale, nodes | lhs_nodes | {value}
+
+    return None
+
+
+def _infer_functional_conv_channels_and_kernel(
+    weight: Tensor, groups: int, spatial_ndim: int
+) -> tuple[int, int, tuple[int, ...]]:
+    raw_weight = weight.detach()
+    kernel_size = tuple(int(v) for v in raw_weight.shape[-spatial_ndim:])
+    in_channels = int(raw_weight.shape[1]) * groups
+    out_channels = int(raw_weight.shape[0])
+    return in_channels, out_channels, kernel_size
+
+
+def _attach_functional_conv_metadata(
+    conv: nn.Conv1d | nn.Conv2d,
+    weight: Tensor,
+    weight_scale: Tensor | float | int | None,
+    weight_zero_point: Tensor | int | None,
+) -> None:
+    raw_weight = weight.detach().clone()
+    scale = torch.as_tensor(
+        1.0 if weight_scale is None else weight_scale, dtype=torch.float32
+    ).detach()
+    zero_point = torch.as_tensor(
+        0 if weight_zero_point is None else weight_zero_point, dtype=torch.int32
+    ).detach()
+
+    conv.register_buffer("raw_weight", raw_weight)
+    conv.register_buffer("scale", scale)
+    conv.register_buffer("zero_point", zero_point)
+
+
+def _build_functional_conv_module(
+    spec: _FunctionalConvLoweringSpec,
+    weight: Tensor,
+    bias: Tensor | None,
+    stride: int | tuple[int, ...] = 1,
+    padding: int | tuple[int, ...] = 0,
+    dilation: int | tuple[int, ...] = 1,
+    groups: int = 1,
+    weight_scale: Tensor | float | int | None = None,
+    weight_zero_point: Tensor | int | None = None,
+) -> nn.Conv1d | nn.Conv2d:
+    in_channels, out_channels, kernel_size = _infer_functional_conv_channels_and_kernel(
+        weight, groups, spatial_ndim=spec.spatial_ndim
+    )
+
+    module_cls = nn.Conv1d if spec.spatial_ndim == 1 else nn.Conv2d
+    conv = module_cls(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        groups=groups,
+        bias=bias is not None,
+    )
+
+    with torch.no_grad():
+        conv.weight.copy_(weight.detach().to(conv.weight.dtype))
+        conv.weight.requires_grad_(False)
+        if bias is not None and conv.bias is not None:
+            conv.bias.copy_(bias.detach().to(conv.bias.dtype))
+            conv.bias.requires_grad_(False)
+
+    _attach_functional_conv_metadata(conv, weight, weight_scale, weight_zero_point)
+    return conv
+
+
+def extract_functional_conv_spec(
+    gm: fx.GraphModule, node: fx.Node
+) -> ConvSpec | None:
+    """Extract a normalized conv spec from a function-form conv FX node."""
+    spec = _get_functional_conv_spec(node.target)
+    if node.op != "call_function" or spec is None:
+        return None
+
+    normalized_kwargs = _get_normalized_call_kwargs(node, gm)
+    if normalized_kwargs is not None:
+        input_arg = normalized_kwargs.get("input")
+        weight_arg = normalized_kwargs.get("weight")
+        bias_arg = normalized_kwargs.get("bias")
+        stride = normalized_kwargs.get("stride", 1)
+        padding = normalized_kwargs.get("padding", 0)
+        dilation = normalized_kwargs.get("dilation", 1)
+        groups = normalized_kwargs.get("groups", 1)
+    else:
+        input_arg = _get_call_arg(node, 0, "input")
+        weight_arg = _get_call_arg(node, 1, "weight")
+        bias_arg = _get_call_arg(node, 2, "bias")
+        stride = _get_call_arg(node, 3, "stride", 1)
+        padding = _get_call_arg(node, 4, "padding", 0)
+        dilation = _get_call_arg(node, 5, "dilation", 1)
+        groups = _get_call_arg(node, 6, "groups", 1)
+
+    if not isinstance(input_arg, fx.Node) or not isinstance(groups, int):
+        return None
+
+    weight_spec = _match_quantized_functional_conv_weight_expr(gm, weight_arg)
+    if weight_spec is None:
+        return None
+
+    weight, weight_scale, aux_nodes = weight_spec
+    bias_value, bias_nodes = _resolve_constant_value(gm, bias_arg)
+    if bias_value is not None and not isinstance(bias_value, Tensor):
+        return None
+
+    module = _build_functional_conv_module(
+        spec,
+        weight,
+        bias_value,
+        stride,
+        padding,
+        dilation,
+        groups,
+        weight_scale,
+    )
+    return ConvSpec(input_arg, module, frozenset(aux_nodes | bias_nodes))
+
+
+def build_conv_ir_node(spec: ConvSpec) -> tuple[StandaloneCompOp, tuple[fx.Node, ...]]:
+    return StandaloneCompOp(comp=spec.module), (spec.input_node,)

--- a/paibox/paiir/lowering/conv_lowering.py
+++ b/paibox/paiir/lowering/conv_lowering.py
@@ -44,9 +44,7 @@ def _get_functional_conv_spec(target: Any) -> _FunctionalConvLoweringSpec | None
     return _FUNCTIONAL_CONV_SPECS.get(getattr(target, "__name__", ""))
 
 
-def extract_module_conv_spec(
-    node: fx.Node, module: nn.Module
-) -> ConvSpec | None:
+def extract_module_conv_spec(node: fx.Node, module: nn.Module) -> ConvSpec | None:
     if not isinstance(module, (nn.Conv1d, nn.Conv2d)):
         return None
     if not node.args or not isinstance(node.args[0], fx.Node):
@@ -255,9 +253,7 @@ def _build_functional_conv_module(
     return conv
 
 
-def extract_functional_conv_spec(
-    gm: fx.GraphModule, node: fx.Node
-) -> ConvSpec | None:
+def extract_functional_conv_spec(gm: fx.GraphModule, node: fx.Node) -> ConvSpec | None:
     """Extract a normalized conv spec from a function-form conv FX node."""
     spec = _get_functional_conv_spec(node.target)
     if node.op != "call_function" or spec is None:

--- a/paibox/paiir/lowering/converter.py
+++ b/paibox/paiir/lowering/converter.py
@@ -25,6 +25,7 @@ Example::
     graph = torch_to_paiir(model)
 """
 
+import math
 import operator
 import warnings
 from collections.abc import Callable
@@ -43,16 +44,30 @@ from ..ir.graph import PAIIRGraph
 from ..ir.ir_base import InputNode, OutputNode
 from ..ir.lut_activation import LutActivation, LutReLU, LutSigmoid, LutSoftsign, LutTanh
 from ..ir.op_node import ConcatOp, OpNode, ReshapeOp, StandaloneActOp, StandaloneCompOp
+from ..ir.reshape_semantics import RESHAPE_LEAF_MODULE_TYPES
 from .dims_prop import DimsProp, DimsType
+from .shape_analysis import (
+    ReshapeSinkInfo,
+    ShapeAnalysisResult,
+    analyze_shape_helpers,
+)
 
 __all__ = ["torch_to_paiir", "register_neuron"]
 
 ModuleMapper = dict[type[nn.Module], Callable[[nn.Module], OpNode]]
 """Module mapping type: ``nn.Module`` subclass -> converter function returning an :class:`OpNode`."""
 
-# Modules that are kept as leaf nodes but produce no PAIIR node (bypass).
-# Note: Flatten is a bypass - it changes tensor shape but is handled via shape propagation.
-BYPASS_MODULE_TYPES = (nn.BatchNorm1d, nn.BatchNorm2d, nn.Flatten)
+# Modules that are kept in the FX graph but intentionally disappear from PAIIR
+# data flow during lowering.
+LOWERING_BYPASS_MODULE_TYPES = (nn.BatchNorm1d, nn.BatchNorm2d)
+
+# Modules that should remain leaf nodes during FX tracing so lowering can decide
+# how to handle them later.
+#
+# - BatchNorm stays a true bypass at lowering time.
+# - Flatten is preserved as a leaf for tracing, but lowering materializes it as
+#   a ``ReshapeOp`` so graph-level simulation keeps the shape transition.
+TRACE_LEAF_MODULE_TYPES = LOWERING_BYPASS_MODULE_TYPES + RESHAPE_LEAF_MODULE_TYPES
 
 # Modules removed by _EraseModuleTransformer: each call_module node is replaced
 # by its input, leaving no trace in the graph after dead-code elimination.
@@ -64,14 +79,7 @@ CAT_OPS = (torch.cat,)
 
 # Known bypass targets (shape/dim ops that don't need IR nodes)
 KNOWN_BYPASS_FUNCS = (operator.getitem,)
-KNOWN_BYPASS_METHODS = (
-    "flatten",
-    "reshape",
-    "view",
-    "contiguous",
-    "transpose",
-    "permute",
-)
+KNOWN_BYPASS_METHODS = ("size", "contiguous", "transpose", "permute")
 
 
 class FunctionalConv2d(nn.Conv2d):
@@ -82,12 +90,6 @@ class FunctionalConv2d(nn.Conv2d):
     can reconstruct the FX graph semantics accurately. Quantization parameters
     are kept only as optional metadata; exact dequantized simulation is not the
     priority here because the chip backend cannot execute dequantization.
-
-    Preserved metadata:
-
-    - ``raw_weight``: exported graph-side quantized weight tensor
-    - ``scale``: optional quantization scale observed in the FX graph
-    - ``zero_point``: optional quantization zero-point, defaulting to ``0``
     """
 
     def __init__(
@@ -125,9 +127,6 @@ class FunctionalConv2d(nn.Conv2d):
         )
 
         with torch.no_grad():
-            # Keep the native Conv2d surface available for downstream code, but
-            # do not treat this float-cast compatibility weight as authoritative
-            # graph information.
             self.weight.copy_(raw_weight.to(self.weight.dtype))
             self.weight.requires_grad_(False)
             if bias is not None and self.bias is not None:
@@ -140,7 +139,6 @@ class FunctionalConv2d(nn.Conv2d):
 
     @property
     def weight_scale(self) -> Tensor:
-        """Compatibility alias for customer exports that use ``weight_scale``."""
         return self.scale
 
 
@@ -223,13 +221,54 @@ def _is_dtype_getattr(node: fx.Node) -> bool:
     )
 
 
-def _is_shape_getattr(node: fx.Node) -> bool:
-    return (
-        node.op == "call_function"
-        and node.target is getattr
-        and len(node.args) >= 2
-        and node.args[1] == "shape"
+def _make_fixed_shape_fn(
+    target_shape: tuple[int, ...],
+) -> Callable[[torch.Size], torch.Size]:
+    return lambda _input_shape, target=target_shape: torch.Size(target)
+
+
+def _normalize_dim(ndim: int, dim: int) -> int:
+    return dim if dim >= 0 else dim + ndim
+
+
+def _flatten_output_shape(
+    input_shape: torch.Size, start_dim: int, end_dim: int
+) -> torch.Size:
+    ndim = len(input_shape)
+    if ndim == 0:
+        return torch.Size((1,))
+
+    start = _normalize_dim(ndim, start_dim)
+    end = _normalize_dim(ndim, end_dim)
+    if start < 0 or end < 0 or start >= ndim or end >= ndim or start > end:
+        raise ValueError(
+            f"invalid flatten range start_dim={start_dim}, end_dim={end_dim}, ndim={ndim}"
+        )
+
+    flat_size = math.prod(input_shape[start : end + 1])
+    return torch.Size((*input_shape[:start], flat_size, *input_shape[end + 1 :]))
+
+
+def _make_flatten_shape_fn(
+    start_dim: int = 0, end_dim: int = -1
+) -> Callable[[torch.Size], torch.Size]:
+    return lambda input_shape, s=start_dim, e=end_dim: _flatten_output_shape(
+        input_shape, s, e
     )
+
+
+def _build_reshape_op(
+    output_shape: tuple[int, ...],
+    shape_fn: Callable[[torch.Size], torch.Size] | None = None,
+) -> ReshapeOp | None:
+    """Create a ``ReshapeOp`` from analyzed shape metadata or a shape function."""
+    if shape_fn is not None:
+        return ReshapeOp(shape_fn)
+
+    if output_shape:
+        return ReshapeOp(shape_fn=_make_fixed_shape_fn(output_shape))
+
+    return None
 
 
 def _resolve_attr_value(gm: fx.GraphModule, target: str) -> Any:
@@ -251,7 +290,7 @@ def _infer_normalize_arg_type(value: Any) -> Any:
     if isinstance(value, tuple):
         return tuple(type(item) for item in value)
     if isinstance(value, list):
-        return list[type(value[0])] if value else list[Any]
+        return list[Any]
     return type(value)
 
 
@@ -289,38 +328,6 @@ def _resolve_to_aux_nodes(
                 return None, False
             extra_nodes |= extra
     return extra_nodes, True
-
-
-def _collect_shape_aux_nodes(gm: fx.GraphModule) -> set[fx.Node]:
-    """Collect FX nodes that participate only in tensor-shape arithmetic.
-
-    These nodes are needed to validate reshape/view argument expressions but
-    must not reappear as tensor predecessors when wiring the PAIIR data-flow
-    graph. Otherwise shape queries such as ``x.shape[...]`` leak the original
-    input tensor back into unrelated compute/activation nodes.
-    """
-    shape_aux_nodes = {node for node in gm.graph.nodes if _is_shape_getattr(node)}
-    changed = True
-    while changed:
-        changed = False
-        for node in gm.graph.nodes:
-            if node in shape_aux_nodes:
-                continue
-
-            if node.op == "call_function" and node.target is operator.getitem:
-                if any(inp in shape_aux_nodes for inp in node.all_input_nodes):
-                    shape_aux_nodes.add(node)
-                    changed = True
-                    continue
-
-            if node.op == "call_function" and node.target is operator.floordiv:
-                if node.all_input_nodes and all(
-                    inp in shape_aux_nodes for inp in node.all_input_nodes
-                ):
-                    shape_aux_nodes.add(node)
-                    changed = True
-
-    return shape_aux_nodes
 
 
 def _resolve_constant_value(
@@ -481,20 +488,7 @@ def _lower_general_add_ir(
 def _match_quantized_conv_weight_expr(
     gm: fx.GraphModule, value: Any
 ) -> tuple[Tensor, Tensor | float | int | None, set[fx.Node]] | None:
-    """Match the quantized-weight expression used by customer functional convs.
-
-    Supported forms are intentionally narrow and mirror the exported
-    ``QuantizedConv2d.forward()`` pattern:
-
-    - ``get_attr(weight_int8)``
-    - ``weight_expr.to(x.dtype)``
-    - ``weight_expr * constant`` or ``constant * weight_expr``
-
-    Returns the raw graph-side weight tensor, an optional scale-like metadata
-    factor collected from ``mul(...)``, and the FX nodes that belong to this
-    auxiliary weight-construction expression. This is a pattern matcher for the
-    current functional-conv export style, not a general FX expression evaluator.
-    """
+    """Match the quantized-weight expression used by customer functional convs."""
     if isinstance(value, fx.Node):
         if value.op == "get_attr":
             resolved = _resolve_attr_value(gm, str(value.target))
@@ -518,9 +512,6 @@ def _match_quantized_conv_weight_expr(
             lhs_const, lhs_nodes = _resolve_constant_value(gm, value.args[0])
             rhs_const, rhs_nodes = _resolve_constant_value(gm, value.args[1])
 
-            # Only accept weight_expr * constant. Ordinary tensor-tensor mul
-            # should stay visible as a separate FX operator instead of being
-            # absorbed into a conv-weight pattern.
             if lhs is not None and rhs_const is not None:
                 weight, scale, nodes = lhs
                 merged_scale = rhs_const if scale is None else scale * rhs_const
@@ -612,6 +603,31 @@ def _get_input_dims(
         input_nodes if input_nodes is not None else tuple(node.all_input_nodes)
     )
     return [_get_output_dims(inp) for inp in source_nodes]
+
+
+def _build_flatten_ir_node(
+    data_input: fx.Node, start_dim: int, end_dim: int
+) -> tuple[ReshapeOp, tuple[fx.Node, ...]] | None:
+    """Build the normalized PAIIR form for any flatten-style operation."""
+    return (
+        ReshapeOp(shape_fn=_make_flatten_shape_fn(start_dim, end_dim)),
+        (data_input,),
+    )
+
+
+def _build_reshape_like_ir_node(
+    sink_info: ReshapeSinkInfo,
+) -> tuple[ReshapeOp, tuple[fx.Node, ...]] | None:
+    """Lower one analyzed reshape sink to ``ReshapeOp`` and its data input."""
+    if sink_info.kind == "flatten":
+        return _build_flatten_ir_node(
+            sink_info.data_input, sink_info.start_dim, sink_info.end_dim
+        )
+
+    ir_node = _build_reshape_op(sink_info.output_shape)
+    if ir_node is None:
+        return None
+    return ir_node, (sink_info.data_input,)
 
 
 class _PAIIRTracer(fx.Tracer):
@@ -711,8 +727,8 @@ def torch_to_paiir(
     if type(model) in full_map:
         model = nn.Sequential(model)
 
-    # Leaf types = module_map keys + bypass types
-    leaf_types = tuple(full_map.keys()) + BYPASS_MODULE_TYPES
+    # Leaf types = module_map keys + modules that need special post-trace handling.
+    leaf_types = tuple(full_map.keys()) + TRACE_LEAF_MODULE_TYPES
     tracer = _PAIIRTracer(custom_leaf_modules=leaf_types)
     traced = tracer.trace(model, concrete_args)
     gm = fx.GraphModule(tracer.root, traced)
@@ -731,8 +747,9 @@ def torch_to_paiir(
     return _fx_graph_to_paiir(gm, full_map, strict)
 
 
-def _is_bypass_module(mod: nn.Module) -> bool:
-    return isinstance(mod, BYPASS_MODULE_TYPES)
+def _is_lowering_bypass_module(mod: nn.Module) -> bool:
+    """Return whether *mod* should be elided during PAIIR lowering."""
+    return isinstance(mod, LOWERING_BYPASS_MODULE_TYPES)
 
 
 def _fill_shape_dims(
@@ -753,6 +770,7 @@ class _LoweringContext:
     """Shared lowering state for ``FX -> PAIIR`` conversion."""
 
     fx_to_ir: dict[str, str] = field(default_factory=dict)
+    shape_analysis: ShapeAnalysisResult | None = None
     bypass_nodes: set[fx.Node] = field(default_factory=set)
     aux_bypass_nodes: set[fx.Node] = field(default_factory=set)
     ignored_nodes: set[fx.Node] = field(default_factory=set)
@@ -791,6 +809,13 @@ def _register_ir_node(
     """
     if fill_meta:
         _fill_shape_dims(ir_node, fx_node, input_nodes_override=input_nodes_override)
+
+    if input_nodes_override is not None:
+        # Persist the normalized data-input view for the later edge-wiring pass.
+        # Without this, shape-only FX operands such as ``view_as(ref)`` still
+        # appear in ``all_input_nodes`` and can be mis-wired as real data preds.
+        ctx.input_nodes_overrides[fx_node] = input_nodes_override
+
     paiir_graph.add_node(ir_node)
     ctx.fx_to_ir[fx_node.name] = ir_node.name
 
@@ -805,11 +830,23 @@ def _mark_unsupported(
 
 
 def _apply_shape_aux_rule(gm: fx.GraphModule, ctx: _LoweringContext) -> None:
-    ctx.aux_bypass_nodes |= _collect_shape_aux_nodes(gm)
+    """Pre-mark reshape-size helper nodes so they never enter PAIIR data flow."""
+    analysis = analyze_shape_helpers(gm)
+    ctx.shape_analysis = analysis
+    ctx.aux_bypass_nodes |= analysis.aux_nodes
+
+
+def _get_reshape_sink_info(
+    ctx: _LoweringContext, node: fx.Node
+) -> ReshapeSinkInfo | None:
+    analysis = ctx.shape_analysis
+    if analysis is None:
+        return None
+    return analysis.sink_for(node)
 
 
 def _apply_functional_conv_rule(gm: fx.GraphModule, ctx: _LoweringContext) -> None:
-    # Pre-identify function-form conv2d nodes and the helper nodes that build
+    # Pre-identify function-form conv nodes and the helper nodes that build
     # their weight expressions, so lowering can materialize the conv itself
     # while edge wiring ignores these helper nodes as real data producers.
     for node in gm.graph.nodes:
@@ -860,7 +897,29 @@ def _apply_module_lowering_rule(
     torch_module = gm.get_submodule(str(node.target))
     input_override = ctx.input_nodes_overrides.get(node)
 
-    if _is_bypass_module(torch_module):
+    sink_info = _get_reshape_sink_info(ctx, node)
+    if sink_info is not None:
+        built = _build_reshape_like_ir_node(sink_info)
+        if built is None:
+            _mark_unsupported(
+                ctx,
+                node,
+                f"nn.Module '{type(torch_module).__name__}' with unsupported reshape arguments",
+                strict,
+            )
+            return True
+
+        ir_node, reshape_override = built
+        _register_ir_node(
+            paiir_graph,
+            ctx,
+            node,
+            ir_node,
+            input_nodes_override=reshape_override,
+        )
+        return True
+
+    if _is_lowering_bypass_module(torch_module):
         ctx.bypass_nodes.add(node)
         return True
 
@@ -928,6 +987,29 @@ def _apply_builtin_function_lowering_rule(
         _register_ir_node(paiir_graph, ctx, node, ConcatOp(dim=raw_dim))
         return True
 
+    sink_info = _get_reshape_sink_info(ctx, node)
+    if sink_info is not None:
+        built = _build_reshape_like_ir_node(sink_info)
+        if built is None:
+            func_name = getattr(node.target, "__name__", str(node.target))
+            _mark_unsupported(
+                ctx,
+                node,
+                f"function '{func_name}' with unsupported reshape arguments",
+                strict,
+            )
+            return True
+
+        ir_node, input_override = built
+        _register_ir_node(
+            paiir_graph,
+            ctx,
+            node,
+            ir_node,
+            input_nodes_override=input_override,
+        )
+        return True
+
     if node.target in KNOWN_BYPASS_FUNCS:
         ctx.bypass_nodes.add(node)
         return True
@@ -969,10 +1051,26 @@ def _apply_builtin_method_lowering_rule(
         )
         return True
 
-    if node.target == "flatten":
-        # flatten method - create ReshapeOp for simulation
-        # On chip, flatten is implicit (no computation)
-        _register_ir_node(paiir_graph, ctx, node, ReshapeOp())
+    sink_info = _get_reshape_sink_info(ctx, node)
+    if sink_info is not None:
+        built = _build_reshape_like_ir_node(sink_info)
+        if built is None:
+            _mark_unsupported(
+                ctx,
+                node,
+                f"method '{node.target}' with unsupported reshape arguments",
+                strict,
+            )
+            return True
+
+        ir_node, input_override = built
+        _register_ir_node(
+            paiir_graph,
+            ctx,
+            node,
+            ir_node,
+            input_nodes_override=input_override,
+        )
         return True
 
     if node.target in KNOWN_BYPASS_METHODS:

--- a/paibox/paiir/lowering/converter.py
+++ b/paibox/paiir/lowering/converter.py
@@ -45,6 +45,11 @@ from ..ir.ir_base import InputNode, OutputNode
 from ..ir.lut_activation import LutActivation, LutReLU, LutSigmoid, LutSoftsign, LutTanh
 from ..ir.op_node import ConcatOp, OpNode, ReshapeOp, StandaloneActOp, StandaloneCompOp
 from ..ir.reshape_semantics import RESHAPE_LEAF_MODULE_TYPES
+from .conv_lowering import (
+    build_conv_ir_node,
+    extract_functional_conv_spec,
+    extract_module_conv_spec,
+)
 from .dims_prop import DimsProp, DimsType
 from .shape_analysis import (
     ReshapeSinkInfo,
@@ -80,66 +85,6 @@ CAT_OPS = (torch.cat,)
 # Known bypass targets (shape/dim ops that don't need IR nodes)
 KNOWN_BYPASS_FUNCS = (operator.getitem,)
 KNOWN_BYPASS_METHODS = ("size", "contiguous", "transpose", "permute")
-
-
-class FunctionalConv2d(nn.Conv2d):
-    """Thin ``nn.Conv2d`` adapter for FX graphs that materialize ``torch.conv2d``.
-
-    This adapter is intentionally graph-first: it preserves the original
-    exported quantized weight tensor and convolution hyperparameters so PAIIR
-    can reconstruct the FX graph semantics accurately. Quantization parameters
-    are kept only as optional metadata; exact dequantized simulation is not the
-    priority here because the chip backend cannot execute dequantization.
-    """
-
-    def __init__(
-        self,
-        weight: Tensor,
-        bias: Tensor | None,
-        stride: int | tuple[int, int] = 1,
-        padding: int | tuple[int, int] = 0,
-        dilation: int | tuple[int, int] = 1,
-        groups: int = 1,
-        weight_scale: Tensor | float | int | None = None,
-        weight_zero_point: Tensor | int | None = None,
-    ) -> None:
-        raw_weight = weight.detach().clone()
-        scale = torch.as_tensor(
-            1.0 if weight_scale is None else weight_scale, dtype=torch.float32
-        ).detach()
-        zero_point = torch.as_tensor(
-            0 if weight_zero_point is None else weight_zero_point, dtype=torch.int32
-        ).detach()
-
-        kernel_size = tuple(int(v) for v in raw_weight.shape[-2:])
-        in_channels = int(raw_weight.shape[1]) * groups
-        out_channels = int(raw_weight.shape[0])
-
-        super().__init__(
-            in_channels=in_channels,
-            out_channels=out_channels,
-            kernel_size=kernel_size,
-            stride=stride,
-            padding=padding,
-            dilation=dilation,
-            groups=groups,
-            bias=bias is not None,
-        )
-
-        with torch.no_grad():
-            self.weight.copy_(raw_weight.to(self.weight.dtype))
-            self.weight.requires_grad_(False)
-            if bias is not None and self.bias is not None:
-                self.bias.copy_(bias.detach().to(self.bias.dtype))
-                self.bias.requires_grad_(False)
-
-        self.register_buffer("raw_weight", raw_weight)
-        self.register_buffer("scale", scale)
-        self.register_buffer("zero_point", zero_point)
-
-    @property
-    def weight_scale(self) -> Tensor:
-        return self.scale
 
 
 def _map_comp(mod: nn.Module, **kwargs) -> OpNode:
@@ -206,10 +151,6 @@ def _propagate_dims(gm: fx.GraphModule) -> None:
     for determining the number of dimensions).
     """
     DimsProp().propagate(gm)
-
-
-def _is_conv2d_target(target: Any) -> bool:
-    return getattr(target, "__name__", "") == "conv2d"
 
 
 def _is_dtype_getattr(node: fx.Node) -> bool:
@@ -483,91 +424,6 @@ def _lower_general_add_ir(
     _register_ir_node(
         paiir_graph, ctx, node, ir_node, input_nodes_override=input_override
     )
-
-
-def _match_quantized_conv_weight_expr(
-    gm: fx.GraphModule, value: Any
-) -> tuple[Tensor, Tensor | float | int | None, set[fx.Node]] | None:
-    """Match the quantized-weight expression used by customer functional convs."""
-    if isinstance(value, fx.Node):
-        if value.op == "get_attr":
-            resolved = _resolve_attr_value(gm, str(value.target))
-            if isinstance(resolved, Tensor):
-                return resolved.detach().clone(), None, {value}
-            return None
-
-        if value.op == "call_method" and value.target == "to" and value.args:
-            extracted = _match_quantized_conv_weight_expr(gm, value.args[0])
-            if extracted is None:
-                return None
-            weight, scale, nodes = extracted
-            extra_nodes, ok = _resolve_to_aux_nodes(gm, value)
-            if not ok or extra_nodes is None:
-                return None
-            return weight, scale, nodes | extra_nodes
-
-        if value.op == "call_function" and value.target in (operator.mul, torch.mul):
-            lhs = _match_quantized_conv_weight_expr(gm, value.args[0])
-            rhs = _match_quantized_conv_weight_expr(gm, value.args[1])
-            lhs_const, lhs_nodes = _resolve_constant_value(gm, value.args[0])
-            rhs_const, rhs_nodes = _resolve_constant_value(gm, value.args[1])
-
-            if lhs is not None and rhs_const is not None:
-                weight, scale, nodes = lhs
-                merged_scale = rhs_const if scale is None else scale * rhs_const
-                return weight, merged_scale, nodes | rhs_nodes | {value}
-
-            if rhs is not None and lhs_const is not None:
-                weight, scale, nodes = rhs
-                merged_scale = lhs_const if scale is None else scale * lhs_const
-                return weight, merged_scale, nodes | lhs_nodes | {value}
-
-    return None
-
-
-def _build_functional_conv2d_node(
-    gm: fx.GraphModule,
-    node: fx.Node,
-) -> tuple[OpNode, set[fx.Node]] | None:
-    """Build a PAIIR compute node for a supported function-form ``conv2d``."""
-    if node.op != "call_function" or not _is_conv2d_target(node.target):
-        return None
-
-    normalized_kwargs = _get_normalized_call_kwargs(node, gm)
-    if normalized_kwargs is not None:
-        input_arg = normalized_kwargs.get("input")
-        weight_arg = normalized_kwargs.get("weight")
-        bias_arg = normalized_kwargs.get("bias")
-        stride = normalized_kwargs.get("stride", 1)
-        padding = normalized_kwargs.get("padding", 0)
-        dilation = normalized_kwargs.get("dilation", 1)
-        groups = normalized_kwargs.get("groups", 1)
-    else:
-        input_arg = _get_call_arg(node, 0, "input")
-        weight_arg = _get_call_arg(node, 1, "weight")
-        bias_arg = _get_call_arg(node, 2, "bias")
-        stride = _get_call_arg(node, 3, "stride", 1)
-        padding = _get_call_arg(node, 4, "padding", 0)
-        dilation = _get_call_arg(node, 5, "dilation", 1)
-        groups = _get_call_arg(node, 6, "groups", 1)
-
-    if not isinstance(input_arg, fx.Node) or not isinstance(groups, int):
-        return None
-
-    weight_spec = _match_quantized_conv_weight_expr(gm, weight_arg)
-    if weight_spec is None:
-        return None
-
-    weight, weight_scale, aux_nodes = weight_spec
-    bias_value, bias_nodes = _resolve_constant_value(gm, bias_arg)
-    if bias_value is not None and not isinstance(bias_value, Tensor):
-        return None
-
-    comp = FunctionalConv2d(
-        weight, bias_value, stride, padding, dilation, groups, weight_scale
-    )
-    ir_node = StandaloneCompOp(comp=comp)
-    return ir_node, aux_nodes | bias_nodes
 
 
 def _get_output_shape(node: fx.Node) -> tuple[int, ...]:
@@ -850,13 +706,14 @@ def _apply_functional_conv_rule(gm: fx.GraphModule, ctx: _LoweringContext) -> No
     # their weight expressions, so lowering can materialize the conv itself
     # while edge wiring ignores these helper nodes as real data producers.
     for node in gm.graph.nodes:
-        built = _build_functional_conv2d_node(gm, node)
-        if built is None:
+        spec = extract_functional_conv_spec(gm, node)
+        if spec is None:
             continue
 
-        ir_node, aux_nodes = built
+        ir_node, input_override = build_conv_ir_node(spec)
         ctx.prebuilt_ir_nodes[node] = ir_node
-        ctx.aux_bypass_nodes |= aux_nodes
+        ctx.input_nodes_overrides[node] = input_override
+        ctx.aux_bypass_nodes |= set(spec.aux_nodes)
 
 
 def _analyze_graph(gm: fx.GraphModule, ctx: _LoweringContext) -> None:
@@ -896,6 +753,18 @@ def _apply_module_lowering_rule(
 
     torch_module = gm.get_submodule(str(node.target))
     input_override = ctx.input_nodes_overrides.get(node)
+
+    conv_spec = extract_module_conv_spec(node, torch_module)
+    if conv_spec is not None:
+        ir_node, conv_input_override = build_conv_ir_node(conv_spec)
+        _register_ir_node(
+            paiir_graph,
+            ctx,
+            node,
+            ir_node,
+            input_nodes_override=conv_input_override,
+        )
+        return True
 
     sink_info = _get_reshape_sink_info(ctx, node)
     if sink_info is not None:

--- a/paibox/paiir/lowering/converter.py
+++ b/paibox/paiir/lowering/converter.py
@@ -91,6 +91,25 @@ def _map_comp(mod: nn.Module, **kwargs) -> OpNode:
     return StandaloneCompOp(comp=mod, **kwargs)
 
 
+def _has_nonzero_padding(padding: Any) -> bool:
+    if isinstance(padding, tuple):
+        return any(int(p) != 0 for p in padding)
+    return int(padding) != 0
+
+
+def _unsupported_avgpool_description(mod: nn.Module) -> str | None:
+    if not isinstance(mod, (nn.AvgPool1d, nn.AvgPool2d)):
+        return None
+
+    if mod.count_include_pad is False and _has_nonzero_padding(mod.padding):
+        return (
+            f"nn.Module '{type(mod).__name__}' with count_include_pad=False and "
+            "padding>0"
+        )
+
+    return None
+
+
 def _map_sj_ifnode(mod: nn.Module, **kwargs) -> OpNode:
     assert isinstance(mod, neuron.IFNode)
     return StandaloneActOp(act=IFNodeV25(mod.v_threshold, mod.v_reset, **kwargs))
@@ -790,6 +809,12 @@ def _apply_module_lowering_rule(
 
     if _is_lowering_bypass_module(torch_module):
         ctx.bypass_nodes.add(node)
+        return True
+
+    if (
+        unsupported_avgpool := _unsupported_avgpool_description(torch_module)
+    ) is not None:
+        _mark_unsupported(ctx, node, unsupported_avgpool, strict)
         return True
 
     if (mod_type := type(torch_module)) in module_map:

--- a/paibox/paiir/lowering/dims_prop.py
+++ b/paibox/paiir/lowering/dims_prop.py
@@ -14,13 +14,14 @@ from typing import cast
 import torch
 from torch import fx
 
+from ..ir.reshape_semantics import is_dims_reset_target
+
 __all__ = ["DimsProp", "DimsType"]
 
 DimsType = tuple[int, ...]
 
 TRANSPOSE_TARGETS = {torch.transpose, "transpose", "transpose_"}
 PERMUTE_TARGETS = {torch.permute, "permute", "permute_"}
-RESHAPE_TARGETS = {"flatten", "reshape", "view"}
 CONTIGUOUS_TARGETS = {"contiguous", "contiguous_"}
 
 
@@ -71,7 +72,7 @@ class DimsProp:
                 return self._handle_transpose(node)
             if node.target in PERMUTE_TARGETS:
                 return self._handle_permute(node)
-            if node.target in RESHAPE_TARGETS:
+            if is_dims_reset_target(node.target):
                 return self._identity(node)
             if node.target in CONTIGUOUS_TARGETS:
                 return self._inherit(node)

--- a/paibox/paiir/lowering/shape_analysis.py
+++ b/paibox/paiir/lowering/shape_analysis.py
@@ -1,0 +1,423 @@
+"""FX-level analysis for reshape-like sinks and shape-only helper subgraphs.
+
+This module keeps shape reasoning separate from the main PAIIR lowering flow.
+It identifies reshape/flatten sinks, extracts the FX nodes that participate
+only in output-size computation, and returns analysis results that the
+converter can consume when building executable ``ReshapeOp`` routing nodes.
+"""
+
+import operator
+from dataclasses import dataclass
+from typing import Any, Literal, TypeAlias
+
+import torch
+from torch import fx
+
+from ..ir.reshape_semantics import (
+    FLATTEN_FUNCTION_TARGETS,
+    RESHAPE_FUNCTION_TARGETS,
+    RESHAPE_LEAF_MODULE_TYPES,
+    RESHAPE_METHOD_NAMES,
+    SQUEEZE_FUNCTION_TARGETS,
+    UNSQUEEZE_FUNCTION_TARGETS,
+    is_identity_repeat_values,
+)
+
+__all__ = [
+    "FLATTEN_FUNCTION_TARGETS",
+    "RESHAPE_FUNCTION_TARGETS",
+    "RESHAPE_LEAF_MODULE_TYPES",
+    "RESHAPE_METHOD_NAMES",
+    "ShapeAnalysisResult",
+    "ReshapeSinkInfo",
+    "analyze_shape_helpers",
+]
+_SHAPE_EXPR_FUNCTION_TARGETS = (
+    operator.getitem,
+    operator.add,
+    operator.sub,
+    operator.mul,
+    operator.floordiv,
+    operator.truediv,
+    operator.mod,
+    torch.add,
+    torch.sub,
+    torch.mul,
+    torch.div,
+    torch.remainder,
+)
+_SHAPE_EXPR_UNARY_FUNCTION_TARGETS = (operator.neg, operator.pos, torch.neg)
+
+ShapeExprKind: TypeAlias = Literal["scalar", "shape_container", "unknown"]
+
+
+@dataclass(frozen=True, slots=True)
+class ReshapeSinkInfo:
+    """Normalized description of one reshape-like FX node.
+
+    Attributes:
+        kind: The semantic reshape family. ``"flatten"`` means reshape driven by
+            ``start_dim`` / ``end_dim``. ``"reshape"`` means the output shape is
+            already available from FX metadata and the converter can materialize
+            a fixed-shape ``ReshapeOp``.
+        data_input: The real tensor input that should become the sole PAIIR
+            predecessor.
+        shape_seed_nodes: FX nodes that contribute only to output-size
+            computation. These seed the shape-helper subgraph collection.
+        output_shape: Output shape propagated by Torch metadata when available.
+        start_dim: Flatten start dimension for ``kind == "flatten"``.
+        end_dim: Flatten end dimension for ``kind == "flatten"``.
+    """
+
+    kind: Literal["flatten", "reshape"]
+    data_input: fx.Node
+    shape_seed_nodes: tuple[fx.Node, ...]
+    output_shape: tuple[int, ...]
+    start_dim: int = 0
+    end_dim: int = -1
+
+
+@dataclass(frozen=True, slots=True)
+class ShapeAnalysisResult:
+    """Public analysis result consumed by the main converter pipeline.
+
+    Attributes:
+        reshape_sinks: FX nodes that should lower to ``ReshapeOp`` and their
+            normalized sink metadata.
+        aux_nodes: FX nodes that participate only in reshape-size reasoning and
+            must be ignored by PAIIR data-flow lowering/wiring.
+    """
+
+    reshape_sinks: dict[fx.Node, ReshapeSinkInfo]
+    aux_nodes: set[fx.Node]
+
+    def sink_for(self, node: fx.Node) -> ReshapeSinkInfo | None:
+        return self.reshape_sinks.get(node)
+
+    def is_aux(self, node: fx.Node) -> bool:
+        return node in self.aux_nodes
+
+
+def analyze_shape_helpers(gm: fx.GraphModule) -> ShapeAnalysisResult:
+    """Analyze reshape-like sinks and the FX nodes used only for shape math."""
+    reshape_sinks = _analyze_reshape_sinks(gm)
+    shape_aux_nodes = _collect_shape_aux_nodes(reshape_sinks)
+    return ShapeAnalysisResult(reshape_sinks, shape_aux_nodes)
+
+
+def _analyze_reshape_sinks(gm: fx.GraphModule) -> dict[fx.Node, ReshapeSinkInfo]:
+    sinks: dict[fx.Node, ReshapeSinkInfo] = {}
+
+    for node in gm.graph.nodes:
+        info = _build_reshape_sink_info(gm, node)
+        if info is not None:
+            sinks[node] = info
+
+    return sinks
+
+
+def _build_reshape_sink_info(
+    gm: fx.GraphModule, node: fx.Node
+) -> ReshapeSinkInfo | None:
+    if node.op == "call_module":
+        torch_module = gm.get_submodule(str(node.target))
+        if not isinstance(torch_module, RESHAPE_LEAF_MODULE_TYPES):
+            return None
+        if not node.args or not isinstance(node.args[0], fx.Node):
+            return None
+
+        return ReshapeSinkInfo(
+            "flatten",
+            node.args[0],
+            (),
+            _extract_tensor_output_shape(node),
+            torch_module.start_dim,
+            torch_module.end_dim,
+        )
+
+    if not node.args or not isinstance(node.args[0], fx.Node):
+        return None
+
+    data_input = node.args[0]
+
+    if node.op == "call_method":
+        if node.target == "flatten":
+            return ReshapeSinkInfo(
+                "flatten",
+                data_input,
+                (),
+                _extract_tensor_output_shape(node),
+                _get_call_arg(node, 1, "start_dim", 0),
+                _get_call_arg(node, 2, "end_dim", -1),
+            )
+
+        if node.target == "unsqueeze":
+            return ReshapeSinkInfo(
+                "reshape",
+                data_input,
+                (),
+                _extract_tensor_output_shape(node),
+            )
+
+        if node.target == "squeeze":
+            return ReshapeSinkInfo(
+                "reshape",
+                data_input,
+                (),
+                _extract_tensor_output_shape(node),
+            )
+
+        if node.target == "repeat" and _is_identity_repeat(node):
+            return ReshapeSinkInfo(
+                "reshape",
+                data_input,
+                (),
+                _extract_tensor_output_shape(node),
+            )
+
+        if node.target in RESHAPE_METHOD_NAMES:
+            return ReshapeSinkInfo(
+                "reshape",
+                data_input,
+                tuple(_reshape_shape_seed_nodes(node)),
+                _extract_tensor_output_shape(node),
+            )
+        return None
+
+    if node.op == "call_function":
+        if node.target in FLATTEN_FUNCTION_TARGETS:
+            return ReshapeSinkInfo(
+                "flatten",
+                data_input,
+                (),
+                _extract_tensor_output_shape(node),
+                _get_call_arg(node, 1, "start_dim", 0),
+                _get_call_arg(node, 2, "end_dim", -1),
+            )
+
+        if node.target in SQUEEZE_FUNCTION_TARGETS:
+            return ReshapeSinkInfo(
+                "reshape",
+                data_input,
+                (),
+                _extract_tensor_output_shape(node),
+            )
+
+        if node.target in UNSQUEEZE_FUNCTION_TARGETS:
+            return ReshapeSinkInfo(
+                "reshape",
+                data_input,
+                (),
+                _extract_tensor_output_shape(node)
+            )
+
+        if node.target in RESHAPE_FUNCTION_TARGETS:
+            return ReshapeSinkInfo(
+                "reshape",
+                data_input,
+                tuple(_reshape_shape_seed_nodes(node)),
+                _extract_tensor_output_shape(node),
+            )
+
+    return None
+
+
+def _is_identity_repeat(node: fx.Node) -> bool:
+    repeat_values = [*node.args[1:], *node.kwargs.values()]
+    return is_identity_repeat_values(repeat_values)
+
+
+def _reshape_shape_seed_nodes(node: fx.Node) -> list[fx.Node]:
+    """Return the non-data FX arguments that define a reshape output size."""
+    args = list(node.args)
+    kwargs = list(node.kwargs.values())
+    non_data_values = [*args[1:], *kwargs]
+
+    seeds: list[fx.Node] = []
+    seen: set[fx.Node] = set()
+    for value in non_data_values:
+        for maybe_node in _iter_nested_fx_nodes(value):
+            if maybe_node not in seen:
+                seeds.append(maybe_node)
+                seen.add(maybe_node)
+    return seeds
+
+
+def _iter_nested_fx_nodes(value: Any) -> list[fx.Node]:
+    """Collect FX nodes recursively from tuple/list/dict-shaped arguments."""
+    if isinstance(value, fx.Node):
+        return [value]
+    if isinstance(value, (tuple, list)):
+        nodes: list[fx.Node] = []
+        for item in value:
+            nodes.extend(_iter_nested_fx_nodes(item))
+        return nodes
+    if isinstance(value, dict):
+        nodes: list[fx.Node] = []
+        for item in value.values():
+            nodes.extend(_iter_nested_fx_nodes(item))
+        return nodes
+    return []
+
+
+def _extract_tensor_output_shape(node: fx.Node) -> tuple[int, ...]:
+    """Return output tensor shape using Torch-propagated metadata when available."""
+    tensor_meta = node.meta.get("tensor_meta")
+    if tensor_meta is not None and hasattr(tensor_meta, "shape"):
+        return tuple(tensor_meta.shape)
+
+    val = node.meta.get("val")
+    if isinstance(val, torch.Tensor):
+        return tuple(val.shape)
+
+    return ()
+
+
+def _get_call_arg(node: fx.Node, index: int, name: str, default: Any = None) -> Any:
+    if len(node.args) > index:
+        return node.args[index]
+    return node.kwargs.get(name, default)
+
+
+def _collect_shape_aux_nodes(
+    reshape_sinks: dict[fx.Node, ReshapeSinkInfo],
+) -> set[fx.Node]:
+    """Collect FX nodes used only to compute reshape-like output sizes.
+
+    The collection is conservative: after gathering the backward slice from
+    reshape shape-seeds, a user-closure pruning step removes any node whose
+    value is also consumed by a non-shape user elsewhere in the FX graph.
+    """
+    shape_aux_nodes: set[fx.Node] = set()
+    kind_cache: dict[fx.Node, ShapeExprKind] = {}
+
+    for info in reshape_sinks.values():
+        for seed in info.shape_seed_nodes:
+            _collect_shape_aux_nodes_from_seed(seed, shape_aux_nodes, kind_cache)
+
+    return _prune_nonlocal_shape_users(shape_aux_nodes, set(reshape_sinks))
+
+
+def _collect_shape_aux_nodes_from_seed(
+    seed: fx.Node, collected: set[fx.Node], kind_cache: dict[fx.Node, ShapeExprKind]
+) -> None:
+    """Recursively collect upstream shape-only helpers from one shape seed."""
+    if seed in collected or _infer_shape_expr_kind(seed, kind_cache) == "unknown":
+        return
+
+    collected.add(seed)
+    for inp in seed.all_input_nodes:
+        _collect_shape_aux_nodes_from_seed(inp, collected, kind_cache)
+
+
+def _prune_nonlocal_shape_users(
+    candidate_nodes: set[fx.Node], reshape_sink_nodes: set[fx.Node]
+) -> set[fx.Node]:
+    """Drop candidates that are also consumed by non-shape users.
+
+    A node is shape-aux only if every FX user stays inside the candidate
+    subgraph or directly belongs to a reshape sink. This prevents shared nodes
+    from being silently ignored when they also feed a real computation/output
+    path elsewhere in the graph.
+    """
+    kept = set(candidate_nodes)
+    changed = True
+
+    while changed:
+        changed = False
+        for node in tuple(kept):
+            if any(
+                user not in kept and user not in reshape_sink_nodes
+                for user in node.users
+            ):
+                kept.remove(node)
+                changed = True
+
+    return kept
+
+
+def _infer_shape_expr_kind(
+    node: fx.Node, cache: dict[fx.Node, ShapeExprKind]
+) -> ShapeExprKind:
+    """Infer whether an FX node semantically behaves like a shape expression.
+
+    Torch-propagated metadata is the first information source. If metadata is
+    not specific enough, fall back to a lightweight semantic analysis of the
+    node's operator and the inferred kinds of its inputs.
+    """
+    if node in cache:
+        return cache[node]
+
+    kind = _shape_expr_kind_from_value(node.meta.get("val"))
+    if kind == "unknown":
+        if _is_shape_getattr(node):
+            kind = "shape_container"
+        elif _is_size_method(node):
+            kind = "scalar"
+        elif node.op == "call_function":
+            kind = _infer_call_function_shape_expr_kind(node, cache)
+
+    cache[node] = kind
+    return kind
+
+
+def _infer_call_function_shape_expr_kind(
+    node: fx.Node, cache: dict[fx.Node, ShapeExprKind]
+) -> ShapeExprKind:
+    """Infer shape-expression kind for a call_function node from its semantics."""
+    if node.target is operator.getitem:
+        base_kind = _shape_expr_kind_from_value(_get_call_arg(node, 0, "input"), cache)
+        index_kind = _shape_expr_kind_from_value(_get_call_arg(node, 1, "index"), cache)
+        if base_kind == "shape_container" and index_kind in {"scalar", "unknown"}:
+            return "scalar"
+        return "unknown"
+
+    if node.target in _SHAPE_EXPR_UNARY_FUNCTION_TARGETS:
+        operand_kind = _shape_expr_kind_from_value(
+            _get_call_arg(node, 0, "input"), cache
+        )
+        return "scalar" if operand_kind == "scalar" else "unknown"
+
+    if node.target in _SHAPE_EXPR_FUNCTION_TARGETS:
+        operand_values = [*node.args, *node.kwargs.values()]
+        if operand_values and all(
+            _shape_expr_kind_from_value(value, cache) == "scalar"
+            for value in operand_values
+        ):
+            return "scalar"
+
+    return "unknown"
+
+
+def _shape_expr_kind_from_value(
+    value: Any, cache: dict[fx.Node, ShapeExprKind] | None = None
+) -> ShapeExprKind:
+    """Classify a Python/FX value as scalar shape, shape container, or unknown."""
+    if isinstance(value, fx.Node):
+        if cache is None:
+            cache = {}
+        return _infer_shape_expr_kind(value, cache)
+
+    if isinstance(value, bool):
+        return "unknown"
+    if isinstance(value, (int, torch.SymInt)):
+        return "scalar"
+    if isinstance(value, torch.Size):
+        return "shape_container"
+    if isinstance(value, (tuple, list)):
+        if all(_shape_expr_kind_from_value(item, cache) == "scalar" for item in value):
+            return "shape_container"
+    return "unknown"
+
+
+def _is_shape_getattr(node: fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target is getattr
+        and len(node.args) >= 2
+        and node.args[1] == "shape"
+    )
+
+
+def _is_size_method(node: fx.Node) -> bool:
+    return node.op == "call_method" and node.target == "size"

--- a/paibox/paiir/lowering/shape_analysis.py
+++ b/paibox/paiir/lowering/shape_analysis.py
@@ -205,10 +205,7 @@ def _build_reshape_sink_info(
 
         if node.target in UNSQUEEZE_FUNCTION_TARGETS:
             return ReshapeSinkInfo(
-                "reshape",
-                data_input,
-                (),
-                _extract_tensor_output_shape(node)
+                "reshape", data_input, (), _extract_tensor_output_shape(node)
             )
 
         if node.target in RESHAPE_FUNCTION_TARGETS:

--- a/paibox/paiir/pipeline/__init__.py
+++ b/paibox/paiir/pipeline/__init__.py
@@ -1,26 +1,8 @@
 """PAIIR compile-time pipeline utilities."""
 
 from .compile import CompileConfig, compile_to_paiir
-from .data_format import (
-    DataFormat,
-    infer_output_format,
-    infer_weight_format,
-    merge_data_formats,
-)
-from .passes import (
-    propagate_signal_domain,
-    specialize_general_adds,
-    validate_deployable_graph,
-)
 
 __all__ = [
     "CompileConfig",
-    "DataFormat",
     "compile_to_paiir",
-    "infer_output_format",
-    "infer_weight_format",
-    "merge_data_formats",
-    "propagate_signal_domain",
-    "specialize_general_adds",
-    "validate_deployable_graph",
 ]

--- a/paibox/paiir/pipeline/avgpool/__init__.py
+++ b/paibox/paiir/pipeline/avgpool/__init__.py
@@ -1,16 +1,6 @@
 """AvgPool-specific deployment logic for PAIIR."""
 
 from .calibration import CalibrationResult, calibrate_avgpool_threshold
-from .compensation import (
-    apply_avgpool_leak_params,
-    apply_avgpool_lut_compensation,
-    apply_avgpool_snn_compensation,
-    apply_sumpool_snn_compensation,
-    compensate_avgpool_lut,
-    compensate_avgpool_lut_for_sumpool,
-    compensate_avgpool_neuron,
-    compensate_sumpool_neuron,
-)
 from .deploy_scheme import (
     AvgPoolDeployScheme,
     AvgPoolLIFCandidateScore,
@@ -18,25 +8,15 @@ from .deploy_scheme import (
     select_avgpool_lif_candidate,
     select_avgpool_lif_deployment,
 )
-from .metadata import AvgPoolDeployMetadata
 from .pass_ops import calibrate_avgpool_thresholds
 
 __all__ = [
     "AvgPoolDeployScheme",
-    "AvgPoolDeployMetadata",
     "AvgPoolLIFCandidateScore",
     "CalibrationResult",
-    "apply_avgpool_leak_params",
-    "apply_avgpool_lut_compensation",
-    "apply_avgpool_snn_compensation",
-    "apply_sumpool_snn_compensation",
     "calibrate_avgpool_threshold",
     "calibrate_avgpool_thresholds",
     "score_avgpool_lif_candidates",
     "select_avgpool_lif_candidate",
     "select_avgpool_lif_deployment",
-    "compensate_avgpool_lut",
-    "compensate_avgpool_lut_for_sumpool",
-    "compensate_avgpool_neuron",
-    "compensate_sumpool_neuron",
 ]

--- a/paibox/paiir/pipeline/avgpool/calibration.py
+++ b/paibox/paiir/pipeline/avgpool/calibration.py
@@ -109,6 +109,7 @@ def calibrate_avgpool_threshold(
     act: CoreNeuronV25,
     window_size: int,
     baseline_thres: int,
+    avg_divisor: int | None = None,
     calibration_input: Tensor | None = None,
     n_steps: int = 32,
     input_range: tuple[int, int] | None = None,
@@ -124,6 +125,8 @@ def calibrate_avgpool_threshold(
     """
     if baseline_thres < 0:
         raise ValueError(f"baseline_thres must be non-negative, got {baseline_thres}")
+    if avg_divisor is None:
+        avg_divisor = window_size
 
     if calibration_input is None:
         if input_range is None:
@@ -146,7 +149,7 @@ def calibrate_avgpool_threshold(
     # Reference branch: the same sampled sequence interpreted in the AvgPool
     # domain, i.e. divide the sampled sum-domain current back by window_size.
     ref_spikes = _simulate_ideal_lif(
-        calibration_input / window_size,
+        calibration_input / avg_divisor,
         tau,
         act.thres_pos,
         reset_v,

--- a/paibox/paiir/pipeline/avgpool/compensation.py
+++ b/paibox/paiir/pipeline/avgpool/compensation.py
@@ -50,8 +50,11 @@ def compensate_avgpool_lut(lut: LutData, window_size: int) -> LutData:
     scaled = lut.thresholds.float() * scale
     if not lut.is_float:
         scaled.round_()
-    lut.thresholds = scaled.to(lut.thresholds.dtype)
-    return lut
+    return LutData(
+        thresholds=scaled.to(lut.thresholds.dtype),
+        values=lut.values,
+        is_float=lut.is_float,
+    )
 
 
 def compensate_avgpool_neuron(
@@ -80,8 +83,11 @@ def compensate_avgpool_neuron(
 
 def compensate_avgpool_lut_for_sumpool(lut: LutData, window_size: int) -> LutData:
     """Move a LUT from AvgPool domain into SumPool domain."""
-    lut.thresholds = lut.thresholds * window_size
-    return lut
+    return LutData(
+        thresholds=lut.thresholds * window_size,
+        values=lut.values,
+        is_float=lut.is_float,
+    )
 
 
 def compensate_sumpool_neuron(

--- a/paibox/paiir/pipeline/avgpool/deploy_scheme.py
+++ b/paibox/paiir/pipeline/avgpool/deploy_scheme.py
@@ -102,7 +102,7 @@ def _make_eval_sum_input_bank(
 
 def _shared_core_baseline_threshold(
     act: CoreNeuronV25,
-    window_size: int,
+    avg_divisor: int,
     decay_input: bool,
 ) -> int:
     """Return the analytically compensated shared-core threshold."""
@@ -113,7 +113,7 @@ def _shared_core_baseline_threshold(
             reset_v=act.reset_v,
             init_v=act.init_v,
         ),
-        window_size,
+        avg_divisor,
         decay_input,
         act.tau,
     )
@@ -141,7 +141,7 @@ def _simulate_shared_core_candidate(
 
 def _simulate_split_core_candidate(
     act: CoreNeuronV25,
-    window_size: int,
+    avg_divisor: int,
     probe_sum_input: torch.Tensor,
     decay_input: bool,
 ) -> torch.Tensor:
@@ -153,7 +153,7 @@ def _simulate_split_core_candidate(
             reset_v=act.reset_v,
             init_v=act.init_v,
         ),
-        window_size,
+        avg_divisor,
     )
     return _simulate_quantized_lif(
         probe_sum_input,
@@ -171,6 +171,7 @@ def _score_candidate_over_probes(
     uses_calibration: bool,
     act: CoreNeuronV25,
     window_size: int,
+    avg_divisor: int,
     probe_sum_inputs: Sequence[torch.Tensor],
     decay_input: bool,
     resource_cost: float,
@@ -185,7 +186,7 @@ def _score_candidate_over_probes(
 
     for probe_sum_input in probe_sum_inputs:
         ref_spikes = _simulate_ideal_lif(
-            probe_sum_input / window_size,
+            probe_sum_input / avg_divisor,
             act.tau,
             act.thres_pos,
             act.reset_v,
@@ -220,6 +221,7 @@ def score_avgpool_lif_candidates(
     window_size: int,
     allow_split_lif: bool = False,
     try_calibration: bool = False,
+    avg_divisor: int | None = None,
     *,
     n_probe_steps: int = _LIF_PROBE_STEPS,
     probe_seeds: tuple[int, ...] | None = None,
@@ -246,11 +248,13 @@ def score_avgpool_lif_candidates(
     - quality: compare mean firing-rate errors against the ideal reference
     - cost: a fixed resource penalty for split-core execution
     """
+    if avg_divisor is None:
+        avg_divisor = window_size
     decay_input = act.leak_multi_input == LeakMultiInputMode.ENABLE
     probe_sum_inputs = _make_eval_sum_input_bank(
         pred_out_width, window_size, n_probe_steps, probe_seeds
     )
-    baseline_thres = _shared_core_baseline_threshold(act, window_size, decay_input)
+    baseline_thres = _shared_core_baseline_threshold(act, avg_divisor, decay_input)
 
     def simulate_shared_baseline(probe_sum_input: torch.Tensor) -> torch.Tensor:
         return _simulate_shared_core_candidate(act, probe_sum_input, baseline_thres)
@@ -261,6 +265,7 @@ def score_avgpool_lif_candidates(
             False,
             act,
             window_size,
+            avg_divisor,
             probe_sum_inputs,
             decay_input,
             0.0,
@@ -275,7 +280,8 @@ def score_avgpool_lif_candidates(
                 act,
                 window_size,
                 baseline_thres,
-                probe_sum_input,
+                avg_divisor=avg_divisor,
+                calibration_input=probe_sum_input,
                 decay_input=decay_input,
             ).best_thres
             return _simulate_shared_core_candidate(act, probe_sum_input, best_thres)
@@ -286,6 +292,7 @@ def score_avgpool_lif_candidates(
                 True,
                 act,
                 window_size,
+                avg_divisor,
                 probe_sum_inputs,
                 decay_input,
                 0.0,
@@ -297,7 +304,7 @@ def score_avgpool_lif_candidates(
 
         def simulate_split_core(probe_sum_input: torch.Tensor) -> torch.Tensor:
             return _simulate_split_core_candidate(
-                act, window_size, probe_sum_input, decay_input
+                act, avg_divisor, probe_sum_input, decay_input
             )
 
         candidates.append(
@@ -306,6 +313,7 @@ def score_avgpool_lif_candidates(
                 False,
                 act,
                 window_size,
+                avg_divisor,
                 probe_sum_inputs,
                 decay_input,
                 _SPLIT_CORE_RESOURCE_COST,
@@ -322,6 +330,7 @@ def select_avgpool_lif_candidate(
     window_size: int,
     allow_split_lif: bool = False,
     try_calibration: bool = False,
+    avg_divisor: int | None = None,
     *,
     n_probe_steps: int = _LIF_PROBE_STEPS,
     probe_seeds: tuple[int, ...] | None = None,
@@ -333,6 +342,7 @@ def select_avgpool_lif_candidate(
         window_size,
         allow_split_lif,
         try_calibration,
+        avg_divisor,
         n_probe_steps=n_probe_steps,
         probe_seeds=probe_seeds,
     )
@@ -352,6 +362,7 @@ def select_avgpool_lif_deployment(
     window_size: int,
     allow_split_lif: bool = False,
     try_calibration: bool = False,
+    avg_divisor: int | None = None,
     *,
     n_probe_steps: int = _LIF_PROBE_STEPS,
     probe_seeds: tuple[int, ...] | None = None,
@@ -374,6 +385,7 @@ def select_avgpool_lif_deployment(
         window_size,
         allow_split_lif,
         try_calibration,
+        avg_divisor,
         n_probe_steps=n_probe_steps,
         probe_seeds=probe_seeds,
     )

--- a/paibox/paiir/pipeline/avgpool/fusion.py
+++ b/paibox/paiir/pipeline/avgpool/fusion.py
@@ -192,9 +192,7 @@ def _try_handle_avgpool_activation(
         shared = _materialize_shared_sequential(
             pred_name, pred, act_name, act_node, consumed, node_remap
         )
-        _prepare_shared_avgpool_ann_params(
-            cast(ANNNodeV25, shared.act), avg_divisor
-        )
+        _prepare_shared_avgpool_ann_params(cast(ANNNodeV25, shared.act), avg_divisor)
         return shared
 
     if act_node.act.has_if_dynamics:

--- a/paibox/paiir/pipeline/avgpool/fusion.py
+++ b/paibox/paiir/pipeline/avgpool/fusion.py
@@ -33,18 +33,18 @@ from .compensation import (
 )
 from .deploy_scheme import AvgPoolDeployScheme, select_avgpool_lif_candidate
 from .metadata import AvgPoolDeployMetadata
-from .utils import _get_pool_window_size, _is_avgpool
+from .utils import _get_avgpool_divisor, _get_pool_window_size, _is_avgpool
 
 __all__ = [
     "_try_handle_avgpool_activation",
 ]
 
 
-def _prepare_shared_avgpool_ann_params(act: ANNNodeV25, window_size: int) -> None:
+def _prepare_shared_avgpool_ann_params(act: ANNNodeV25, avg_divisor: int) -> None:
     """Write shared-core ANN AvgPool deployment parameters into the live node."""
     assert act.lut is not None
-    apply_avgpool_lut_compensation(act.lut, window_size)
-    shift = round(math.log2(window_size))
+    apply_avgpool_lut_compensation(act.lut, avg_divisor)
+    shift = round(math.log2(avg_divisor))
     act.leak_tau = -shift
     act.leak_multi_input = LeakMultiInputMode.ENABLE
     act.leak_multi_mode = LeakMultiMode.DISABLE
@@ -52,7 +52,7 @@ def _prepare_shared_avgpool_ann_params(act: ANNNodeV25, window_size: int) -> Non
 
 
 def _prepare_shared_avgpool_lif_params(
-    node: SequentialOp, window_size: int, uses_calibration: bool
+    node: SequentialOp, avg_divisor: int, uses_calibration: bool
 ) -> None:
     """Write shared-core LIF deployment params or calibration prerequisites."""
     source_decay_input = node.act.leak_multi_input == LeakMultiInputMode.ENABLE
@@ -61,17 +61,17 @@ def _prepare_shared_avgpool_lif_params(
     )
     apply_avgpool_snn_compensation(
         node.act,
-        window_size,
+        avg_divisor,
         decay_input=source_decay_input,
         calibrated=uses_calibration,
     )
 
 
 def _prepare_split_avgpool_lif_core2_params(
-    act_node: StandaloneActOp, window_size: int
+    act_node: StandaloneActOp, avg_divisor: int
 ) -> None:
     """Write split-core LIF Core 2 params into the sum domain."""
-    apply_sumpool_snn_compensation(act_node.act, window_size)
+    apply_sumpool_snn_compensation(act_node.act, avg_divisor)
 
 
 def _infer_avgpool_pred_output_format(
@@ -102,7 +102,7 @@ def _infer_avgpool_pred_output_format(
 
 
 def _build_split_avgpool_core1_lut(
-    out_width: DataWidth, window_size: int, *, emit_exact_sum_code: bool
+    out_width: DataWidth, avg_divisor: int, *, emit_exact_sum_code: bool
 ) -> LutCustom:
     """Build the Core 1 LUT used by split-core AvgPool deployment."""
     if emit_exact_sum_code:
@@ -128,7 +128,7 @@ def _build_split_avgpool_core1_lut(
         # IF split-core path: Core 1 converts the pooled sum into the downstream
         # IF input domain. The LUT therefore behaves like a thresholded mapper
         # rather than a raw sum pass-through.
-        thresholds = torch.arange(256, dtype=torch.int32) * window_size
+        thresholds = torch.arange(256, dtype=torch.int32) * avg_divisor
         values = torch.cat(
             [torch.zeros(1, dtype=torch.int8), torch.ones(255, dtype=torch.int8)]
         )
@@ -188,11 +188,12 @@ def _try_handle_avgpool_activation(
     if not act_node.act.is_snn:
         # ANN activations only need static AvgPool gain compensation, so the
         # regular shared-core SequentialOp remains the preferred topology.
+        avg_divisor = _get_avgpool_divisor(pred.comp)
         shared = _materialize_shared_sequential(
             pred_name, pred, act_name, act_node, consumed, node_remap
         )
         _prepare_shared_avgpool_ann_params(
-            cast(ANNNodeV25, shared.act), _get_pool_window_size(pred.comp)
+            cast(ANNNodeV25, shared.act), avg_divisor
         )
         return shared
 
@@ -200,10 +201,10 @@ def _try_handle_avgpool_activation(
         # IF must split: shared-core AvgPool would enable leak on the neuron
         # datapath and turn the downstream behavior into LIF-like dynamics.
         _, out_width = _infer_avgpool_pred_output_format(graph, pred_name)
-        window_size = _get_pool_window_size(pred.comp)
+        avg_divisor = _get_avgpool_divisor(pred.comp)
 
         core1_lut = _build_split_avgpool_core1_lut(
-            out_width, window_size, emit_exact_sum_code=False
+            out_width, avg_divisor, emit_exact_sum_code=False
         )
         return _materialize_split_avgpool_pair(
             pred_name, pred, act_name, act_node, consumed, node_remap, core1_lut
@@ -216,16 +217,18 @@ def _try_handle_avgpool_activation(
         )
 
     _, out_width = _infer_avgpool_pred_output_format(graph, pred_name)
-    window_size = _get_pool_window_size(pred.comp)
+    sum_window_size = _get_pool_window_size(pred.comp)
+    avg_divisor = _get_avgpool_divisor(pred.comp)
 
     # LIF is the only case where both shared-core & split-core can be valid.
     # Delegate the final topology choice to the AvgPool deployment policy.
     best_candidate = select_avgpool_lif_candidate(
         act_node.act,
         out_width,
-        window_size,
+        sum_window_size,
         enable_split_avgpool_lif,
         try_calibration=enable_avgpool_calibration,
+        avg_divisor=avg_divisor,
     )
     if best_candidate.scheme == AvgPoolDeployScheme.SHARED_CORE:
         # Default/compatible case: keep AvgPool and LIF on the same core and
@@ -234,18 +237,18 @@ def _try_handle_avgpool_activation(
             pred_name, pred, act_name, act_node, consumed, node_remap
         )
         _prepare_shared_avgpool_lif_params(
-            shared, window_size, best_candidate.uses_calibration
+            shared, avg_divisor, best_candidate.uses_calibration
         )
         return shared
 
     # SPLIT_CORE_LIF_EXACT_SUM
     core1_lut = _build_split_avgpool_core1_lut(
-        out_width, window_size, emit_exact_sum_code=True
+        out_width, avg_divisor, emit_exact_sum_code=True
     )
     split_pair = _materialize_split_avgpool_pair(
         pred_name, pred, act_name, act_node, consumed, node_remap, core1_lut
     )
-    _prepare_split_avgpool_lif_core2_params(act_node, window_size)
+    _prepare_split_avgpool_lif_core2_params(act_node, avg_divisor)
     return split_pair
 
 

--- a/paibox/paiir/pipeline/avgpool/pass_ops.py
+++ b/paibox/paiir/pipeline/avgpool/pass_ops.py
@@ -5,7 +5,7 @@ from paicorelib import LeakMultiInputMode
 from ...ir.graph import PAIIRGraph
 from ...ir.op_node import SequentialOp
 from .calibration import CalibrationResult, calibrate_avgpool_threshold
-from .utils import _get_pool_window_size, _is_avgpool
+from .utils import _get_avgpool_divisor, _get_pool_window_size, _is_avgpool
 
 __all__ = ["calibrate_avgpool_thresholds"]
 
@@ -29,7 +29,8 @@ def calibrate_avgpool_thresholds(
         if not node.act.has_lif_dynamics:
             continue
 
-        window_size = _get_pool_window_size(node.comp)
+        sum_window_size = _get_pool_window_size(node.comp)
+        avg_divisor = _get_avgpool_divisor(node.comp)
         avgpool_deploy_metadata = node.avgpool_deploy_metadata
         if (
             avgpool_deploy_metadata is not None
@@ -43,16 +44,19 @@ def calibrate_avgpool_thresholds(
         )
         # Baseline starts from the analytic shared-core rule; the calibration
         # sweep only searches a neighbourhood around this integer threshold.
-        factor = window_size if source_decay_input else window_size / node.act.tau
+        factor = avg_divisor if source_decay_input else avg_divisor / node.act.tau
         baseline = round(
             node.act.reset_v + (node.act.thres_pos - node.act.reset_v) * factor
         )
-        node_input_range = input_range if input_range is not None else (0, window_size)
+        node_input_range = (
+            input_range if input_range is not None else (0, sum_window_size)
+        )
 
         result = calibrate_avgpool_threshold(
             node.act,
-            window_size,
+            sum_window_size,
             baseline,
+            avg_divisor=avg_divisor,
             n_steps=n_steps,
             input_range=node_input_range,
             search_ratio=search_ratio,

--- a/paibox/paiir/pipeline/avgpool/utils.py
+++ b/paibox/paiir/pipeline/avgpool/utils.py
@@ -1,22 +1,25 @@
 """Internal helpers for AvgPool-related deployment logic."""
 
 import math
+from typing import TypeAlias, TypeGuard
 
 import torch.nn as nn
 
 from ...nn import SumPool1d, SumPool2d
 
-__all__ = ["_get_pool_window_size", "_is_avgpool"]
+__all__ = ["_get_avgpool_divisor", "_get_pool_window_size", "_is_avgpool"]
 
 
-def _is_avgpool(comp: nn.Module) -> bool:
+PoolWindowModule: TypeAlias = nn.AvgPool1d | nn.AvgPool2d | SumPool1d | SumPool2d
+
+
+def _is_avgpool(comp: nn.Module) -> TypeGuard[nn.AvgPool1d | nn.AvgPool2d]:
     """Check if a compute module is an average-pooling op."""
     return isinstance(comp, (nn.AvgPool1d, nn.AvgPool2d))
 
 
-def _get_pool_window_size(comp: nn.Module) -> int:
+def _get_pool_window_size(comp: PoolWindowModule) -> int:
     """Return the number of elements in the pooling window."""
-    assert isinstance(comp, (nn.AvgPool1d, nn.AvgPool2d, SumPool1d, SumPool2d))
     ks = comp.kernel_size
     if isinstance(ks, int):
         if isinstance(comp, (nn.AvgPool2d, SumPool2d)):
@@ -24,3 +27,12 @@ def _get_pool_window_size(comp: nn.Module) -> int:
         else:
             ks = (ks,)
     return math.prod(ks)
+
+
+def _get_avgpool_divisor(comp: nn.AvgPool1d | nn.AvgPool2d) -> int:
+    """Return the effective AvgPool divisor used by the frontend module."""
+    divisor_override = comp.divisor_override if isinstance(comp, nn.AvgPool2d) else None
+    if divisor_override is not None:
+        return int(divisor_override)
+
+    return _get_pool_window_size(comp)

--- a/paibox/paiir/pipeline/passes.py
+++ b/paibox/paiir/pipeline/passes.py
@@ -15,11 +15,13 @@ Two validation stages live in this module:
   final graph that will be returned to callers.
 """
 
+import math
 import warnings
-from typing import TypedDict
+from typing import TypedDict, TypeGuard
 
 import torch
 from paicorelib import DataSign, DataWidth, OutputType, SNNMode
+from torch import nn
 
 from ..exceptions import GraphCleanupWarning, GraphValidationError
 from ..ir.add_ops import GeneralAddOp, PotentialAddOp
@@ -35,6 +37,7 @@ from ..ir.op_node import (
     StandaloneActOp,
     StandaloneCompOp,
 )
+from ..ir.reshape_semantics import shape_after_dims
 from ..ir.signal_domain import SignalDomain
 from .avgpool import calibrate_avgpool_thresholds
 from .avgpool.calibration import CalibrationResult
@@ -445,6 +448,12 @@ def validate_compiled_graph(graph: PAIIRGraph) -> None:
         if node.output_domain is None:
             errors.append(f"OpNode '{name}' is missing output_domain")
 
+        if isinstance(node, ConcatOp):
+            _validate_concat_contract(errors, graph, name, node)
+
+        if isinstance(node, ReshapeOp):
+            _validate_reshape_contract(errors, graph, name, node)
+
         if isinstance(node, PotentialAddOp):
             _validate_potential_add_contract(errors, graph, name, node)
 
@@ -465,6 +474,133 @@ def validate_compiled_graph(graph: PAIIRGraph) -> None:
 
     if errors:
         raise GraphValidationError(errors)
+
+
+def _get_node_output_shape(node: PAIIRNode) -> tuple[int, ...]:
+    if isinstance(node, InputNode):
+        return node.shape
+    if isinstance(node, OutputNode):
+        return node.shape
+    if isinstance(node, OpNode):
+        return node.output_shape
+    return ()
+
+
+def _validate_concat_contract(
+    errors: list[str], graph: PAIIRGraph, name: str, node: ConcatOp
+) -> None:
+    preds = graph.predecessors(name)
+    pred_shapes = [_get_node_output_shape(graph.nodes[p]) for p in preds]
+
+    if len(preds) < 1:
+        errors.append(f"ConcatOp '{name}' must define at least one input path")
+        return
+
+    if node.input_shapes and len(node.input_shapes) != len(preds):
+        errors.append(
+            f"ConcatOp '{name}' has {len(node.input_shapes)} input_shapes but "
+            f"{len(preds)} predecessor(s)"
+        )
+        return
+
+    if node.input_shapes:
+        mismatched = [
+            (pred, pred_shape, expected_shape)
+            for pred, pred_shape, expected_shape in zip(
+                preds, pred_shapes, node.input_shapes
+            )
+            if pred_shape and pred_shape != expected_shape
+        ]
+        if mismatched:
+            details = ", ".join(
+                f"{pred}: pred_output_shape={pred_shape}, input_shape={expected_shape}"
+                for pred, pred_shape, expected_shape in mismatched
+            )
+            errors.append(f"ConcatOp '{name}' predecessor shape mismatch: {details}")
+            return
+
+        ranks = {len(shape) for shape in node.input_shapes if shape}
+        if len(ranks) > 1:
+            errors.append(
+                f"ConcatOp '{name}' requires same-rank operands, got {node.input_shapes}"
+            )
+            return
+
+        if ranks:
+            rank = next(iter(ranks))
+            dim = node.dim if node.dim >= 0 else node.dim + rank
+            if dim < 0 or dim >= rank:
+                errors.append(
+                    f"ConcatOp '{name}' has invalid concat dim={node.dim} for rank {rank}"
+                )
+                return
+
+            base_shape = list(node.input_shapes[0])
+            concat_extent = 0
+            for shape in node.input_shapes:
+                if any(
+                    shape[axis] != base_shape[axis]
+                    for axis in range(rank)
+                    if axis != dim
+                ):
+                    errors.append(
+                        f"ConcatOp '{name}' non-concat dims differ across inputs: {node.input_shapes}"
+                    )
+                    return
+                concat_extent += shape[dim]
+
+            expected_output = tuple(
+                concat_extent if axis == dim else base_shape[axis]
+                for axis in range(rank)
+            )
+            if node.output_shape and expected_output != node.output_shape:
+                errors.append(
+                    f"ConcatOp '{name}' output_shape mismatch: "
+                    f"expected {expected_output}, got {node.output_shape}"
+                )
+
+
+def _validate_reshape_contract(
+    errors: list[str], graph: PAIIRGraph, name: str, node: ReshapeOp
+) -> None:
+    preds = graph.predecessors(name)
+    if len(preds) != 1:
+        errors.append(
+            f"ReshapeOp '{name}' must have exactly one predecessor, got {len(preds)}"
+        )
+        return
+
+    pred_shape = _get_node_output_shape(graph.nodes[preds[0]])
+    if node.input_shapes and len(node.input_shapes) != 1:
+        errors.append(
+            f"ReshapeOp '{name}' has {len(node.input_shapes)} input_shapes (expected 1)"
+        )
+        return
+
+    if node.input_shapes and pred_shape:
+        expected_input_shape = node.input_shapes[0]
+        if pred_shape != expected_input_shape:
+            logical_pred_shape = None
+            if len(node.input_dims) == 1:
+                logical_pred_shape = shape_after_dims(pred_shape, node.input_dims[0])
+
+            if logical_pred_shape != expected_input_shape:
+                details = f"pred_output_shape={pred_shape}, input_shape={expected_input_shape}"
+                if logical_pred_shape is not None:
+                    details += f", pred_shape_after_input_dims={logical_pred_shape}"
+                errors.append(
+                    f"ReshapeOp '{name}' predecessor shape mismatch: {details}"
+                )
+                return
+
+    if node.input_shapes and node.output_shape:
+        in_numel = math.prod(node.input_shapes[0])
+        out_numel = math.prod(node.output_shape)
+        if in_numel != out_numel:
+            errors.append(
+                f"ReshapeOp '{name}' changes element count: "
+                f"input_shape={node.input_shapes[0]}, output_shape={node.output_shape}"
+            )
 
 
 def propagate_signal_domain(graph: PAIIRGraph) -> None:
@@ -542,6 +678,11 @@ def propagate_signal_domain(graph: PAIIRGraph) -> None:
                 )
                 continue
             node.output_domain = SignalDomain.POTENTIAL
+            continue
+
+        if _is_standalone_maxpool(node):
+            if known_pred_domains:
+                node.output_domain = known_pred_domains[0]
             continue
 
         if isinstance(node, OfflineCoreOp):
@@ -746,24 +887,72 @@ _DEFAULT_ANN_INPUT: DataFormat = (DataSign.SIGNED, DataWidth.WIDTH_8BIT)
 _WEIGHTLESS_WEIGHT_FORMAT: DataFormat = (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT)
 
 
+def _is_standalone_maxpool(node: PAIIRNode) -> TypeGuard[StandaloneCompOp]:
+    return isinstance(node, StandaloneCompOp) and isinstance(
+        node.comp, (nn.MaxPool1d, nn.MaxPool2d)
+    )
+
+
+def _is_format_transparent_routing_node(
+    node: PAIIRNode
+) -> TypeGuard[ConcatOp | ReshapeOp]:
+    """Return whether *node* preserves scalar data format across routing."""
+    return isinstance(node, (ConcatOp, ReshapeOp))
+
+
 def propagate_data_format(
     graph: PAIIRGraph, input_formats: dict[str, DataFormat] | None = None
 ) -> None:
-    """Infer and fill data format parameters on every :class:`OfflineCoreOp`."""
+    """Infer and write data-format fields on every :class:`OfflineCoreOp`.
+
+    This pass fills the three backend-facing format groups stored in
+    :class:`~paibox.paiir.ir.calc_params.OfflineCoreParams`:
+
+    - ``input_sign`` / ``input_width``
+    - ``output_sign`` / ``output_width``
+    - ``weight_sign`` / ``weight_width``
+
+    The propagation is intentionally split into two topological passes:
+
+    1. Seed an effective format for every external input, then assign each
+       deployable core's intrinsic output format and weight format.
+    2. Propagate those resolved formats through routing-only nodes
+       (:class:`ConcatOp`, :class:`ReshapeOp`, :class:`OutputNode`) and finally
+       back-fill each deployable core's input format from its predecessors.
+
+    The ordering matters because a core's input format depends on the already
+    resolved output formats of its predecessors, while many cores can determine
+    their own output format directly from their activation semantics.
+
+    Args:
+        graph: Fused PAIIR graph whose node connectivity has already been
+            validated.
+        input_formats: Optional mapping from ``InputNode`` name to explicit
+            external input format. Any omitted input falls back to
+            :func:`_infer_input_node_default`.
+    """
     if input_formats is None:
         input_formats = {}
 
     input_node_names = {
         n for n, node in graph.nodes.items() if isinstance(node, InputNode)
     }
+    # Warn early if the caller passed a boundary-name override that does not
+    # correspond to the current graph, but keep processing valid entries.
     for name in input_formats:
         if name not in input_node_names:
             warnings.warn(
                 f"input_formats key '{name}' does not match any InputNode in the graph"
             )
 
+    # Effective data format per graph node, including routing-only nodes and
+    # graph boundaries. This is separate from `core_params`, which only exists
+    # on deployable offline-core operators.
     resolved: dict[str, DataFormat] = {}
 
+    # Pass 1: establish each deployable core's own output and weight formats.
+    # This gives later consumers a stable predecessor-output view before we
+    # compute per-core input formats.
     for name in graph.topo_sort():
         node = graph.nodes[name]
 
@@ -776,29 +965,39 @@ def propagate_data_format(
             continue
         if isinstance(node, OutputNode):
             continue
-        if isinstance(node, (ConcatOp, ReshapeOp)):
+        if _is_format_transparent_routing_node(node):
+            # Routing nodes have no `core_params`; their effective formats are
+            # propagated in the second pass after predecessor outputs are known.
             continue
         if not isinstance(node, OfflineCoreOp):
             continue
 
-        out_fmt = _infer_node_output_format(node)
+        pred_formats = _collect_effective_predecessor_formats(graph, name, resolved)
+        out_fmt = _infer_node_output_format(node, pred_formats)
         node.core_params.set_output_format(out_fmt)
         resolved[name] = out_fmt
 
         w_fmt = _infer_node_weight_format(node)
         node.core_params.set_weight_format(w_fmt)
 
+    # Pass 2: thread those resolved formats through non-deploy routing nodes
+    # and then back-fill each deployable core's input format from predecessor
+    # outputs.
     for name in graph.topo_sort():
         node = graph.nodes[name]
 
         if isinstance(node, (InputNode, OutputNode)):
             if isinstance(node, OutputNode):
+                # Output nodes are pure pass-through graph boundaries: they
+                # inherit the effective format of their sole predecessor.
                 preds = graph.predecessors(name)
                 if preds and preds[0] in resolved:
                     resolved[name] = resolved[preds[0]]
             continue
 
         if isinstance(node, ConcatOp):
+            # Concat preserves element encoding and therefore resolves to the
+            # merged predecessor format.
             pred_formats = [
                 resolved[p] for p in graph.predecessors(name) if p in resolved
             ]
@@ -807,6 +1006,7 @@ def propagate_data_format(
             continue
 
         if isinstance(node, ReshapeOp):
+            # Reshape/view/flatten do not change the scalar representation.
             preds = graph.predecessors(name)
             if preds and preds[0] in resolved:
                 resolved[name] = resolved[preds[0]]
@@ -820,6 +1020,34 @@ def propagate_data_format(
         node.core_params.set_input_format(in_fmt)
 
 
+def _collect_effective_predecessor_formats(
+    graph: PAIIRGraph, node_name: str, resolved: dict[str, DataFormat]
+) -> list[DataFormat]:
+    formats: list[DataFormat] = []
+    for pred_name in graph.predecessors(node_name):
+        formats.extend(_collect_effective_node_formats(graph, pred_name, resolved))
+
+    return formats
+
+
+def _collect_effective_node_formats(
+    graph: PAIIRGraph,
+    node_name: str,
+    resolved: dict[str, DataFormat],
+) -> list[DataFormat]:
+    if node_name in resolved:
+        return [resolved[node_name]]
+
+    node = graph.nodes[node_name]
+    if _is_format_transparent_routing_node(node):
+        formats: list[DataFormat] = []
+        for pred_name in graph.predecessors(node_name):
+            formats.extend(_collect_effective_node_formats(graph, pred_name, resolved))
+        return formats
+
+    return []
+
+
 def _infer_input_node_default(graph: PAIIRGraph, name: str) -> DataFormat:
     succs = graph.successors(name)
     for succ_name in succs:
@@ -831,7 +1059,16 @@ def _infer_input_node_default(graph: PAIIRGraph, name: str) -> DataFormat:
     return _DEFAULT_ANN_INPUT
 
 
-def _infer_node_output_format(node: OfflineCoreOp) -> DataFormat:
+def _infer_node_output_format(
+    node: OfflineCoreOp, pred_formats: list[DataFormat] | None = None
+) -> DataFormat:
+    if _is_standalone_maxpool(node):
+        if not pred_formats:
+            raise ValueError(
+                f"Standalone MaxPool '{node.name}' requires predecessor format"
+            )
+        return merge_data_formats(pred_formats)
+
     act = getattr(node, "act", None)
     if act is not None:
         return infer_output_format(act)

--- a/paibox/paiir/pipeline/passes.py
+++ b/paibox/paiir/pipeline/passes.py
@@ -894,7 +894,7 @@ def _is_standalone_maxpool(node: PAIIRNode) -> TypeGuard[StandaloneCompOp]:
 
 
 def _is_format_transparent_routing_node(
-    node: PAIIRNode
+    node: PAIIRNode,
 ) -> TypeGuard[ConcatOp | ReshapeOp]:
     """Return whether *node* preserves scalar data format across routing."""
     return isinstance(node, (ConcatOp, ReshapeOp))

--- a/poetry.lock
+++ b/poetry.lock
@@ -913,6 +913,35 @@ url = "https://pypi.tuna.tsinghua.edu.cn/simple"
 reference = "tsinghua"
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147"},
+    {file = "markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "markdown-it-pyrs", "mistletoe (>=1.0,<2.0)", "mistune (>=3.0,<4.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins (>=0.5.0)"]
+profiling = ["gprof2dot"]
+rtd = ["ipykernel", "jupyter_sphinx", "mdit-py-plugins (>=0.5.0)", "myst-parser", "pyyaml", "sphinx", "sphinx-book-theme (>=1.0,<2.0)", "sphinx-copybutton", "sphinx-design"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "requests"]
+
+[package.source]
+type = "legacy"
+url = "https://pypi.tuna.tsinghua.edu.cn/simple"
+reference = "tsinghua"
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -1101,6 +1130,23 @@ url = "https://pypi.tuna.tsinghua.edu.cn/simple"
 reference = "tsinghua"
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
+
+[package.source]
+type = "legacy"
+url = "https://pypi.tuna.tsinghua.edu.cn/simple"
+reference = "tsinghua"
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 description = "Python library for arbitrary-precision floating-point arithmetic"
@@ -1185,7 +1231,7 @@ description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
-markers = "python_version < \"3.14\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb"},
     {file = "numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90"},
@@ -1256,7 +1302,7 @@ description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
 groups = ["main", "dev"]
-markers = "python_version >= \"3.14\""
+markers = "python_version >= \"3.11\""
 files = [
     {file = "numpy-2.4.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:33b3bf58ee84b172c067f56aeadc7ee9ab6de69c5e800ab5b10295d54c581adb"},
     {file = "numpy-2.4.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8ba7b51e71c05aa1f9bc3641463cd82308eab40ce0d5c7e1fd4038cbf9938147"},
@@ -1330,524 +1376,6 @@ files = [
     {file = "numpy-2.4.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e236dbda4e1d319d681afcbb136c0c4a8e0f1a5c58ceec2adebb547357fe857"},
     {file = "numpy-2.4.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:4b42639cdde6d24e732ff823a3fa5b701d8acad89c4142bc1d0bd6dc85200ba5"},
     {file = "numpy-2.4.3.tar.gz", hash = "sha256:483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cublas-cu12"
-version = "12.1.3.1"
-description = "CUBLAS native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "python_version < \"3.12\" and platform_machine == \"x86_64\" and platform_system == \"Linux\""
-files = [
-    {file = "nvidia_cublas_cu12-12.1.3.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:ee53ccca76a6fc08fb9701aa95b6ceb242cdaab118c3bb152af4e579af792728"},
-    {file = "nvidia_cublas_cu12-12.1.3.1-py3-none-win_amd64.whl", hash = "sha256:2b964d60e8cf11b5e1073d179d85fa340c120e99b3067558f3cf98dd69d02906"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cublas-cu12"
-version = "12.6.4.1"
-description = "CUBLAS native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08ed2686e9875d01b58e3cb379c6896df8e76c75e0d4a7f7dace3d7b6d9ef8eb"},
-    {file = "nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:235f728d6e2a409eddf1df58d5b0921cf80cfa9e72b9f2775ccb7b4a87984668"},
-    {file = "nvidia_cublas_cu12-12.6.4.1-py3-none-win_amd64.whl", hash = "sha256:9e4fa264f4d8a4eb0cdbd34beadc029f453b3bafae02401e999cf3d5a5af75f8"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.1.105"
-description = "CUDA profiling tools runtime libs."
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "python_version < \"3.12\" and platform_machine == \"x86_64\" and platform_system == \"Linux\""
-files = [
-    {file = "nvidia_cuda_cupti_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:e54fde3983165c624cb79254ae9818a456eb6e87a7fd4d56a2352c24ee542d7e"},
-    {file = "nvidia_cuda_cupti_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:bea8236d13a0ac7190bd2919c3e8e6ce1e402104276e6f9694479e48bb0eb2a4"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.6.80"
-description = "CUDA profiling tools runtime libs."
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:166ee35a3ff1587f2490364f90eeeb8da06cd867bd5b701bf7f9a02b78bc63fc"},
-    {file = "nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_aarch64.whl", hash = "sha256:358b4a1d35370353d52e12f0a7d1769fc01ff74a191689d3870b2123156184c4"},
-    {file = "nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6768bad6cab4f19e8292125e5f1ac8aa7d1718704012a0e3272a6f61c4bce132"},
-    {file = "nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a3eff6cdfcc6a4c35db968a06fcadb061cbc7d6dde548609a941ff8701b98b73"},
-    {file = "nvidia_cuda_cupti_cu12-12.6.80-py3-none-win_amd64.whl", hash = "sha256:bbe6ae76e83ce5251b56e8c8e61a964f757175682bbad058b170b136266ab00a"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.1.105"
-description = "NVRTC native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "python_version < \"3.12\" and platform_machine == \"x86_64\" and platform_system == \"Linux\""
-files = [
-    {file = "nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:339b385f50c309763ca65456ec75e17bbefcbbf2893f462cb8b90584cd27a1c2"},
-    {file = "nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:0a98a522d9ff138b96c010a65e145dc1b4850e9ecb75a0172371793752fd46ed"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.6.77"
-description = "NVRTC native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:5847f1d6e5b757f1d2b3991a01082a44aad6f10ab3c5c0213fa3e25bddc25a13"},
-    {file = "nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:35b0cc6ee3a9636d5409133e79273ce1f3fd087abb0532d2d2e8fff1fe9efc53"},
-    {file = "nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-win_amd64.whl", hash = "sha256:f7007dbd914c56bd80ea31bc43e8e149da38f68158f423ba845fc3292684e45a"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.1.105"
-description = "CUDA Runtime native Libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "python_version < \"3.12\" and platform_machine == \"x86_64\" and platform_system == \"Linux\""
-files = [
-    {file = "nvidia_cuda_runtime_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:6e258468ddf5796e25f1dc591a31029fa317d97a0a94ed93468fc86301d61e40"},
-    {file = "nvidia_cuda_runtime_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:dfb46ef84d73fababab44cf03e3b83f80700d27ca300e537f85f636fac474344"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.6.77"
-description = "CUDA Runtime native Libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6116fad3e049e04791c0256a9778c16237837c08b27ed8c8401e2e45de8d60cd"},
-    {file = "nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:d461264ecb429c84c8879a7153499ddc7b19b5f8d84c204307491989a365588e"},
-    {file = "nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ba3b56a4f896141e25e19ab287cd71e52a6a0f4b29d0d31609f60e3b4d5219b7"},
-    {file = "nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a84d15d5e1da416dd4774cb42edf5e954a3e60cc945698dc1d5be02321c44dc8"},
-    {file = "nvidia_cuda_runtime_cu12-12.6.77-py3-none-win_amd64.whl", hash = "sha256:86c58044c824bf3c173c49a2dbc7a6c8b53cb4e4dca50068be0bf64e9dab3f7f"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cudnn-cu12"
-version = "8.9.2.26"
-description = "cuDNN runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "python_version < \"3.12\" and platform_machine == \"x86_64\" and platform_system == \"Linux\""
-files = [
-    {file = "nvidia_cudnn_cu12-8.9.2.26-py3-none-manylinux1_x86_64.whl", hash = "sha256:5ccb288774fdfb07a7e7025ffec286971c06d8d7b4fb162525334616d7629ff9"},
-]
-
-[package.dependencies]
-nvidia-cublas-cu12 = "*"
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cudnn-cu12"
-version = "9.5.1.17"
-description = "cuDNN runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9fd4584468533c61873e5fda8ca41bac3a38bcb2d12350830c69b0a96a7e4def"},
-    {file = "nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2"},
-    {file = "nvidia_cudnn_cu12-9.5.1.17-py3-none-win_amd64.whl", hash = "sha256:d7af0f8a4f3b4b9dbb3122f2ef553b45694ed9c384d5a75bab197b8eefb79ab8"},
-]
-
-[package.dependencies]
-nvidia-cublas-cu12 = "*"
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cufft-cu12"
-version = "11.0.2.54"
-description = "CUFFT native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "python_version < \"3.12\" and platform_machine == \"x86_64\" and platform_system == \"Linux\""
-files = [
-    {file = "nvidia_cufft_cu12-11.0.2.54-py3-none-manylinux1_x86_64.whl", hash = "sha256:794e3948a1aa71fd817c3775866943936774d1c14e7628c74f6f7417224cdf56"},
-    {file = "nvidia_cufft_cu12-11.0.2.54-py3-none-win_amd64.whl", hash = "sha256:d9ac353f78ff89951da4af698f80870b1534ed69993f10a4cf1d96f21357e253"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cufft-cu12"
-version = "11.3.0.4"
-description = "CUFFT native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d16079550df460376455cba121db6564089176d9bac9e4f360493ca4741b22a6"},
-    {file = "nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8510990de9f96c803a051822618d42bf6cb8f069ff3f48d93a8486efdacb48fb"},
-    {file = "nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5"},
-    {file = "nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.whl", hash = "sha256:768160ac89f6f7b459bee747e8d175dbf53619cfe74b2a5636264163138013ca"},
-    {file = "nvidia_cufft_cu12-11.3.0.4-py3-none-win_amd64.whl", hash = "sha256:6048ebddfb90d09d2707efb1fd78d4e3a77cb3ae4dc60e19aab6be0ece2ae464"},
-]
-
-[package.dependencies]
-nvidia-nvjitlink-cu12 = "*"
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cufile-cu12"
-version = "1.11.1.6"
-description = "cuFile GPUDirect libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "nvidia_cufile_cu12-1.11.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc23469d1c7e52ce6c1d55253273d32c565dd22068647f3aa59b3c6b005bf159"},
-    {file = "nvidia_cufile_cu12-1.11.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:8f57a0051dcf2543f6dc2b98a98cb2719c37d3cee1baba8965d57f3bbc90d4db"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.2.106"
-description = "CURAND native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "python_version < \"3.12\" and platform_machine == \"x86_64\" and platform_system == \"Linux\""
-files = [
-    {file = "nvidia_curand_cu12-10.3.2.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:9d264c5036dde4e64f1de8c50ae753237c12e0b1348738169cd0f8a536c0e1e0"},
-    {file = "nvidia_curand_cu12-10.3.2.106-py3-none-win_amd64.whl", hash = "sha256:75b6b0c574c0037839121317e17fd01f8a69fd2ef8e25853d826fec30bdba74a"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.7.77"
-description = "CURAND native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:6e82df077060ea28e37f48a3ec442a8f47690c7499bff392a5938614b56c98d8"},
-    {file = "nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a42cd1344297f70b9e39a1e4f467a4e1c10f1da54ff7a85c12197f6c652c8bdf"},
-    {file = "nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:99f1a32f1ac2bd134897fc7a203f779303261268a65762a623bf30cc9fe79117"},
-    {file = "nvidia_curand_cu12-10.3.7.77-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:7b2ed8e95595c3591d984ea3603dd66fe6ce6812b886d59049988a712ed06b6e"},
-    {file = "nvidia_curand_cu12-10.3.7.77-py3-none-win_amd64.whl", hash = "sha256:6d6d935ffba0f3d439b7cd968192ff068fafd9018dbf1b85b37261b13cfc9905"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.4.5.107"
-description = "CUDA solver native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "python_version < \"3.12\" and platform_machine == \"x86_64\" and platform_system == \"Linux\""
-files = [
-    {file = "nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl", hash = "sha256:8a7ec542f0412294b15072fa7dab71d31334014a69f953004ea7a118206fe0dd"},
-    {file = "nvidia_cusolver_cu12-11.4.5.107-py3-none-win_amd64.whl", hash = "sha256:74e0c3a24c78612192a74fcd90dd117f1cf21dea4822e66d89e8ea80e3cd2da5"},
-]
-
-[package.dependencies]
-nvidia-cublas-cu12 = "*"
-nvidia-cusparse-cu12 = "*"
-nvidia-nvjitlink-cu12 = "*"
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.7.1.2"
-description = "CUDA solver native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0ce237ef60acde1efc457335a2ddadfd7610b892d94efee7b776c64bb1cac9e0"},
-    {file = "nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c"},
-    {file = "nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:6cf28f17f64107a0c4d7802be5ff5537b2130bfc112f25d5a30df227058ca0e6"},
-    {file = "nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dbbe4fc38ec1289c7e5230e16248365e375c3673c9c8bac5796e2e20db07f56e"},
-    {file = "nvidia_cusolver_cu12-11.7.1.2-py3-none-win_amd64.whl", hash = "sha256:6813f9d8073f555444a8705f3ab0296d3e1cb37a16d694c5fc8b862a0d8706d7"},
-]
-
-[package.dependencies]
-nvidia-cublas-cu12 = "*"
-nvidia-cusparse-cu12 = "*"
-nvidia-nvjitlink-cu12 = "*"
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.1.0.106"
-description = "CUSPARSE native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "python_version < \"3.12\" and platform_machine == \"x86_64\" and platform_system == \"Linux\""
-files = [
-    {file = "nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c"},
-    {file = "nvidia_cusparse_cu12-12.1.0.106-py3-none-win_amd64.whl", hash = "sha256:b798237e81b9719373e8fae8d4f091b70a0cf09d9d85c95a557e11df2d8e9a5a"},
-]
-
-[package.dependencies]
-nvidia-nvjitlink-cu12 = "*"
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.5.4.2"
-description = "CUSPARSE native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d25b62fb18751758fe3c93a4a08eff08effedfe4edf1c6bb5afd0890fe88f887"},
-    {file = "nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7aa32fa5470cf754f72d1116c7cbc300b4e638d3ae5304cfa4a638a5b87161b1"},
-    {file = "nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73"},
-    {file = "nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:23749a6571191a215cb74d1cdbff4a86e7b19f1200c071b3fcf844a5bea23a2f"},
-    {file = "nvidia_cusparse_cu12-12.5.4.2-py3-none-win_amd64.whl", hash = "sha256:4acb8c08855a26d737398cba8fb6f8f5045d93f82612b4cfd84645a2332ccf20"},
-]
-
-[package.dependencies]
-nvidia-nvjitlink-cu12 = "*"
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-cusparselt-cu12"
-version = "0.6.3"
-description = "NVIDIA cuSPARSELt"
-optional = false
-python-versions = "*"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8371549623ba601a06322af2133c4a44350575f5a3108fb75f3ef20b822ad5f1"},
-    {file = "nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:e5c8a26c36445dd2e6812f1177978a24e2d37cacce7e090f297a688d1ec44f46"},
-    {file = "nvidia_cusparselt_cu12-0.6.3-py3-none-win_amd64.whl", hash = "sha256:3b325bcbd9b754ba43df5a311488fca11a6b5dc3d11df4d190c000cf1a0765c7"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-nccl-cu12"
-version = "2.18.1"
-description = "NVIDIA Collective Communication Library (NCCL) Runtime"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "python_version < \"3.12\" and platform_machine == \"x86_64\" and platform_system == \"Linux\""
-files = [
-    {file = "nvidia_nccl_cu12-2.18.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:1a6c4acefcbebfa6de320f412bf7866de856e786e0462326ba1bac40de0b5e71"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-nccl-cu12"
-version = "2.26.2"
-description = "NVIDIA Collective Communication Library (NCCL) Runtime"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c196e95e832ad30fbbb50381eb3cbd1fadd5675e587a548563993609af19522"},
-    {file = "nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:694cf3879a206553cc9d7dbda76b13efaf610fdb70a50cba303de1b0d1530ac6"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.6.85"
-description = "Nvidia JIT LTO Library"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:eedc36df9e88b682efe4309aa16b5b4e78c2407eac59e8c10a6a47535164369a"},
-    {file = "nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cf4eaa7d4b6b543ffd69d6abfb11efdeb2db48270d94dfd3a452c24150829e41"},
-    {file = "nvidia_nvjitlink_cu12-12.6.85-py3-none-win_amd64.whl", hash = "sha256:e61120e52ed675747825cdd16febc6a0730537451d867ee58bee3853b1b13d1c"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.9.86"
-description = "Nvidia JIT LTO Library"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "python_version < \"3.12\" and platform_machine == \"x86_64\" and platform_system == \"Linux\""
-files = [
-    {file = "nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9"},
-    {file = "nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca"},
-    {file = "nvidia_nvjitlink_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:cc6fcec260ca843c10e34c936921a1c426b351753587fdd638e8cff7b16bb9db"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.1.105"
-description = "NVIDIA Tools Extension"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "python_version < \"3.12\" and platform_machine == \"x86_64\" and platform_system == \"Linux\""
-files = [
-    {file = "nvidia_nvtx_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:dc21cf308ca5691e7c04d962e213f8a4aa9bbfa23d95412f452254c2caeb09e5"},
-    {file = "nvidia_nvtx_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:65f4d98982b31b60026e0e6de73fbdfc09d08a96f4656dd3665ca616a11e1e82"},
-]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.6.77"
-description = "NVIDIA Tools Extension"
-optional = false
-python-versions = ">=3"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f44f8d86bb7d5629988d61c8d3ae61dddb2015dee142740536bc7481b022fe4b"},
-    {file = "nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:adcaabb9d436c9761fca2b13959a2d237c5f9fd406c8e4b723c695409ff88059"},
-    {file = "nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b90bed3df379fa79afbd21be8e04a0314336b8ae16768b58f2d34cb1d04cd7d2"},
-    {file = "nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:6574241a3ec5fdc9334353ab8c479fe75841dbe8f4532a8fc97ce63503330ba1"},
-    {file = "nvidia_nvtx_cu12-12.6.77-py3-none-win_amd64.whl", hash = "sha256:2fb11a4af04a5e6c84073e6404d26588a34afd35379f0855a99797897efa75c0"},
 ]
 
 [package.source]
@@ -2084,15 +1612,15 @@ reference = "tsinghua"
 
 [[package]]
 name = "paicorelib"
-version = "2.0.0a2"
+version = "2.0.0a3"
 description = "Library of PAICORE"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 markers = "platform_machine != \"armv7l\""
 files = [
-    {file = "paicorelib-2.0.0a2-py3-none-any.whl", hash = "sha256:c80264e83aa6fdd7d6f5a39112fb871892b46f87e0ecfc902ca20ca3fd5f4e72"},
-    {file = "paicorelib-2.0.0a2.tar.gz", hash = "sha256:7a7eedbfccf281c336107cdbdd9287bd4b1260eb5d7581e72ec398a80c1521d2"},
+    {file = "paicorelib-2.0.0a3-py3-none-any.whl", hash = "sha256:27149559bb599810fd3cd054e88af3c071f49771a8423ff58870693ed0d585a6"},
+    {file = "paicorelib-2.0.0a3.tar.gz", hash = "sha256:2c05f00c5d0de8583fd472521404266b8cf7eca9f27ac6661b1a9b6aff2275f3"},
 ]
 
 [package.dependencies]
@@ -2664,7 +2192,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -2858,6 +2386,30 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[package.source]
+type = "legacy"
+url = "https://pypi.tuna.tsinghua.edu.cn/simple"
+reference = "tsinghua"
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.8.0"
+groups = ["main"]
+files = [
+    {file = "rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d"},
+    {file = "rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [package.source]
 type = "legacy"
@@ -3191,33 +2743,21 @@ reference = "tsinghua"
 
 [[package]]
 name = "torch"
-version = "2.1.2"
+version = "2.1.2+cpu"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
 optional = false
 python-versions = ">=3.8.0"
 groups = ["dev"]
 markers = "python_version < \"3.12\""
 files = [
-    {file = "torch-2.1.2-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:3a871edd6c02dae77ad810335c0833391c1a4ce49af21ea8cf0f6a5d2096eea8"},
-    {file = "torch-2.1.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:bef6996c27d8f6e92ea4e13a772d89611da0e103b48790de78131e308cf73076"},
-    {file = "torch-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:0e13034fd5fb323cbbc29e56d0637a3791e50dd589616f40c79adfa36a5a35a1"},
-    {file = "torch-2.1.2-cp310-none-macosx_10_9_x86_64.whl", hash = "sha256:d9b535cad0df3d13997dbe8bd68ac33e0e3ae5377639c9881948e40794a61403"},
-    {file = "torch-2.1.2-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:f9a55d55af02826ebfbadf4e9b682f0f27766bc33df8236b48d28d705587868f"},
-    {file = "torch-2.1.2-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:a6ebbe517097ef289cc7952783588c72de071d4b15ce0f8b285093f0916b1162"},
-    {file = "torch-2.1.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:8f32ce591616a30304f37a7d5ea80b69ca9e1b94bba7f308184bf616fdaea155"},
-    {file = "torch-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:e0ee6cf90c8970e05760f898d58f9ac65821c37ffe8b04269ec787aa70962b69"},
-    {file = "torch-2.1.2-cp311-none-macosx_10_9_x86_64.whl", hash = "sha256:76d37967c31c99548ad2c4d3f2cf191db48476f2e69b35a0937137116da356a1"},
-    {file = "torch-2.1.2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:e2d83f07b4aac983453ea5bf8f9aa9dacf2278a8d31247f5d9037f37befc60e4"},
-    {file = "torch-2.1.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:f41fe0c7ecbf903a568c73486139a75cfab287a0f6c17ed0698fdea7a1e8641d"},
-    {file = "torch-2.1.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e3225f47d50bb66f756fe9196a768055d1c26b02154eb1f770ce47a2578d3aa7"},
-    {file = "torch-2.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:33d59cd03cb60106857f6c26b36457793637512998666ee3ce17311f217afe2b"},
-    {file = "torch-2.1.2-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:8e221deccd0def6c2badff6be403e0c53491805ed9915e2c029adbcdb87ab6b5"},
-    {file = "torch-2.1.2-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:05b18594f60a911a0c4f023f38a8bda77131fba5fd741bda626e97dcf5a3dd0a"},
-    {file = "torch-2.1.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:9ca96253b761e9aaf8e06fb30a66ee301aecbf15bb5a303097de1969077620b6"},
-    {file = "torch-2.1.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d93ba70f67b08c2ae5598ee711cbc546a1bc8102cef938904b8c85c2089a51a0"},
-    {file = "torch-2.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:255b50bc0608db177e6a3cc118961d77de7e5105f07816585fa6f191f33a9ff3"},
-    {file = "torch-2.1.2-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:6984cd5057c0c977b3c9757254e989d3f1124f4ce9d07caa6cb637783c71d42a"},
-    {file = "torch-2.1.2-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:bc195d7927feabc0eb7c110e457c955ed2ab616f3c7c28439dd4188cf589699f"},
+    {file = "torch-2.1.2+cpu-cp310-cp310-linux_x86_64.whl", hash = "sha256:bf3ca897f8c7c218dd6c4b1cc5eec57b4f4e71106b0b8120e92f5fdaf4acf6cd"},
+    {file = "torch-2.1.2+cpu-cp310-cp310-win_amd64.whl", hash = "sha256:679458a652006bc5b9d3972f046ae299039dcc63f465ac623b439cbc27a3645c"},
+    {file = "torch-2.1.2+cpu-cp311-cp311-linux_x86_64.whl", hash = "sha256:6acac7871cca2b72f00b60496dd7d59d7d8247721f374705b8f9c6b9aeea482a"},
+    {file = "torch-2.1.2+cpu-cp311-cp311-win_amd64.whl", hash = "sha256:d7ed25db586afef2c022eb143471c6742088decbe05ed1f879fac770e67df189"},
+    {file = "torch-2.1.2+cpu-cp38-cp38-linux_x86_64.whl", hash = "sha256:c4620b08e9b8572594861ebedaf739d86801068a48c0399cbdf6559d1d351789"},
+    {file = "torch-2.1.2+cpu-cp38-cp38-win_amd64.whl", hash = "sha256:8b90d5c0023891717dfc5659eebe6c57c3632db1e3981e22e523be51c4c962c9"},
+    {file = "torch-2.1.2+cpu-cp39-cp39-linux_x86_64.whl", hash = "sha256:10df25736edb00852eca6041941e99d13502e65773d5c6164372eaaab83d976b"},
+    {file = "torch-2.1.2+cpu-cp39-cp39-win_amd64.whl", hash = "sha256:83bac7f809c09700c227abc9e3474e3a847a3f4c1bb2443aa16004f36a1e7e43"},
 ]
 
 [package.dependencies]
@@ -3225,19 +2765,7 @@ filelock = "*"
 fsspec = "*"
 jinja2 = "*"
 networkx = "*"
-nvidia-cublas-cu12 = {version = "12.1.3.1", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-cupti-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-nvrtc-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-runtime-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cudnn-cu12 = {version = "8.9.2.26", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cufft-cu12 = {version = "11.0.2.54", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-curand-cu12 = {version = "10.3.2.106", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cusolver-cu12 = {version = "11.4.5.107", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cusparse-cu12 = {version = "12.1.0.106", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-nccl-cu12 = {version = "2.18.1", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-nvtx-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 sympy = "*"
-triton = {version = "2.1.0", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 typing-extensions = "*"
 
 [package.extras]
@@ -3246,42 +2774,37 @@ opt-einsum = ["opt-einsum (>=3.3)"]
 
 [package.source]
 type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
+url = "https://download.pytorch.org/whl/cpu"
+reference = "pytorch-cpu"
 
 [[package]]
 name = "torch"
-version = "2.7.1"
+version = "2.7.1+cpu"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
 optional = false
 python-versions = ">=3.9.0"
 groups = ["dev"]
 markers = "python_version >= \"3.12\""
 files = [
-    {file = "torch-2.7.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:a103b5d782af5bd119b81dbcc7ffc6fa09904c423ff8db397a1e6ea8fd71508f"},
-    {file = "torch-2.7.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:fe955951bdf32d182ee8ead6c3186ad54781492bf03d547d31771a01b3d6fb7d"},
-    {file = "torch-2.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:885453d6fba67d9991132143bf7fa06b79b24352f4506fd4d10b309f53454162"},
-    {file = "torch-2.7.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:d72acfdb86cee2a32c0ce0101606f3758f0d8bb5f8f31e7920dc2809e963aa7c"},
-    {file = "torch-2.7.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:236f501f2e383f1cb861337bdf057712182f910f10aeaf509065d54d339e49b2"},
-    {file = "torch-2.7.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:06eea61f859436622e78dd0cdd51dbc8f8c6d76917a9cf0555a333f9eac31ec1"},
-    {file = "torch-2.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:8273145a2e0a3c6f9fd2ac36762d6ee89c26d430e612b95a99885df083b04e52"},
-    {file = "torch-2.7.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:aea4fc1bf433d12843eb2c6b2204861f43d8364597697074c8d38ae2507f8730"},
-    {file = "torch-2.7.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:27ea1e518df4c9de73af7e8a720770f3628e7f667280bce2be7a16292697e3fa"},
-    {file = "torch-2.7.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c33360cfc2edd976c2633b3b66c769bdcbbf0e0b6550606d188431c81e7dd1fc"},
-    {file = "torch-2.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:d8bf6e1856ddd1807e79dc57e54d3335f2b62e6f316ed13ed3ecfe1fc1df3d8b"},
-    {file = "torch-2.7.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:787687087412c4bd68d315e39bc1223f08aae1d16a9e9771d95eabbb04ae98fb"},
-    {file = "torch-2.7.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:03563603d931e70722dce0e11999d53aa80a375a3d78e6b39b9f6805ea0a8d28"},
-    {file = "torch-2.7.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d632f5417b6980f61404a125b999ca6ebd0b8b4bbdbb5fbbba44374ab619a412"},
-    {file = "torch-2.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:23660443e13995ee93e3d844786701ea4ca69f337027b05182f5ba053ce43b38"},
-    {file = "torch-2.7.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:0da4f4dba9f65d0d203794e619fe7ca3247a55ffdcbd17ae8fb83c8b2dc9b585"},
-    {file = "torch-2.7.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e08d7e6f21a617fe38eeb46dd2213ded43f27c072e9165dc27300c9ef9570934"},
-    {file = "torch-2.7.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:30207f672328a42df4f2174b8f426f354b2baa0b7cca3a0adb3d6ab5daf00dc8"},
-    {file = "torch-2.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:79042feca1c634aaf6603fe6feea8c6b30dfa140a6bbc0b973e2260c7e79a22e"},
-    {file = "torch-2.7.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:988b0cbc4333618a1056d2ebad9eb10089637b659eb645434d0809d8d937b946"},
-    {file = "torch-2.7.1-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:e0d81e9a12764b6f3879a866607c8ae93113cbcad57ce01ebde63eb48a576369"},
-    {file = "torch-2.7.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:8394833c44484547ed4a47162318337b88c97acdb3273d85ea06e03ffff44998"},
-    {file = "torch-2.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:df41989d9300e6e3c19ec9f56f856187a6ef060c3662fe54f4b6baf1fc90bd19"},
-    {file = "torch-2.7.1-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:a737b5edd1c44a5c1ece2e9f3d00df9d1b3fb9541138bee56d83d38293fb6c9d"},
+    {file = "torch-2.7.1+cpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:c0df17cee97653d09a4e84488a33d21217f9b24208583c55cf28f0045aab0766"},
+    {file = "torch-2.7.1+cpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:1f04a373a3f643821f721da9898ef77dce73b5b6bfc64486f0976f7fb5f90e83"},
+    {file = "torch-2.7.1+cpu-cp310-cp310-win_amd64.whl", hash = "sha256:b4cc706973655151f198d027ed34c92ab31a3db55676b44251194e1280631426"},
+    {file = "torch-2.7.1+cpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:5fe6045b8f426bf2d0426e4fe009f1667a954ec2aeb82f1bd0bf60c6d7a85445"},
+    {file = "torch-2.7.1+cpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a1684793e352f03fa14f78857e55d65de4ada8405ded1da2bf4f452179c4b779"},
+    {file = "torch-2.7.1+cpu-cp311-cp311-win_amd64.whl", hash = "sha256:7b977eccbc85ae2bd19d6998de7b1f1f4bd3c04eaffd3015deb7934389783399"},
+    {file = "torch-2.7.1+cpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3bf2db5adf77b433844f080887ade049c4705ddf9fe1a32023ff84ff735aa5ad"},
+    {file = "torch-2.7.1+cpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:8f8b3cfc53010a4b4a3c7ecb88c212e9decc4f5eeb6af75c3c803937d2d60947"},
+    {file = "torch-2.7.1+cpu-cp312-cp312-win_amd64.whl", hash = "sha256:0bc887068772233f532b51a3e8c8cfc682ae62bef74bf4e0c53526c8b9e4138f"},
+    {file = "torch-2.7.1+cpu-cp312-cp312-win_arm64.whl", hash = "sha256:a2618775f32eb4126c5b2050686da52001a08cffa331637d9cf51c8250931e00"},
+    {file = "torch-2.7.1+cpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:eb17646792ac4374ffc87e42369f45d21eff17c790868963b90483ef0b6db4ef"},
+    {file = "torch-2.7.1+cpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:84ea1f6a1d15663037d01b121d6e33bb9da3c90af8e069e5072c30f413455a57"},
+    {file = "torch-2.7.1+cpu-cp313-cp313-win_amd64.whl", hash = "sha256:b66f77f6f67317344ee083aa7ac4751a14395fcb38060d564bf513978d267153"},
+    {file = "torch-2.7.1+cpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:56136a2aca6707df3c8811e46ea2d379eaafd18e656e2fd51e8e4d0ca995651b"},
+    {file = "torch-2.7.1+cpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:355614185a2aea7155f9c88a20bfd49de5f3063866f3cf9b2f21b6e9e59e31e0"},
+    {file = "torch-2.7.1+cpu-cp313-cp313t-win_amd64.whl", hash = "sha256:464bca1bc9452f2ccd676514688896e66b9488f2a0268ecd3ac497cf09c5aac1"},
+    {file = "torch-2.7.1+cpu-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:a4551cb97b83df5f93fc0d7538332535828581e1db2f179afc287027afbdd6e8"},
+    {file = "torch-2.7.1+cpu-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:d205cac087d60bc176bdc0b63a1d00dc7a4ee5ac76fd20a2ca318ac65674167e"},
+    {file = "torch-2.7.1+cpu-cp39-cp39-win_amd64.whl", hash = "sha256:d25435bdc4780d3cb512aad55142aca9584ae1fe8f8691cda6d32f19faf5d58e"},
 ]
 
 [package.dependencies]
@@ -3289,23 +2812,8 @@ filelock = "*"
 fsspec = "*"
 jinja2 = "*"
 networkx = "*"
-nvidia-cublas-cu12 = {version = "12.6.4.1", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-cupti-cu12 = {version = "12.6.80", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-nvrtc-cu12 = {version = "12.6.77", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-runtime-cu12 = {version = "12.6.77", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cudnn-cu12 = {version = "9.5.1.17", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cufft-cu12 = {version = "11.3.0.4", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cufile-cu12 = {version = "1.11.1.6", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-curand-cu12 = {version = "10.3.7.77", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cusolver-cu12 = {version = "11.7.1.2", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cusparse-cu12 = {version = "12.5.4.2", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cusparselt-cu12 = {version = "0.6.3", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-nccl-cu12 = {version = "2.26.2", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-nvjitlink-cu12 = {version = "12.6.85", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-nvtx-cu12 = {version = "12.6.77", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 setuptools = {version = "*", markers = "python_version >= \"3.12\""}
 sympy = ">=1.13.3"
-triton = {version = "3.3.1", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
 typing-extensions = ">=4.10.0"
 
 [package.extras]
@@ -3314,8 +2822,8 @@ optree = ["optree (>=0.13.0)"]
 
 [package.source]
 type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
+url = "https://download.pytorch.org/whl/cpu"
+reference = "pytorch-cpu"
 
 [[package]]
 name = "torchvision"
@@ -3439,68 +2947,6 @@ url = "https://pypi.tuna.tsinghua.edu.cn/simple"
 reference = "tsinghua"
 
 [[package]]
-name = "triton"
-version = "2.1.0"
-description = "A language and compiler for custom Deep Learning operations"
-optional = false
-python-versions = "*"
-groups = ["dev"]
-markers = "python_version < \"3.12\" and platform_machine == \"x86_64\" and platform_system == \"Linux\""
-files = [
-    {file = "triton-2.1.0-0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:66439923a30d5d48399b08a9eae10370f6c261a5ec864a64983bae63152d39d7"},
-    {file = "triton-2.1.0-0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:919b06453f0033ea52c13eaf7833de0e57db3178d23d4e04f9fc71c4f2c32bf8"},
-    {file = "triton-2.1.0-0-cp37-cp37m-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ae4bb8a91de790e1866405211c4d618379781188f40d5c4c399766914e84cd94"},
-    {file = "triton-2.1.0-0-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:39f6fb6bdccb3e98f3152e3fbea724f1aeae7d749412bbb1fa9c441d474eba26"},
-    {file = "triton-2.1.0-0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21544e522c02005a626c8ad63d39bdff2f31d41069592919ef281e964ed26446"},
-    {file = "triton-2.1.0-0-pp37-pypy37_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:143582ca31dd89cd982bd3bf53666bab1c7527d41e185f9e3d8a3051ce1b663b"},
-    {file = "triton-2.1.0-0-pp38-pypy38_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:82fc5aeeedf6e36be4e4530cbdcba81a09d65c18e02f52dc298696d45721f3bd"},
-    {file = "triton-2.1.0-0-pp39-pypy39_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:81a96d110a738ff63339fc892ded095b31bd0d205e3aace262af8400d40b6fa8"},
-]
-
-[package.dependencies]
-filelock = "*"
-
-[package.extras]
-build = ["cmake (>=3.18)", "lit"]
-tests = ["autopep8", "flake8", "isort", "numpy", "pytest", "scipy (>=1.7.1)"]
-tutorials = ["matplotlib", "pandas", "tabulate"]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
-name = "triton"
-version = "3.3.1"
-description = "A language and compiler for custom Deep Learning operations"
-optional = false
-python-versions = "*"
-groups = ["dev"]
-markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\" and python_version >= \"3.12\""
-files = [
-    {file = "triton-3.3.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b74db445b1c562844d3cfad6e9679c72e93fdfb1a90a24052b03bb5c49d1242e"},
-    {file = "triton-3.3.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b31e3aa26f8cb3cc5bf4e187bf737cbacf17311e1112b781d4a059353dfd731b"},
-    {file = "triton-3.3.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9999e83aba21e1a78c1f36f21bce621b77bcaa530277a50484a7cb4a822f6e43"},
-    {file = "triton-3.3.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b89d846b5a4198317fec27a5d3a609ea96b6d557ff44b56c23176546023c4240"},
-    {file = "triton-3.3.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3198adb9d78b77818a5388bff89fa72ff36f9da0bc689db2f0a651a67ce6a42"},
-    {file = "triton-3.3.1-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f6139aeb04a146b0b8e0fbbd89ad1e65861c57cfed881f21d62d3cb94a36bab7"},
-]
-
-[package.dependencies]
-setuptools = ">=40.8.0"
-
-[package.extras]
-build = ["cmake (>=3.20)", "lit"]
-tests = ["autopep8", "isort", "llnl-hatchet", "numpy", "pytest", "pytest-forked", "pytest-xdist", "scipy (>=1.7.1)"]
-tutorials = ["matplotlib", "pandas", "tabulate"]
-
-[package.source]
-type = "legacy"
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-reference = "tsinghua"
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -3583,4 +3029,4 @@ reference = "tsinghua"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "64d185b2cd48fac442ab1157a90bd195fe84d99d4bbdaa4b7273b8765bcb3fa9"
+content-hash = "a3de5b94dc0a009569498e4f3f5ca70653e286d6450b24092286dbccb5a4d84c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,10 @@ name = "paibox"
 version = "1.3.0"
 description = "Toolchain of PAICORE"
 authors = [{ name = "Ziru Pan", email = "zrpan@stu.pku.edu.cn" }]
-license = { text = "GPL-3.0-or-later" }
+license = "GPL-3.0-or-later"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["numpy (>=2.1.0,<3.0.0)"]
+dependencies = ["numpy (>=2.1.0,<3.0.0)", "rich>=14.0.0"]
 maintainers = [
     { name = "Hongjian Wen", email = "221900303@smail.nju.edu.cn" },
     { name = "Siyuan Gao", email = "siyuan-gao@outlook.com" },
@@ -16,7 +16,6 @@ maintainers = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
@@ -44,7 +43,7 @@ dev = [
     "pytest-md>=0.2",
     "pytest-xdist>=3.7.0",
     "orjson>=3.11.6",
-    "paicorelib>=2.0.0a2 ; platform_machine != 'armv7l'",
+    "paicorelib>=2.0.0a3 ; platform_machine != 'armv7l'",
     "torch>=2.0.0,<2.2.0 ; python_full_version < '3.12'",
     "torch>=2.2.0 ; python_full_version >= '3.12'",
     "spikingjelly>=0.0.0.0.12",
@@ -98,5 +97,5 @@ torch = { index = "pytorch-cpu" }
 
 
 [build-system]
-requires = ["poetry-core>=2.0.0,<3.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["uv_build>=0.11.0,<0.12"]
+build-backend = "uv_build"

--- a/tests/backendv2/test_reorder_node.py
+++ b/tests/backendv2/test_reorder_node.py
@@ -1,0 +1,35 @@
+import numpy as np
+import paicorelib
+import torch
+
+for name, value in {
+    "LUT_ACTIVATION_DTYPE": np.int8,
+    "LUT_POTENTIAL_DTYPE": np.int8,
+    "LUTActivationType": np.ndarray,
+    "LUTPotentialType": np.ndarray,
+}.items():
+    if not hasattr(paicorelib, name):
+        setattr(paicorelib, name, value)
+
+from paibox.backendv2.op_node import InNode, ReorderNode, get_elem  # noqa: E402
+from paibox.paiir.ir.ir_base import InputNode  # noqa: E402
+from paibox.paiir.ir.op_node import ReshapeOp  # noqa: E402
+
+
+def test_reorder_node_respects_input_dims_permutation():
+    raw_input = InputNode(shape=(1, 2, 3))
+    source = InNode(raw_input.name, raw_input, raw_input.shape)
+
+    raw_reshape = ReshapeOp(shape_fn=lambda _shape: torch.Size((1, 6)))
+    raw_reshape.input_dims = [(0, 2, 1)]
+    raw_reshape.output_shape = (1, 6)
+
+    reorder = ReorderNode("ReorderNode_0", raw_reshape, raw_reshape.output_shape)
+    reorder.predecessors = [source]
+
+    reorder_map = reorder.get_reorder_info()
+
+    expected = {0: 0, 1: 2, 2: 4, 3: 1, 4: 3, 5: 5}
+    for src_idx, dst_idx in expected.items():
+        src_elem = get_elem(source, src_idx)
+        assert reorder_map[src_elem].index.idx == dst_idx

--- a/tests/paiir/ir/test_op_node.py
+++ b/tests/paiir/ir/test_op_node.py
@@ -26,7 +26,7 @@ from paibox.paiir.ir.op_node import (
     StandaloneActOp,
     StandaloneCompOp,
 )
-from paibox.paiir.pipeline.avgpool import (
+from paibox.paiir.pipeline.avgpool.compensation import (
     apply_avgpool_lut_compensation,
     apply_avgpool_snn_compensation,
 )

--- a/tests/paiir/lowering/test_converter.py
+++ b/tests/paiir/lowering/test_converter.py
@@ -81,7 +81,8 @@ class TestStrictMode:
         pool_nodes = [
             node
             for node in graph.nodes.values()
-            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.AvgPool2d)
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.AvgPool2d)
         ]
         assert len(pool_nodes) == 1
 

--- a/tests/paiir/lowering/test_converter.py
+++ b/tests/paiir/lowering/test_converter.py
@@ -7,7 +7,7 @@ from torch import nn
 from paibox.paiir.exceptions import UnsupportedOpError, UnsupportedOpWarning
 from paibox.paiir.ir.core_neuron import ANNNodeV25
 from paibox.paiir.ir.lut_activation import LutCustom
-from paibox.paiir.ir.op_node import SequentialOp
+from paibox.paiir.ir.op_node import SequentialOp, StandaloneCompOp
 from paibox.paiir.lowering.converter import register_neuron, torch_to_paiir
 from tests.paiir.conftest import (
     UnsupportedSinModel,
@@ -17,6 +17,34 @@ from tests.paiir.conftest import (
     make_multispike4_lut,
     make_vec_8d,
 )
+
+
+class UnsupportedCountIncludePadAvgPool2d(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pool = nn.AvgPool2d(
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            count_include_pad=False,
+        )
+
+    def forward(self, x):
+        return self.pool(x)
+
+
+class SupportedNoPaddingCountIncludePadAvgPool2d(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pool = nn.AvgPool2d(
+            kernel_size=3,
+            stride=1,
+            padding=0,
+            count_include_pad=False,
+        )
+
+    def forward(self, x):
+        return self.pool(x)
 
 
 class TestStrictMode:
@@ -34,6 +62,28 @@ class TestStrictMode:
         with pytest.warns(UnsupportedOpWarning, match="unsupported"):
             graph = torch_to_paiir(model, make_img_3ch_8x8(), strict=False)
         assert len(graph.nodes) > 0
+
+    def test_strict_mode_rejects_count_include_pad_false_with_padding(self):
+        model = UnsupportedCountIncludePadAvgPool2d()
+        with pytest.raises(UnsupportedOpError, match="count_include_pad=False"):
+            torch_to_paiir(model, make_img_3ch_8x8(), strict=True)
+
+    def test_non_strict_mode_warns_for_count_include_pad_false_with_padding(self):
+        model = UnsupportedCountIncludePadAvgPool2d()
+        with pytest.warns(UnsupportedOpWarning, match="count_include_pad=False"):
+            graph = torch_to_paiir(model, make_img_3ch_8x8(), strict=False)
+        assert len(graph.nodes) > 0
+
+    def test_padding_free_count_include_pad_false_is_allowed(self):
+        model = SupportedNoPaddingCountIncludePadAvgPool2d()
+        graph = torch_to_paiir(model, make_img_3ch_8x8(), strict=True)
+
+        pool_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.AvgPool2d)
+        ]
+        assert len(pool_nodes) == 1
 
 
 class TestRegisterNeuron:

--- a/tests/paiir/lowering/test_dims_prop.py
+++ b/tests/paiir/lowering/test_dims_prop.py
@@ -1,16 +1,7 @@
 import torch
 from torch import fx, nn
-from torch.fx.passes.shape_prop import ShapeProp
 
-from paibox.paiir.lowering.dims_prop import DimsProp
-
-
-def _propagate(model: nn.Module, *inputs: torch.Tensor) -> fx.GraphModule:
-    """Trace, run ShapeProp, then DimsProp. Returns the GraphModule."""
-    gm = fx.symbolic_trace(model)
-    ShapeProp(gm).propagate(*inputs)
-    DimsProp().propagate(gm)
-    return gm
+from tests.paiir.tracing import trace_with_fx_shape_and_dims as _propagate
 
 
 def _output_dims(gm: fx.GraphModule) -> tuple[int, ...]:
@@ -184,6 +175,42 @@ class TestDimsProp:
         gm = _propagate(M(), torch.randn(2, 3, 4))
         assert _output_dims(gm) == (0, 1)
 
+    def test_view_as_resets_to_identity(self):
+        class M(nn.Module):
+            def forward(self, x: torch.Tensor, ref: torch.Tensor) -> torch.Tensor:
+                return x.view_as(ref)
+
+        gm = _propagate(M(), torch.randn(1, 3, 2, 2), torch.randn(1, 12))
+        assert _output_dims(gm) == (0, 1)
+        assert _node_dims(gm, "view_as") == (0, 1)
+
+    def test_function_unsqueeze_resets_to_identity(self):
+        class M(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return torch.unsqueeze(x, 1)
+
+        gm = _propagate(M(), torch.randn(1, 2, 3))
+        assert _output_dims(gm) == (0, 1, 2, 3)
+        assert _node_dims(gm, "unsqueeze") == (0, 1, 2, 3)
+
+    def test_method_squeeze_resets_to_identity(self):
+        class M(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x.squeeze(1)
+
+        gm = _propagate(M(), torch.randn(1, 1, 2, 3))
+        assert _output_dims(gm) == (0, 1, 2)
+        assert _node_dims(gm, "squeeze") == (0, 1, 2)
+
+    def test_function_squeeze_resets_to_identity(self):
+        class M(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return torch.squeeze(x, 1)
+
+        gm = _propagate(M(), torch.randn(1, 1, 2, 3))
+        assert _output_dims(gm) == (0, 1, 2)
+        assert _node_dims(gm, "squeeze") == (0, 1, 2)
+
     def test_contiguous_inherits_dims(self):
         """contiguous() preserves dims from input (no layout change)."""
 
@@ -244,7 +271,7 @@ class TestDimsProp:
                 self.register_buffer("buf", torch.randn(3, 4))
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
-                return x + self.buf
+                return x + self.buf  # type: ignore
 
         gm = _propagate(M(), torch.randn(3, 4))
         for node in gm.graph.nodes:

--- a/tests/paiir/lowering/test_shape_analysis.py
+++ b/tests/paiir/lowering/test_shape_analysis.py
@@ -1,0 +1,287 @@
+import operator
+
+import torch
+from torch import nn
+
+from paibox.paiir.lowering.shape_analysis import analyze_shape_helpers
+from tests.paiir.tracing import trace_for_lowering as _trace_for_shape_analysis
+
+
+class TestShapeAnalysis:
+    def test_flatten_module_is_recorded_as_reshape_sink(self):
+        class M(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.flatten = nn.Flatten(1)
+
+            def forward(self, x):
+                return self.flatten(x)
+
+        gm = _trace_for_shape_analysis(M(), torch.randn(1, 3, 4, 5))
+        analysis = analyze_shape_helpers(gm)
+
+        flatten_node = next(node for node in gm.graph.nodes if node.op == "call_module")
+        sink = analysis.sink_for(flatten_node)
+        assert sink is not None
+
+        assert sink.kind == "flatten"
+        assert sink.data_input.op == "placeholder"
+        assert sink.start_dim == 1
+        assert sink.end_dim == -1
+        assert sink.shape_seed_nodes == ()
+        assert sink.output_shape == (1, 60)
+        assert analysis.aux_nodes == set()
+
+    def test_function_unsqueeze_is_recorded_as_reshape_sink(self):
+        class M(nn.Module):
+            def forward(self, x):
+                return torch.unsqueeze(x, 1)
+
+        gm = _trace_for_shape_analysis(M(), torch.randn(1, 2, 3))
+        analysis = analyze_shape_helpers(gm)
+
+        unsqueeze_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function" and node.target is torch.unsqueeze
+        )
+        sink = analysis.sink_for(unsqueeze_node)
+        assert sink is not None
+
+        assert sink.kind == "reshape"
+        assert sink.data_input.op == "placeholder"
+        assert sink.shape_seed_nodes == ()
+        assert sink.output_shape == (1, 1, 2, 3)
+
+    def test_method_squeeze_is_recorded_as_reshape_sink(self):
+        class M(nn.Module):
+            def forward(self, x):
+                return x.squeeze(1)
+
+        gm = _trace_for_shape_analysis(M(), torch.randn(1, 1, 2, 3))
+        analysis = analyze_shape_helpers(gm)
+
+        squeeze_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_method" and node.target == "squeeze"
+        )
+        sink = analysis.sink_for(squeeze_node)
+        assert sink is not None
+
+        assert sink.kind == "reshape"
+        assert sink.data_input.op == "placeholder"
+        assert sink.shape_seed_nodes == ()
+        assert sink.output_shape == (1, 2, 3)
+
+    def test_function_squeeze_is_recorded_as_reshape_sink(self):
+        class M(nn.Module):
+            def forward(self, x):
+                return torch.squeeze(x, 1)
+
+        gm = _trace_for_shape_analysis(M(), torch.randn(1, 1, 2, 3))
+        analysis = analyze_shape_helpers(gm)
+
+        squeeze_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function" and node.target is torch.squeeze
+        )
+        sink = analysis.sink_for(squeeze_node)
+        assert sink is not None
+
+        assert sink.kind == "reshape"
+        assert sink.data_input.op == "placeholder"
+        assert sink.shape_seed_nodes == ()
+        assert sink.output_shape == (1, 2, 3)
+
+    def test_tuple_repeat_all_ones_is_recorded_as_reshape_sink(self):
+        class M(nn.Module):
+            def forward(self, x):
+                return x.repeat((1, 1, 1))
+
+        gm = _trace_for_shape_analysis(M(), torch.randn(1, 2, 3))
+        analysis = analyze_shape_helpers(gm)
+
+        repeat_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_method" and node.target == "repeat"
+        )
+        sink = analysis.sink_for(repeat_node)
+        assert sink is not None
+
+        assert sink.kind == "reshape"
+        assert sink.data_input.op == "placeholder"
+        assert sink.shape_seed_nodes == ()
+        assert sink.output_shape == (1, 2, 3)
+
+    def test_view_shape_arithmetic_marks_only_shape_helpers(self):
+        class M(nn.Module):
+            def forward(self, x):
+                batch = x.size(0) + x.size(1) - x.size(1)
+                features = (x.size(1) * x.size(2) * x.size(3)) // batch
+                return x.view(batch, features)
+
+        gm = _trace_for_shape_analysis(M(), torch.randn(1, 2, 3, 4))
+        analysis = analyze_shape_helpers(gm)
+
+        view_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_method" and node.target == "view"
+        )
+        sink = analysis.sink_for(view_node)
+        assert sink is not None
+
+        assert sink.kind == "reshape"
+        assert sink.data_input.op == "placeholder"
+        assert sink.output_shape == (1, 24)
+        assert sink.shape_seed_nodes
+
+        size_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_method" and node.target == "size"
+        ]
+        assert size_nodes
+        assert all(analysis.is_aux(node) for node in size_nodes)
+        assert not analysis.is_aux(sink.data_input)
+
+    def test_shape_getattr_and_getitem_feed_shape_expression_semantics(self):
+        class M(nn.Module):
+            def forward(self, x):
+                shape = x.shape
+                batch = shape[0]
+                features = shape[1] * shape[2] * shape[3]
+                return x.view(batch, features)
+
+        gm = _trace_for_shape_analysis(M(), torch.randn(1, 2, 3, 4))
+        analysis = analyze_shape_helpers(gm)
+
+        view_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_method" and node.target == "view"
+        )
+        sink = analysis.sink_for(view_node)
+        assert sink is not None
+
+        shape_getattrs = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and node.target is getattr
+            and len(node.args) >= 2
+            and node.args[1] == "shape"
+        ]
+        getitems = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function" and node.target is operator.getitem
+        ]
+
+        assert sink.output_shape == (1, 24)
+        assert shape_getattrs
+        assert getitems
+        assert all(analysis.is_aux(node) for node in shape_getattrs)
+        assert all(analysis.is_aux(node) for node in getitems)
+
+    def test_user_closure_excludes_size_node_shared_with_non_shape_user(self):
+        class M(nn.Module):
+            def forward(self, x):
+                batch = x.size(0)
+                y = x.view(batch, -1)
+                return y, batch
+
+        gm = _trace_for_shape_analysis(M(), torch.randn(1, 2, 3, 4))
+        analysis = analyze_shape_helpers(gm)
+
+        view_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_method" and node.target == "view"
+        )
+        sink = analysis.sink_for(view_node)
+        assert sink is not None
+        size_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_method" and node.target == "size"
+        )
+
+        assert sink.shape_seed_nodes == (size_node,)
+        assert not analysis.is_aux(size_node)
+
+    def test_flatten_then_fixed_reshape_records_two_sinks(self):
+        class M(nn.Module):
+            def forward(self, x):
+                x = x.flatten(1)
+                return x.reshape(1, 2, 12)
+
+        gm = _trace_for_shape_analysis(M(), torch.randn(1, 2, 3, 4))
+        analysis = analyze_shape_helpers(gm)
+
+        flatten_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_method" and node.target == "flatten"
+        )
+        reshape_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_method" and node.target == "reshape"
+        )
+
+        flatten_sink = analysis.sink_for(flatten_node)
+        reshape_sink = analysis.sink_for(reshape_node)
+        assert flatten_sink is not None
+        assert reshape_sink is not None
+
+        assert flatten_sink.kind == "flatten"
+        assert flatten_sink.data_input.op == "placeholder"
+        assert flatten_sink.output_shape == (1, 24)
+        assert flatten_sink.shape_seed_nodes == ()
+
+        assert reshape_sink.kind == "reshape"
+        assert reshape_sink.data_input is flatten_node
+        assert reshape_sink.output_shape == (1, 2, 12)
+        assert reshape_sink.shape_seed_nodes == ()
+        assert len(analysis.reshape_sinks) == 2
+
+    def test_flatten_then_reshape_shape_arithmetic_marks_flatten_size_users_aux(self):
+        class M(nn.Module):
+            def forward(self, x):
+                x = x.flatten(1)
+                return x.reshape(x.size(0), 2, x.size(1) // 2)
+
+        gm = _trace_for_shape_analysis(M(), torch.randn(1, 2, 3, 4))
+        analysis = analyze_shape_helpers(gm)
+
+        flatten_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_method" and node.target == "flatten"
+        )
+        reshape_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_method" and node.target == "reshape"
+        )
+        reshape_sink = analysis.sink_for(reshape_node)
+        assert reshape_sink is not None
+
+        size_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_method"
+            and node.target == "size"
+            and node.args
+            and node.args[0] is flatten_node
+        ]
+
+        assert analysis.sink_for(flatten_node) is not None
+        assert reshape_sink.data_input is flatten_node
+        assert reshape_sink.output_shape == (1, 2, 12)
+        assert size_nodes
+        assert all(analysis.is_aux(node) for node in size_nodes)

--- a/tests/paiir/pipeline/avgpool/test_compensation.py
+++ b/tests/paiir/pipeline/avgpool/test_compensation.py
@@ -9,15 +9,17 @@ from paibox.paiir.pipeline.avgpool import (
     AvgPoolDeployScheme,
     AvgPoolLIFCandidateScore,
     CalibrationResult,
-    apply_avgpool_leak_params,
     calibrate_avgpool_threshold,
+    score_avgpool_lif_candidates,
+    select_avgpool_lif_candidate,
+    select_avgpool_lif_deployment,
+)
+from paibox.paiir.pipeline.avgpool.compensation import (
+    apply_avgpool_leak_params,
     compensate_avgpool_lut,
     compensate_avgpool_lut_for_sumpool,
     compensate_avgpool_neuron,
     compensate_sumpool_neuron,
-    score_avgpool_lif_candidates,
-    select_avgpool_lif_candidate,
-    select_avgpool_lif_deployment,
 )
 
 

--- a/tests/paiir/pipeline/avgpool/test_compensation.py
+++ b/tests/paiir/pipeline/avgpool/test_compensation.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from paicorelib import DataWidth, LeakMultiInputMode, LeakMultiMode
+from torch import nn
 
 import paibox.paiir.pipeline.avgpool.deploy_scheme as deploy_scheme_mod
 from paibox.paiir.ir.calc_params import LutData, NeuronParams
@@ -20,6 +21,10 @@ from paibox.paiir.pipeline.avgpool.compensation import (
     compensate_avgpool_lut_for_sumpool,
     compensate_avgpool_neuron,
     compensate_sumpool_neuron,
+)
+from paibox.paiir.pipeline.avgpool.utils import (
+    _get_avgpool_divisor,
+    _get_pool_window_size,
 )
 
 
@@ -48,6 +53,13 @@ class TestAvgPoolLeakParams:
         params = apply_avgpool_leak_params(params, window_size=9, is_ann=False)
         assert params.leak_tau == -2  # unchanged
         assert params.leak_multi_input == LeakMultiInputMode.ENABLE
+
+
+class TestAvgPoolUtils:
+    def test_avgpool_divisor_can_differ_from_window_size(self):
+        pool = nn.AvgPool2d(2, divisor_override=1)
+        assert _get_pool_window_size(pool) == 4
+        assert _get_avgpool_divisor(pool) == 1
 
 
 class TestCompensateAvgPoolLut:
@@ -309,6 +321,25 @@ class TestSelectAvgPoolLIFDeployment:
         assert candidate.rate_error == pytest.approx(
             sum(per_probe_errors) / len(per_probe_errors)
         )
+
+    def test_avg_divisor_changes_candidate_scoring(self):
+        act = make_lif_node(tau=4.0, decay_input=True)
+
+        candidates_default = score_avgpool_lif_candidates(
+            act=act,
+            pred_out_width=DataWidth.WIDTH_1BIT,
+            window_size=4,
+            allow_split_lif=False,
+        )
+        candidates_divisor_one = score_avgpool_lif_candidates(
+            act=act,
+            pred_out_width=DataWidth.WIDTH_1BIT,
+            window_size=4,
+            allow_split_lif=False,
+            avg_divisor=1,
+        )
+
+        assert candidates_default != candidates_divisor_one
 
     def test_select_avgpool_lif_candidate_returns_full_winner(self):
         act = make_lif_node(tau=5.0, decay_input=False)

--- a/tests/paiir/pipeline/avgpool/test_deploy_scheme.py
+++ b/tests/paiir/pipeline/avgpool/test_deploy_scheme.py
@@ -8,7 +8,7 @@ from torch import nn
 from paibox.paiir.ir.op_node import SequentialOp, StandaloneActOp
 from paibox.paiir.lowering.converter import torch_to_paiir
 from paibox.paiir.nn import SumPool2d
-from paibox.paiir.pipeline.avgpool import AvgPoolDeployMetadata
+from paibox.paiir.pipeline.avgpool.metadata import AvgPoolDeployMetadata
 from paibox.paiir.pipeline.passes import fuse_to_offline_cores, specialize_general_adds
 from tests.paiir.conftest import (
     SNNWithAvgPoolIF,

--- a/tests/paiir/pipeline/avgpool/test_deploy_scheme.py
+++ b/tests/paiir/pipeline/avgpool/test_deploy_scheme.py
@@ -122,6 +122,30 @@ class TestSplitCoreAvgPoolIF:
         if_core = standalone_acts[0]
         assert if_core.act.thres_pos == 1.0
 
+    def test_divisor_override_controls_split_core_if_lut_scaling(self):
+        class AvgPoolIFDivisorOne(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(3, 16, 3, padding=1)
+                self.if1 = sj.IFNode(v_threshold=1.0)
+                self.pool = nn.AvgPool2d(2, divisor_override=1)
+                self.if2 = sj.IFNode(v_threshold=1.0)
+
+            def forward(self, x):
+                x = self.if1(self.conv(x))
+                return self.if2(self.pool(x))
+
+        fused = convert_and_fuse(AvgPoolIFDivisorOne(), make_img_3ch_8x8())
+
+        seq_nodes = find_nodes(fused, SequentialOp)
+        sumpool_core = [n for n in seq_nodes if isinstance(n.comp, SumPool2d)][0]
+        assert sumpool_core.act.lut is not None
+        assert sumpool_core.act.lut.thresholds[1] == 1
+
+        standalone_acts = find_nodes(fused, StandaloneActOp)
+        assert len(standalone_acts) == 1
+        assert standalone_acts[0].act.thres_pos == 1.0
+
 
 class TestAvgPoolDeploymentWriteback:
     def test_shared_core_lif_records_avgpool_deploy_metadata(self):

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -10,7 +10,7 @@ from torch import nn
 
 import paibox.paiir.pipeline.avgpool.fusion as avgpool_fusion
 import paibox.paiir.pipeline.compile as compile_mod
-from paibox.paiir import CompileConfig, compile_to_paiir, torch_to_paiir
+from paibox.paiir import CompileConfig, LIFNodeV25, compile_to_paiir, torch_to_paiir
 from paibox.paiir.exceptions import UnsupportedOpError, UnsupportedOpWarning
 from paibox.paiir.ir.op_node import (
     AccumulateOp,
@@ -25,6 +25,7 @@ from paibox.paiir.nn import SumPool1d, SumPool2d
 from paibox.paiir.pipeline.avgpool import (
     AvgPoolDeployScheme,
     AvgPoolLIFCandidateScore,
+    calibrate_avgpool_threshold,
 )
 from paibox.paiir.pipeline.avgpool.metadata import AvgPoolDeployMetadata
 from paibox.paiir.pipeline.passes import GraphCleanupWarning
@@ -472,22 +473,18 @@ class TestCompileConfig:
     """CompileConfig and parameter precedence."""
 
     def test_config_applies(self):
-        from paibox.paiir.ir.op_node import StandaloneCompOp
-
         config = CompileConfig(tick_duration=50, auto_reset=False)
         sample_input = make_img_3ch_8x8()
         graph = compile_to_paiir(ANNClassifier(), sample_input, compile_config=config)
 
         for node in offline_nodes(graph):
             assert node.core_params.tick_duration == 50
-            # 有激活函数的节点 tick_initial=1，StandaloneCompOp 无激活函数故为 0
             if isinstance(node, (SequentialOp, AccumulateOp, StandaloneActOp)):
                 assert node.core_params.tick_initial == 1
             elif isinstance(node, StandaloneCompOp):
                 assert node.core_params.tick_initial == 0
 
     def test_explicit_kwarg_overrides_config(self):
-        from paibox.paiir.ir.op_node import StandaloneCompOp
 
         config = CompileConfig(tick_duration=50, auto_reset=False)
         sample_input = make_img_3ch_8x8()
@@ -535,7 +532,8 @@ class TestStrictMode:
         pool_nodes = [
             node
             for node in graph.nodes.values()
-            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.AvgPool2d)
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.AvgPool2d)
         ]
         assert len(pool_nodes) == 1
 
@@ -602,8 +600,7 @@ class TestFunctionalConv:
         comp_nodes = [
             node
             for node in graph.nodes.values()
-            if isinstance(node, StandaloneCompOp)
-            and isinstance(node.comp, nn.Conv2d)
+            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.Conv2d)
         ]
         assert len(comp_nodes) == 1
         assert isinstance(comp_nodes[0].comp, nn.Conv2d)
@@ -620,8 +617,7 @@ class TestFunctionalConv:
         comp_nodes = [
             node
             for node in graph.nodes.values()
-            if isinstance(node, StandaloneCompOp)
-            and isinstance(node.comp, nn.Conv1d)
+            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.Conv1d)
         ]
         assert len(comp_nodes) == 1
         assert isinstance(comp_nodes[0].comp, nn.Conv1d)
@@ -643,8 +639,7 @@ class TestFunctionalConv:
         comp_nodes = [
             node
             for node in graph.nodes.values()
-            if isinstance(node, StandaloneCompOp)
-            and isinstance(node.comp, nn.Conv2d)
+            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.Conv2d)
         ]
         assert len(reshape_nodes) == 1
         assert len(comp_nodes) == 1
@@ -664,8 +659,7 @@ class TestFunctionalConv:
         comp_nodes = [
             node
             for node in graph.nodes.values()
-            if isinstance(node, StandaloneCompOp)
-            and isinstance(node.comp, nn.Conv2d)
+            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.Conv2d)
         ]
 
         assert reshape_nodes
@@ -766,8 +760,6 @@ class TestAvgPool1dCompilation:
     @pytest.mark.parametrize("kernel_size", AVGPOOL1D_KERNEL_SIZES)
     def test_avgpool1d_split_core_fusion(self, kernel_size):
         """Verify AvgPool1d-IF is fused into split-core deployment."""
-        from paibox.paiir.ir.op_node import StandaloneActOp
-
         model = SNNWithAvgPool1dIF(kernel_size)
         graph = compile_to_paiir(model, make_vec_64d())
 
@@ -866,10 +858,7 @@ class TestAvgPoolLIFSplitCore:
                 self.if1 = sj.IFNode(v_threshold=1.0)
                 self.pool = nn.AvgPool2d(2)
                 self.lif2 = sj.LIFNode(
-                    tau=5.0,
-                    decay_input=False,
-                    v_threshold=1.0,
-                    v_reset=0.0,
+                    tau=5.0, decay_input=False, v_threshold=1.0, v_reset=0.0
                 )
 
             def forward(self, x):
@@ -1032,15 +1021,11 @@ class TestAvgPoolCalibration:
             window_size,
             allow_split_lif=False,
             try_calibration=False,
+            avg_divisor=None,
         ):
             calls.append(try_calibration)
             return AvgPoolLIFCandidateScore(
-                AvgPoolDeployScheme.SHARED_CORE,
-                True,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
+                AvgPoolDeployScheme.SHARED_CORE, True, 0.0, 0.0, 0.0, 0.0
             )
 
         class AvgPoolLIF(nn.Module):
@@ -1154,14 +1139,10 @@ class TestAvgPoolCalibration:
             window_size,
             allow_split_lif=False,
             try_calibration=False,
+            avg_divisor=None,
         ):
             return AvgPoolLIFCandidateScore(
-                AvgPoolDeployScheme.SHARED_CORE,
-                False,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
+                AvgPoolDeployScheme.SHARED_CORE, False, 0.0, 0.0, 0.0, 0.0
             )
 
         class AvgPoolLIFNoDecay(nn.Module):
@@ -1205,14 +1186,10 @@ class TestAvgPoolCalibration:
             window_size,
             allow_split_lif=False,
             try_calibration=False,
+            avg_divisor=None,
         ):
             return AvgPoolLIFCandidateScore(
-                AvgPoolDeployScheme.SHARED_CORE,
-                True,
-                0.0,
-                0.0,
-                0.0,
-                0.0,
+                AvgPoolDeployScheme.SHARED_CORE, True, 0.0, 0.0, 0.0, 0.0
             )
 
         class AvgPoolLIFNoDecay(nn.Module):
@@ -1249,9 +1226,6 @@ class TestAvgPoolCalibration:
 
     def test_calibration_search_range(self):
         """Calibration searches in correct range around baseline."""
-        from paibox.paiir import LIFNodeV25
-        from paibox.paiir.pipeline.avgpool import calibrate_avgpool_threshold
-
         # Test the calibration function directly
         act = LIFNodeV25(tau=9.0, v_threshold=1.0)
         window_size = 4

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -1,3 +1,4 @@
+import importlib
 import warnings
 
 import pytest
@@ -9,31 +10,24 @@ from torch import nn
 
 import paibox.paiir.pipeline.avgpool.fusion as avgpool_fusion
 import paibox.paiir.pipeline.compile as compile_mod
-from paibox.paiir import CompileConfig, compile_to_paiir
+from paibox.paiir import CompileConfig, compile_to_paiir, torch_to_paiir
 from paibox.paiir.exceptions import UnsupportedOpError, UnsupportedOpWarning
 from paibox.paiir.ir.op_node import (
     AccumulateOp,
     ConcatOp,
+    ReshapeOp,
     SequentialOp,
     StandaloneActOp,
     StandaloneCompOp,
 )
-from paibox.paiir.lowering.converter import (
-    _DEFAULT_MODULE_MAP,
-    BYPASS_MODULE_TYPES,
-    _analyze_graph,
-    _EraseModuleTransformer,
-    _LoweringContext,
-    _PAIIRTracer,
-    _propagate_dims,
-    _propagate_shapes,
-)
+from paibox.paiir.lowering.converter import _analyze_graph, _LoweringContext
 from paibox.paiir.nn import SumPool1d, SumPool2d
 from paibox.paiir.pipeline.avgpool import (
-    AvgPoolDeployMetadata,
     AvgPoolDeployScheme,
     AvgPoolLIFCandidateScore,
 )
+from paibox.paiir.pipeline.avgpool.metadata import AvgPoolDeployMetadata
+from paibox.paiir.pipeline.passes import GraphCleanupWarning
 from tests.paiir.conftest import (
     ANNClassifier,
     SimpleCNN,
@@ -49,6 +43,7 @@ from tests.paiir.conftest import (
     make_vec_64d,
     offline_nodes,
 )
+from tests.paiir.tracing import trace_for_lowering
 
 
 class ConcatModel(nn.Module):
@@ -61,6 +56,32 @@ class ConcatModel(nn.Module):
 
     def forward(self, x):
         return self.relu(self.conv3(torch.cat([self.conv1(x), self.conv2(x)], dim=1)))
+
+
+class PoolAfterReshape(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pool = nn.MaxPool2d(2, 2)
+
+    def forward(self, x):
+        x = x.reshape(x.shape)
+        return self.pool(x)
+
+
+class TestPackageExports:
+    def test_public_packages_reexport_compile_symbols(self):
+        paiir_mod = importlib.import_module("paibox.paiir")
+        pipeline_mod = importlib.import_module("paibox.paiir.pipeline")
+        avgpool_mod = importlib.import_module("paibox.paiir.pipeline.avgpool")
+
+        assert paiir_mod.compile_to_paiir is compile_mod.compile_to_paiir
+        assert paiir_mod.torch_to_paiir is torch_to_paiir
+        assert pipeline_mod.CompileConfig is CompileConfig
+        assert pipeline_mod.compile_to_paiir is compile_mod.compile_to_paiir
+        assert avgpool_mod.calibrate_avgpool_threshold is not None
+        assert not hasattr(paiir_mod, "OfflineCoreOp")
+        assert not hasattr(pipeline_mod, "DataFormat")
+        assert not hasattr(avgpool_mod, "AvgPoolDeployMetadata")
 
 
 class TestCompileBasic:
@@ -94,6 +115,174 @@ class TestCompileBasic:
         concat_nodes = find_nodes(graph, ConcatOp)
         assert len(concat_nodes) == 1
         assert concat_nodes[0].dim == 1
+
+    def test_transpose_then_flatten_before_linear_compiles(self):
+        class TransposeFlattenLinear(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(6, 4, bias=False)
+
+            def forward(self, x):
+                return self.linear(x.transpose(1, 2).flatten(1))
+
+        graph = compile_to_paiir(TransposeFlattenLinear(), torch.randn(1, 2, 3))
+
+        reshape_nodes = find_nodes(graph, ReshapeOp)
+        linear_nodes = [
+            node
+            for node in find_nodes(graph, StandaloneCompOp)
+            if isinstance(node.comp, nn.Linear)
+        ]
+
+        assert len(reshape_nodes) == 1
+        assert len(linear_nodes) == 1
+        assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
+        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[0].name]
+
+    def test_permute_then_reshape_before_linear_compiles(self):
+        class PermuteReshapeLinear(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(24, 5, bias=False)
+
+            def forward(self, x):
+                x = x.permute(0, 2, 3, 1)
+                x = x.reshape(x.size(0), -1)
+                return self.linear(x)
+
+        graph = compile_to_paiir(PermuteReshapeLinear(), torch.randn(1, 2, 3, 4))
+
+        reshape_nodes = find_nodes(graph, ReshapeOp)
+        linear_nodes = [
+            node
+            for node in find_nodes(graph, StandaloneCompOp)
+            if isinstance(node.comp, nn.Linear)
+        ]
+
+        assert len(reshape_nodes) == 1
+        assert len(linear_nodes) == 1
+        assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
+        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[0].name]
+
+    def test_maxpool_after_reshape_compiles(self):
+        graph = compile_to_paiir(PoolAfterReshape(), make_img_3ch_8x8())
+
+        reshape_nodes = find_nodes(graph, ReshapeOp)
+        pool_nodes = [
+            node
+            for node in find_nodes(graph, StandaloneCompOp)
+            if isinstance(node.comp, nn.MaxPool2d)
+        ]
+
+        assert len(reshape_nodes) == 1
+        assert len(pool_nodes) == 1
+        assert graph.predecessors(pool_nodes[0].name) == [reshape_nodes[0].name]
+        assert pool_nodes[0].core_params.input_sign is not None
+        assert pool_nodes[0].core_params.input_width is not None
+
+    def test_function_unsqueeze_before_linear_compiles(self):
+        class FunctionUnsqueezeLinear(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(6, 4, bias=False)
+
+            def forward(self, x):
+                x = torch.unsqueeze(x, 1)
+                x = x.flatten(1)
+                return self.linear(x)
+
+        graph = compile_to_paiir(FunctionUnsqueezeLinear(), torch.randn(1, 2, 3))
+
+        reshape_nodes = find_nodes(graph, ReshapeOp)
+        linear_nodes = [
+            node
+            for node in find_nodes(graph, StandaloneCompOp)
+            if isinstance(node.comp, nn.Linear)
+        ]
+
+        assert len(reshape_nodes) == 2
+        assert len(linear_nodes) == 1
+        assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
+        assert graph.predecessors(reshape_nodes[1].name) == [reshape_nodes[0].name]
+        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[1].name]
+
+    def test_tuple_repeat_all_ones_before_linear_compiles(self):
+        class TupleRepeatLinear(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(6, 4, bias=False)
+
+            def forward(self, x):
+                x = x.repeat((1, 1, 1))
+                x = x.flatten(1)
+                return self.linear(x)
+
+        graph = compile_to_paiir(TupleRepeatLinear(), torch.randn(1, 2, 3))
+
+        reshape_nodes = find_nodes(graph, ReshapeOp)
+        linear_nodes = [
+            node
+            for node in find_nodes(graph, StandaloneCompOp)
+            if isinstance(node.comp, nn.Linear)
+        ]
+
+        assert len(reshape_nodes) == 2
+        assert len(linear_nodes) == 1
+        assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
+        assert graph.predecessors(reshape_nodes[1].name) == [reshape_nodes[0].name]
+        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[1].name]
+
+    def test_method_squeeze_before_linear_compiles(self):
+        class MethodSqueezeLinear(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(6, 4, bias=False)
+
+            def forward(self, x):
+                x = x.squeeze(1)
+                x = x.flatten(1)
+                return self.linear(x)
+
+        graph = compile_to_paiir(MethodSqueezeLinear(), torch.randn(1, 1, 2, 3))
+
+        reshape_nodes = find_nodes(graph, ReshapeOp)
+        linear_nodes = [
+            node
+            for node in find_nodes(graph, StandaloneCompOp)
+            if isinstance(node.comp, nn.Linear)
+        ]
+
+        assert len(reshape_nodes) == 2
+        assert len(linear_nodes) == 1
+        assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
+        assert graph.predecessors(reshape_nodes[1].name) == [reshape_nodes[0].name]
+        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[1].name]
+
+    def test_function_squeeze_before_linear_compiles(self):
+        class FunctionSqueezeLinear(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(6, 4, bias=False)
+
+            def forward(self, x):
+                x = torch.squeeze(x, 1)
+                x = x.flatten(1)
+                return self.linear(x)
+
+        graph = compile_to_paiir(FunctionSqueezeLinear(), torch.randn(1, 1, 2, 3))
+
+        reshape_nodes = find_nodes(graph, ReshapeOp)
+        linear_nodes = [
+            node
+            for node in find_nodes(graph, StandaloneCompOp)
+            if isinstance(node.comp, nn.Linear)
+        ]
+
+        assert len(reshape_nodes) == 2
+        assert len(linear_nodes) == 1
+        assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
+        assert graph.predecessors(reshape_nodes[1].name) == [reshape_nodes[0].name]
+        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[1].name]
 
 
 class TestDataFormat:
@@ -316,6 +505,21 @@ class FunctionalQuantizedConv(nn.Module):
         return F.conv2d(x, w, self.bias, stride=1, padding=1, dilation=1, groups=1)
 
 
+class FunctionalQuantizedConv1d(nn.Module):
+    def __init__(self):
+        super().__init__()
+        weight = torch.randint(-8, 8, (4, 3, 3), dtype=torch.int8)
+        bias = torch.randn(4)
+        scale = torch.tensor(0.125)
+        self.register_buffer("weight_int8", weight)
+        self.register_buffer("weight_scale", scale)
+        self.register_buffer("bias", bias)
+
+    def forward(self, x):
+        w = self.weight_int8.to(x.dtype) * self.weight_scale
+        return F.conv1d(x, w, self.bias, stride=1, padding=1, dilation=1, groups=1)
+
+
 class FunctionalQuantizedConvWithShapeReshape(nn.Module):
     def __init__(self):
         super().__init__()
@@ -338,18 +542,7 @@ class FunctionalQuantizedConvWithShapeReshape(nn.Module):
         return self.relu(y)
 
 
-class TestFunctionalConv2d:
-    @staticmethod
-    def _trace_for_lowering(model: nn.Module, sample_input: torch.Tensor):
-        leaf_types = tuple(_DEFAULT_MODULE_MAP.keys()) + BYPASS_MODULE_TYPES
-        tracer = _PAIIRTracer(custom_leaf_modules=leaf_types)
-        traced = tracer.trace(model)
-        gm = torch.fx.GraphModule(tracer.root, traced)
-        gm = _EraseModuleTransformer(gm).transform()
-        _propagate_shapes(gm, sample_input)
-        _propagate_dims(gm)
-        return gm
-
+class TestFunctionalConv:
     def test_quantized_functional_conv2d_supported_in_strict_mode(self):
         model = FunctionalQuantizedConv()
         with warnings.catch_warnings(record=True) as caught:
@@ -360,7 +553,7 @@ class TestFunctionalConv2d:
             node
             for node in graph.nodes.values()
             if isinstance(node, StandaloneCompOp)
-            and type(node.comp).__name__ == "FunctionalConv2d"
+            and isinstance(node.comp, nn.Conv2d)
         ]
         assert len(comp_nodes) == 1
         assert isinstance(comp_nodes[0].comp, nn.Conv2d)
@@ -368,23 +561,100 @@ class TestFunctionalConv2d:
         assert graph.predecessors(comp_nodes[0].name) == ["InputNode_0"]
         assert not any("conv2d" in str(w.message) for w in caught)
 
+    def test_quantized_functional_conv1d_supported_in_strict_mode(self):
+        model = FunctionalQuantizedConv1d()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            graph = compile_to_paiir(model, torch.randn(1, 3, 16), strict=True)
+
+        comp_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.Conv1d)
+        ]
+        assert len(comp_nodes) == 1
+        assert isinstance(comp_nodes[0].comp, nn.Conv1d)
+        assert torch.equal(comp_nodes[0].comp.raw_weight, model.weight_int8)
+        assert graph.predecessors(comp_nodes[0].name) == ["InputNode_0"]
+        assert not any("conv1d" in str(w.message) for w in caught)
+
     def test_shape_only_reshape_args_do_not_become_data_predecessors(self):
-        graph = compile_to_paiir(
+        graph = torch_to_paiir(
             FunctionalQuantizedConvWithShapeReshape(),
             torch.randn(1, 3, 8, 8),
             strict=False,
         )
+        graph.summary()
 
-        seq_nodes = [
-            node for node in graph.nodes.values() if isinstance(node, SequentialOp)
+        reshape_nodes = [
+            node for node in graph.nodes.values() if node.name == "ReshapeOp_0"
         ]
-        assert len(seq_nodes) == 1
+        comp_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.Conv2d)
+        ]
+        assert len(reshape_nodes) == 1
+        assert len(comp_nodes) == 1
         assert graph.predecessors("ReshapeOp_0") == ["InputNode_0"]
-        assert graph.predecessors(seq_nodes[0].name) == ["ReshapeOp_0"]
+        assert graph.predecessors("ReshapeOp_1") == ["ReshapeOp_0"]
+        assert graph.predecessors("ReshapeOp_2") == ["ReshapeOp_1"]
+        assert graph.predecessors(comp_nodes[0].name) == ["ReshapeOp_2"]
+
+    def test_unsqueeze_repeat_all_ones_compile_path_succeeds(self):
+        graph = compile_to_paiir(
+            FunctionalQuantizedConvWithShapeReshape(),
+            torch.randn(1, 3, 8, 8),
+            strict=True,
+        )
+
+        reshape_nodes = find_nodes(graph, ReshapeOp)
+        comp_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.Conv2d)
+        ]
+
+        assert reshape_nodes
+        assert comp_nodes
+        assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
+
+    def test_view_as_reference_path_does_not_become_data_predecessor(self):
+        class ViewAsReferenceFromFlatten(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(12, 4, bias=False)
+
+            def forward(self, x):
+                ref = x.flatten(1)
+                y = x.view_as(ref)
+                return self.linear(y)
+
+        model = ViewAsReferenceFromFlatten()
+
+        with pytest.warns(GraphCleanupWarning, match="disconnected"):
+            graph = compile_to_paiir(model, torch.randn(1, 3, 2, 2))
+
+        reshape_nodes = [
+            node for node in graph.nodes.values() if isinstance(node, ReshapeOp)
+        ]
+        comp_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.Linear)
+        ]
+
+        assert len(reshape_nodes) == 1
+        assert len(comp_nodes) == 1
+        assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
+        assert graph.predecessors(comp_nodes[0].name) == [reshape_nodes[0].name]
 
     def test_analysis_prebuilds_functional_conv_and_marks_shape_aux_nodes(self):
         sample = torch.randn(1, 3, 8, 8)
-        gm = self._trace_for_lowering(FunctionalQuantizedConvWithShapeReshape(), sample)
+        gm = trace_for_lowering(FunctionalQuantizedConvWithShapeReshape(), sample)
         ctx = _LoweringContext()
 
         _analyze_graph(gm, ctx)
@@ -408,6 +678,29 @@ class TestFunctionalConv2d:
         ]
         assert shape_getattrs
         assert all(node in ctx.aux_bypass_nodes for node in shape_getattrs)
+        assert ctx.shape_analysis is not None
+        reshape_nodes = [
+            node
+            for node in gm.graph.nodes
+            if ctx.shape_analysis.sink_for(node) is not None
+        ]
+        assert reshape_nodes
+
+    def test_analysis_prebuilds_functional_conv1d_node(self):
+        sample = torch.randn(1, 3, 16)
+        gm = trace_for_lowering(FunctionalQuantizedConv1d(), sample)
+        ctx = _LoweringContext()
+
+        _analyze_graph(gm, ctx)
+
+        conv_nodes = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and getattr(node.target, "__name__", "") == "conv1d"
+        ]
+        assert len(conv_nodes) == 1
+        assert conv_nodes[0] in ctx.prebuilt_ir_nodes
 
 
 # Parametric test values: kernel_size for AvgPool1d

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -68,6 +68,34 @@ class PoolAfterReshape(nn.Module):
         return self.pool(x)
 
 
+class UnsupportedCountIncludePadAvgPool2d(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pool = nn.AvgPool2d(
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            count_include_pad=False,
+        )
+
+    def forward(self, x):
+        return self.pool(x)
+
+
+class SupportedNoPaddingCountIncludePadAvgPool2d(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pool = nn.AvgPool2d(
+            kernel_size=3,
+            stride=1,
+            padding=0,
+            count_include_pad=False,
+        )
+
+    def forward(self, x):
+        return self.pool(x)
+
+
 class TestPackageExports:
     def test_public_packages_reexport_compile_symbols(self):
         paiir_mod = importlib.import_module("paibox.paiir")
@@ -488,6 +516,28 @@ class TestStrictMode:
     def test_non_strict_warns(self):
         with pytest.warns(UnsupportedOpWarning):
             compile_to_paiir(UnsupportedSoftmax(), torch.randn(1, 10), strict=False)
+
+    def test_strict_raises_for_count_include_pad_false_with_padding(self):
+        with pytest.raises(UnsupportedOpError, match="count_include_pad=False"):
+            compile_to_paiir(
+                UnsupportedCountIncludePadAvgPool2d(),
+                make_img_3ch_8x8(),
+                strict=True,
+            )
+
+    def test_padding_free_count_include_pad_false_still_compiles(self):
+        graph = compile_to_paiir(
+            SupportedNoPaddingCountIncludePadAvgPool2d(),
+            make_img_3ch_8x8(),
+            strict=True,
+        )
+
+        pool_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.AvgPool2d)
+        ]
+        assert len(pool_nodes) == 1
 
 
 class FunctionalQuantizedConv(nn.Module):

--- a/tests/paiir/pipeline/test_data_format.py
+++ b/tests/paiir/pipeline/test_data_format.py
@@ -8,7 +8,13 @@ from torch import nn
 
 from paibox.paiir.ir.core_neuron import ANNNodeV25, CoreNeuronV25, IFNodeV25, LIFNodeV25
 from paibox.paiir.ir.lut_activation import LutReLU, LutSigmoid, LutTanh
-from paibox.paiir.ir.op_node import AccumulateOp, OfflineCoreOp, StandaloneActOp
+from paibox.paiir.ir.op_node import (
+    AccumulateOp,
+    OfflineCoreOp,
+    SequentialOp,
+    StandaloneActOp,
+    StandaloneCompOp,
+)
 from paibox.paiir.lowering.converter import torch_to_paiir
 from paibox.paiir.pipeline.data_format import (
     infer_output_format,
@@ -251,6 +257,47 @@ class TestPropagateDataFormatANN:
         assert second.core_params.input_width == DataWidth.WIDTH_8BIT
         assert second.core_params.output_sign == DataSign.UNSIGNED
         assert second.core_params.output_width == DataWidth.WIDTH_8BIT
+
+    @pytest.mark.parametrize(
+        "input_format",
+        [
+            (DataSign.UNSIGNED, DataWidth.WIDTH_8BIT),
+            (DataSign.SIGNED, DataWidth.WIDTH_8BIT),
+            (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT),
+        ],
+        ids=["u8", "i8", "u1"],
+    )
+    def test_standalone_maxpool_preserves_predecessor_format(self, input_format):
+        class MaxPoolConvRelu(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = nn.MaxPool2d(2, 2)
+                self.conv = nn.Conv2d(3, 4, 3, padding=1, bias=False)
+                self.relu = nn.ReLU()
+
+            def forward(self, x):
+                return self.relu(self.conv(self.pool(x)))
+
+        unfused = torch_to_paiir(MaxPoolConvRelu(), torch.randn(1, 3, 8, 8))
+        fused = fuse_to_offline_cores(specialize_general_adds(unfused))
+
+        inp_name = fused.input_nodes()[0].name
+        propagate_data_format(fused, input_formats={inp_name: input_format})
+
+        pool = next(
+            node
+            for node in fused.nodes.values()
+            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.MaxPool2d)
+        )
+        conv = next(
+            node
+            for node in fused.nodes.values()
+            if isinstance(node, SequentialOp) and isinstance(node.comp, nn.Conv2d)
+        )
+
+        assert (pool.core_params.input_sign, pool.core_params.input_width) == input_format
+        assert (pool.core_params.output_sign, pool.core_params.output_width) == input_format
+        assert (conv.core_params.input_sign, conv.core_params.input_width) == input_format
 
     def test_subtract_tanh(self):
         """Two linear branches with subtraction -> tanh: UNSIGNED 8BIT."""

--- a/tests/paiir/pipeline/test_data_format.py
+++ b/tests/paiir/pipeline/test_data_format.py
@@ -287,7 +287,8 @@ class TestPropagateDataFormatANN:
         pool = next(
             node
             for node in fused.nodes.values()
-            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.MaxPool2d)
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.MaxPool2d)
         )
         conv = next(
             node
@@ -295,9 +296,18 @@ class TestPropagateDataFormatANN:
             if isinstance(node, SequentialOp) and isinstance(node.comp, nn.Conv2d)
         )
 
-        assert (pool.core_params.input_sign, pool.core_params.input_width) == input_format
-        assert (pool.core_params.output_sign, pool.core_params.output_width) == input_format
-        assert (conv.core_params.input_sign, conv.core_params.input_width) == input_format
+        assert (
+            pool.core_params.input_sign,
+            pool.core_params.input_width,
+        ) == input_format
+        assert (
+            pool.core_params.output_sign,
+            pool.core_params.output_width,
+        ) == input_format
+        assert (
+            conv.core_params.input_sign,
+            conv.core_params.input_width,
+        ) == input_format
 
     def test_subtract_tanh(self):
         """Two linear branches with subtraction -> tanh: UNSIGNED 8BIT."""

--- a/tests/paiir/pipeline/test_graph_simulation.py
+++ b/tests/paiir/pipeline/test_graph_simulation.py
@@ -13,9 +13,11 @@ from paibox.paiir.ir.op_node import (
     AccumulateOp,
     ConcatOp,
     OfflineCoreOp,
+    ReshapeOp,
     SequentialOp,
     StandaloneCompOp,
 )
+from paibox.paiir.pipeline.passes import GraphCleanupWarning
 from tests.paiir.conftest import MultiInputMerge, find_nodes
 
 
@@ -690,13 +692,35 @@ class TestMultiLayerSNN:
     def test_flatten_linear_transition(self) -> None:
         """SNNFlattenTransition: Conv -> flatten -> Linear.
 
-        Tests spatial-to-dense transition in SNN context.
-
-        Note: Currently skipped because PAIIR does not capture flatten/reshape
-        operations between Conv and Linear. The graph structure expects the
-        Linear input shape (1, 128) but receives (1, 8, 4, 4) from the Conv.
+        Tests spatial-to-dense transition in SNN context now that flatten is
+        materialized as a routing ``ReshapeOp`` for graph simulation.
         """
-        pytest.skip("PAIIR does not capture flatten operations between Conv and Linear")
+        from tests.paiir.conftest import SNNFlattenTransition
+
+        model = SNNFlattenTransition()
+        _set_quantized_weights(model)
+
+        x_compile = torch.randn(1, 1, 4, 4)
+        x_int8 = torch.randint(0, 2, (1, 1, 4, 4), dtype=torch.int8)
+
+        sj_out = _run_snn_reference(model, x_int8)
+        assert torch.is_tensor(sj_out)
+
+        graph = compile_to_paiir(model, x_compile)
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 1
+
+        graph.reset()
+        max_tick_start = max(
+            n.core_params.tick_start
+            for n in graph.nodes.values()
+            if isinstance(n, OfflineCoreOp) and n.core_params.tick_start is not None
+        )
+        for _ in range(max_tick_start):
+            paiir_out = graph.step(x_int8)
+
+        assert torch.is_tensor(paiir_out)
+        assert torch.equal(paiir_out, sj_out)
 
     def test_depthwise_separable(self) -> None:
         """SNNDepthwiseSeparable: DWConv -> PWConv.
@@ -1178,4 +1202,446 @@ class TestStandaloneOpSimulation:
         paiir_out = graph.step(x_int8)
 
         assert torch.is_tensor(paiir_out)
+        assert torch.equal(paiir_out, pytorch_out)
+
+    def test_view_and_view_as_routing_before_linear(self) -> None:
+        """`view(size(0), -1)` and `view_as(...)` execute as routing ops."""
+
+        class ViewLinear(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(12, 4, bias=False)
+
+            def forward(self, x: Tensor) -> Tensor:
+                x = x.view(x.size(0), -1)
+                x = x.view_as(x)
+                return self.linear(x)
+
+        model = ViewLinear()
+        _set_quantized_weights(model)
+
+        x_compile = torch.randn(1, 3, 2, 2)
+        x_int8 = torch.randint(-128, 128, (1, 3, 2, 2), dtype=torch.int8)
+
+        model.eval()
+        with torch.no_grad():
+            pytorch_out = model(x_int8.float())
+
+        graph = compile_to_paiir(model, x_compile)
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 2
+
+        graph.reset()
+        max_tick_start = max(
+            n.core_params.tick_start
+            for n in graph.nodes.values()
+            if isinstance(n, OfflineCoreOp) and n.core_params.tick_start is not None
+        )
+        for _ in range(max_tick_start):
+            paiir_out = graph.step(x_int8)
+
+        assert torch.is_tensor(paiir_out)
+        assert torch.equal(paiir_out, pytorch_out)
+
+    def test_view_as_reference_path_before_linear(self) -> None:
+        """`view_as(ref)` uses only the data tensor as the runtime graph input."""
+
+        class ViewAsReferenceFromFlatten(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(12, 4, bias=False)
+
+            def forward(self, x: Tensor) -> Tensor:
+                ref = x.flatten(1)
+                y = x.view_as(ref)
+                return self.linear(y)
+
+        model = ViewAsReferenceFromFlatten()
+        _set_quantized_weights(model)
+
+        x_compile = torch.randn(1, 3, 2, 2)
+        x_int8 = torch.randint(-128, 128, (1, 3, 2, 2), dtype=torch.int8)
+
+        model.eval()
+        with torch.no_grad():
+            pytorch_out = model(x_int8.float())
+
+        with pytest.warns(GraphCleanupWarning, match="disconnected"):
+            graph = compile_to_paiir(model, x_compile)
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 1
+
+        graph.reset()
+        max_tick_start = max(
+            n.core_params.tick_start
+            for n in graph.nodes.values()
+            if isinstance(n, OfflineCoreOp) and n.core_params.tick_start is not None
+        )
+        for _ in range(max_tick_start):
+            paiir_out = graph.step(x_int8)
+
+        assert torch.is_tensor(paiir_out)
+        assert torch.equal(paiir_out, pytorch_out)
+
+    def test_view_shape_arithmetic_before_linear(self) -> None:
+        """Shape arithmetic feeding `view(...)` is treated as shape-only aux graph."""
+
+        class ViewShapeArithmetic(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(24, 5, bias=False)
+
+            def forward(self, x: Tensor) -> Tensor:
+                batch = x.size(0) + x.size(1) - x.size(1)
+                features = (x.size(1) * x.size(2) * x.size(3)) // batch
+                return self.linear(x.view(batch, features))
+
+        model = ViewShapeArithmetic()
+        _set_quantized_weights(model)
+
+        x_compile = torch.randn(1, 2, 3, 4)
+        x_int8 = torch.randint(-128, 128, (1, 2, 3, 4), dtype=torch.int8)
+
+        model.eval()
+        with torch.no_grad():
+            pytorch_out = model(x_int8.float())
+
+        graph = compile_to_paiir(model, x_compile)
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 1
+
+        graph.reset()
+        max_tick_start = max(
+            n.core_params.tick_start
+            for n in graph.nodes.values()
+            if isinstance(n, OfflineCoreOp) and n.core_params.tick_start is not None
+        )
+        for _ in range(max_tick_start):
+            paiir_out = graph.step(x_int8)
+
+        assert torch.is_tensor(paiir_out)
+        assert torch.equal(paiir_out, pytorch_out)
+
+    def test_function_unsqueeze_before_linear(self) -> None:
+        """Function-form `torch.unsqueeze(...)` executes as a routing op."""
+
+        class FunctionUnsqueezeLinear(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(6, 4, bias=False)
+
+            def forward(self, x: Tensor) -> Tensor:
+                x = torch.unsqueeze(x, 1)
+                x = x.flatten(1)
+                return self.linear(x)
+
+        model = FunctionUnsqueezeLinear()
+        _set_quantized_weights(model)
+
+        x_compile = torch.randn(1, 2, 3)
+        x_int8 = torch.randint(-128, 128, (1, 2, 3), dtype=torch.int8)
+
+        model.eval()
+        with torch.no_grad():
+            pytorch_out = model(x_int8.float())
+
+        graph = compile_to_paiir(model, x_compile)
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 2
+
+        graph.reset()
+        max_tick_start = max(
+            n.core_params.tick_start
+            for n in graph.nodes.values()
+            if isinstance(n, OfflineCoreOp) and n.core_params.tick_start is not None
+        )
+        for _ in range(max_tick_start):
+            paiir_out = graph.step(x_int8)
+
+        assert torch.is_tensor(paiir_out)
+        assert torch.equal(paiir_out, pytorch_out)
+
+    def test_tuple_repeat_all_ones_before_linear(self) -> None:
+        """Tuple-form identity `repeat((1,...))` executes as a routing no-op."""
+
+        class TupleRepeatLinear(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(6, 4, bias=False)
+
+            def forward(self, x: Tensor) -> Tensor:
+                x = x.repeat((1, 1, 1))
+                x = x.flatten(1)
+                return self.linear(x)
+
+        model = TupleRepeatLinear()
+        _set_quantized_weights(model)
+
+        x_compile = torch.randn(1, 2, 3)
+        x_int8 = torch.randint(-128, 128, (1, 2, 3), dtype=torch.int8)
+
+        model.eval()
+        with torch.no_grad():
+            pytorch_out = model(x_int8.float())
+
+        graph = compile_to_paiir(model, x_compile)
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 2
+
+        graph.reset()
+        max_tick_start = max(
+            n.core_params.tick_start
+            for n in graph.nodes.values()
+            if isinstance(n, OfflineCoreOp) and n.core_params.tick_start is not None
+        )
+        for _ in range(max_tick_start):
+            paiir_out = graph.step(x_int8)
+
+        assert torch.is_tensor(paiir_out)
+        assert torch.equal(paiir_out, pytorch_out)
+
+    def test_method_squeeze_before_linear(self) -> None:
+        """Method-form `squeeze(...)` executes as a routing op."""
+
+        class MethodSqueezeLinear(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(6, 4, bias=False)
+
+            def forward(self, x: Tensor) -> Tensor:
+                x = x.squeeze(1)
+                x = x.flatten(1)
+                return self.linear(x)
+
+        model = MethodSqueezeLinear()
+        _set_quantized_weights(model)
+
+        x_compile = torch.randn(1, 1, 2, 3)
+        x_int8 = torch.randint(-128, 128, (1, 1, 2, 3), dtype=torch.int8)
+
+        model.eval()
+        with torch.no_grad():
+            pytorch_out = model(x_int8.float())
+
+        graph = compile_to_paiir(model, x_compile)
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 2
+
+        graph.reset()
+        max_tick_start = max(
+            n.core_params.tick_start
+            for n in graph.nodes.values()
+            if isinstance(n, OfflineCoreOp) and n.core_params.tick_start is not None
+        )
+        for _ in range(max_tick_start):
+            paiir_out = graph.step(x_int8)
+
+        assert torch.is_tensor(paiir_out)
+        assert torch.equal(paiir_out, pytorch_out)
+
+    def test_function_squeeze_before_linear(self) -> None:
+        """Function-form `torch.squeeze(...)` executes as a routing op."""
+
+        class FunctionSqueezeLinear(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(6, 4, bias=False)
+
+            def forward(self, x: Tensor) -> Tensor:
+                x = torch.squeeze(x, 1)
+                x = x.flatten(1)
+                return self.linear(x)
+
+        model = FunctionSqueezeLinear()
+        _set_quantized_weights(model)
+
+        x_compile = torch.randn(1, 1, 2, 3)
+        x_int8 = torch.randint(-128, 128, (1, 1, 2, 3), dtype=torch.int8)
+
+        model.eval()
+        with torch.no_grad():
+            pytorch_out = model(x_int8.float())
+
+        graph = compile_to_paiir(model, x_compile)
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 2
+
+        graph.reset()
+        max_tick_start = max(
+            n.core_params.tick_start
+            for n in graph.nodes.values()
+            if isinstance(n, OfflineCoreOp) and n.core_params.tick_start is not None
+        )
+        for _ in range(max_tick_start):
+            paiir_out = graph.step(x_int8)
+
+        assert torch.is_tensor(paiir_out)
+        assert torch.equal(paiir_out, pytorch_out)
+
+    def test_transpose_then_flatten_before_linear(self) -> None:
+        """Bypassed transpose metadata is materialized at the downstream reshape op."""
+
+        class TransposeFlattenLinear(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(6, 4, bias=False)
+
+            def forward(self, x: Tensor) -> Tensor:
+                return self.linear(x.transpose(1, 2).flatten(1))
+
+        model = TransposeFlattenLinear()
+        _set_quantized_weights(model)
+
+        x_compile = torch.randn(1, 2, 3)
+        x_int8 = torch.randint(-128, 128, (1, 2, 3), dtype=torch.int8)
+
+        model.eval()
+        with torch.no_grad():
+            pytorch_out = model(x_int8.float())
+
+        graph = compile_to_paiir(model, x_compile)
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 1
+
+        graph.reset()
+        max_tick_start = max(
+            n.core_params.tick_start
+            for n in graph.nodes.values()
+            if isinstance(n, OfflineCoreOp) and n.core_params.tick_start is not None
+        )
+        for _ in range(max_tick_start):
+            paiir_out = graph.step(x_int8)
+
+        assert torch.is_tensor(paiir_out)
+        assert torch.equal(paiir_out, pytorch_out)
+
+    def test_permute_then_reshape_before_linear(self) -> None:
+        """Bypassed permute metadata is materialized at the downstream reshape op."""
+
+        class PermuteReshapeLinear(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(24, 5, bias=False)
+
+            def forward(self, x: Tensor) -> Tensor:
+                x = x.permute(0, 2, 3, 1)
+                x = x.reshape(x.size(0), -1)
+                return self.linear(x)
+
+        model = PermuteReshapeLinear()
+        _set_quantized_weights(model)
+
+        x_compile = torch.randn(1, 2, 3, 4)
+        x_int8 = torch.randint(-128, 128, (1, 2, 3, 4), dtype=torch.int8)
+
+        model.eval()
+        with torch.no_grad():
+            pytorch_out = model(x_int8.float())
+
+        graph = compile_to_paiir(model, x_compile)
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 1
+
+        graph.reset()
+        max_tick_start = max(
+            n.core_params.tick_start
+            for n in graph.nodes.values()
+            if isinstance(n, OfflineCoreOp) and n.core_params.tick_start is not None
+        )
+        for _ in range(max_tick_start):
+            paiir_out = graph.step(x_int8)
+
+        assert torch.is_tensor(paiir_out)
+        assert torch.equal(paiir_out, pytorch_out)
+
+    def test_flatten_then_reshape_chain_before_linear(self) -> None:
+        """Chained `flatten -> reshape(size arithmetic) -> flatten -> Linear` simulates."""
+
+        class FlattenReshapeLinear(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(24, 5, bias=False)
+
+            def forward(self, x: Tensor) -> Tensor:
+                x = x.flatten(1)
+                x = x.reshape(x.size(0), 2, x.size(1) // 2)
+                x = x.flatten(1)
+                return self.linear(x)
+
+        model = FlattenReshapeLinear()
+        _set_quantized_weights(model)
+
+        x_compile = torch.randn(1, 2, 3, 4)
+        x_int8 = torch.randint(-128, 128, (1, 2, 3, 4), dtype=torch.int8)
+
+        model.eval()
+        with torch.no_grad():
+            pytorch_out = model(x_int8.float())
+
+        graph = compile_to_paiir(model, x_compile)
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 3
+
+        graph.reset()
+        max_tick_start = max(
+            n.core_params.tick_start
+            for n in graph.nodes.values()
+            if isinstance(n, OfflineCoreOp) and n.core_params.tick_start is not None
+        )
+        for _ in range(max_tick_start):
+            paiir_out = graph.step(x_int8)
+
+        assert torch.is_tensor(paiir_out)
+        assert torch.equal(paiir_out, pytorch_out)
+
+    @pytest.mark.parametrize("dtype", [torch.uint8, torch.int8], ids=["uint8", "int8"])
+    def test_standalone_maxpool_preserves_integer_dtype(
+        self, dtype: torch.dtype
+    ) -> None:
+        model = nn.MaxPool2d(2, 2)
+
+        x_compile = torch.randn(1, 1, 4, 4)
+        x_int = torch.arange(16, dtype=dtype).reshape(1, 1, 4, 4)
+
+        with torch.no_grad():
+            pytorch_out = model(x_int)
+
+        graph = compile_to_paiir(model, x_compile)
+
+        standalone_ops = [
+            n for n in graph.nodes.values() if isinstance(n, StandaloneCompOp)
+        ]
+        assert len(standalone_ops) == 1
+
+        graph.reset()
+        paiir_out = graph.step(x_int)
+
+        assert torch.is_tensor(paiir_out)
+        assert paiir_out.dtype == dtype
+        assert torch.equal(paiir_out, pytorch_out)
+
+    @pytest.mark.parametrize("dtype", [torch.uint8, torch.int8], ids=["uint8", "int8"])
+    def test_standalone_maxpool1d_preserves_integer_dtype(
+        self, dtype: torch.dtype
+    ) -> None:
+        model = nn.MaxPool1d(2, 2)
+
+        x_compile = torch.randn(1, 1, 8)
+        x_int = torch.arange(8, dtype=dtype).reshape(1, 1, 8)
+
+        with torch.no_grad():
+            pytorch_out = model(x_int.to(torch.float32)).to(dtype)
+
+        graph = compile_to_paiir(model, x_compile)
+
+        standalone_ops = [
+            n for n in graph.nodes.values() if isinstance(n, StandaloneCompOp)
+        ]
+        assert len(standalone_ops) == 1
+
+        graph.reset()
+        paiir_out = graph.step(x_int)
+
+        assert torch.is_tensor(paiir_out)
+        assert paiir_out.dtype == dtype
         assert torch.equal(paiir_out, pytorch_out)

--- a/tests/paiir/pipeline/test_graph_simulation.py
+++ b/tests/paiir/pipeline/test_graph_simulation.py
@@ -8,6 +8,7 @@ from spikingjelly.activation_based import functional as sF
 from spikingjelly.activation_based import neuron as sj
 from torch import Tensor, nn
 
+import paibox.paiir.pipeline.avgpool.fusion as avgpool_fusion
 from paibox.paiir import compile_to_paiir
 from paibox.paiir.ir.op_node import (
     AccumulateOp,
@@ -16,6 +17,10 @@ from paibox.paiir.ir.op_node import (
     ReshapeOp,
     SequentialOp,
     StandaloneCompOp,
+)
+from paibox.paiir.pipeline.avgpool import (
+    AvgPoolDeployScheme,
+    AvgPoolLIFCandidateScore,
 )
 from paibox.paiir.pipeline.passes import GraphCleanupWarning
 from tests.paiir.conftest import MultiInputMerge, find_nodes
@@ -820,14 +825,69 @@ class TestMultiLayerSNN:
         assert paiir_out.shape == sj_out.shape
         assert torch.equal(paiir_out, sj_out)
 
-    def test_avgpool_lif_split_core_snn(self) -> None:
+    def test_avgpool_if_snn_with_divisor_override(self) -> None:
+        class AvgPoolIFDivisorOne(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(3, 3, 3, padding=1)
+                self.if1 = sj.IFNode(v_threshold=1.0)
+                self.pool = nn.AvgPool2d(2, divisor_override=1)
+                self.if2 = sj.IFNode(v_threshold=1.0)
+
+            def forward(self, x):
+                x = self.if1(self.conv(x))
+                return self.if2(self.pool(x))
+
+        model = AvgPoolIFDivisorOne()
+        _set_quantized_weights(model)
+
+        x_compile = torch.randn(1, 3, 8, 8)
+        x_int8 = _make_snn_input()
+
+        sj_out = _run_snn_reference(model, x_int8)
+        assert torch.is_tensor(sj_out)
+
+        graph = compile_to_paiir(model, x_compile)
+        graph.reset()
+
+        max_tick_start = max(
+            n.core_params.tick_start
+            for n in graph.nodes.values()
+            if isinstance(n, OfflineCoreOp) and n.core_params.tick_start is not None
+        )
+        for _ in range(max_tick_start):
+            paiir_out = graph.step(x_int8)
+
+        assert torch.is_tensor(paiir_out)
+        assert paiir_out.shape == sj_out.shape
+        assert torch.equal(paiir_out, sj_out)
+
+    def test_avgpool_lif_split_core_snn(self, monkeypatch) -> None:
         """Split-core AvgPool+LIF matches reference when exact-sum coding is enabled.
 
-        Use a configuration where the score-based selector actually prefers the
-        split-core path. With tau=4 the chip leak shift is exact, so any
-        remaining mismatch would come from the split-core construction itself.
+        Force the split-core path explicitly so this test validates split-core
+        simulation semantics rather than score-tie or heuristic selection.
         """
+
         kernel_size = 2
+
+        def fake_select_avgpool_lif_candidate(
+            act,
+            pred_out_width,
+            window_size,
+            allow_split_lif=False,
+            try_calibration=False,
+            avg_divisor=None,
+        ):
+            return AvgPoolLIFCandidateScore(
+                AvgPoolDeployScheme.SPLIT_CORE_LIF_EXACT_SUM, False, 0.0, 0.0, 0.0, 0.0
+            )
+
+        monkeypatch.setattr(
+            avgpool_fusion,
+            "select_avgpool_lif_candidate",
+            fake_select_avgpool_lif_candidate,
+        )
 
         class AvgPoolLIFNoDecay(nn.Module):
             def __init__(self):

--- a/tests/paiir/pipeline/test_passes.py
+++ b/tests/paiir/pipeline/test_passes.py
@@ -26,6 +26,7 @@ from paibox.paiir.ir.op_node import (
     ConcatOp,
     CPUOp,
     OfflineCoreOp,
+    ReshapeOp,
     SequentialOp,
     StandaloneActOp,
     StandaloneCompOp,
@@ -129,12 +130,14 @@ class TestSNNConversion:
         assert groups == [1, 16]
 
     def test_flatten_transition(self):
-        """Conv-IF -> flatten -> Linear-IF: flatten bypassed."""
+        """Conv-IF -> flatten -> Linear-IF: flatten is preserved as ReshapeOp."""
         model = SNNFlattenTransition()
         fused = convert_and_fuse(model, make_img_1ch_4x4())
 
         seq_nodes = find_nodes(fused, SequentialOp)
         assert len(seq_nodes) == 2
+        reshape_nodes = find_nodes(fused, ReshapeOp)
+        assert len(reshape_nodes) == 1
 
         comp_types = sorted(type(n.comp).__name__ for n in seq_nodes)
         assert comp_types == ["Conv2d", "Linear"]
@@ -212,10 +215,7 @@ class TestComplexPatterns:
         assert [
             general_add.is_operand_broadcasted(operand)
             for operand in general_add.operands
-        ] == [
-            False,
-            True,
-        ]
+        ] == [False, True]
 
         y_ref = AddScalar()(x)
         y_ir = graph.forward(x)
@@ -919,6 +919,36 @@ class TestValidateCompiledGraph:
         ):
             validate_compiled_graph(graph)
 
+    def test_rejects_concat_predecessor_shape_mismatch(self):
+        graph = PAIIRGraph("bad_concat_shapes")
+        inp_a = InputNode(shape=(1, 2, 4, 4))
+        inp_b = InputNode(shape=(1, 2, 4))
+        cat = ConcatOp(dim=1)
+        out = OutputNode()
+
+        inp_a.output_domain = SignalDomain.VALUE
+        inp_b.output_domain = SignalDomain.VALUE
+        cat.output_domain = SignalDomain.VALUE
+        out.output_domain = SignalDomain.VALUE
+
+        cat.input_shapes = [(1, 32), (1, 8)]
+        cat.output_shape = (1, 40)
+        cat.input_dims = [(0, 1), (0, 1)]
+        cat.output_dims = (0, 1)
+
+        graph.add_node(inp_a)
+        graph.add_node(inp_b)
+        graph.add_node(cat)
+        graph.add_node(out)
+        graph.add_edge(inp_a.name, cat.name, dst_port=0)
+        graph.add_edge(inp_b.name, cat.name, dst_port=1)
+        graph.add_edge(cat.name, out.name)
+
+        with pytest.raises(
+            GraphValidationError, match="ConcatOp .*predecessor shape mismatch"
+        ):
+            validate_compiled_graph(graph)
+
 
 class TestValidateDeployableGraph:
     def test_rejects_non_backend_ready_node_type(self):
@@ -1038,6 +1068,56 @@ class ValueBranchAdd(nn.Module):
 
 
 class TestSignalDomain:
+    def test_standalone_maxpool_preserves_value_domain(self):
+        class ValueMaxPool(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.relu = nn.ReLU()
+                self.pool = nn.MaxPool2d(2)
+
+            def forward(self, x):
+                return self.pool(self.relu(x))
+
+        unfused = torch_to_paiir(ValueMaxPool(), torch.randn(1, 3, 8, 8))
+        fused = fuse_to_offline_cores(specialize_general_adds(unfused))
+
+        propagate_signal_domain(fused)
+
+        pool = next(
+            node
+            for node in fused.nodes.values()
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.MaxPool2d)
+        )
+        out = fused.output_nodes()[0]
+        assert pool.output_domain == SignalDomain.VALUE
+        assert out.output_domain == SignalDomain.VALUE
+
+    def test_standalone_maxpool_preserves_potential_domain(self):
+        class PotentialMaxPool(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(3, 4, 1)
+                self.pool = nn.MaxPool2d(2)
+
+            def forward(self, x):
+                return self.pool(self.conv(x))
+
+        unfused = torch_to_paiir(PotentialMaxPool(), torch.randn(1, 3, 8, 8))
+        fused = fuse_to_offline_cores(specialize_general_adds(unfused))
+
+        propagate_signal_domain(fused)
+
+        pool = next(
+            node
+            for node in fused.nodes.values()
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.MaxPool2d)
+        )
+        out = fused.output_nodes()[0]
+        assert pool.output_domain == SignalDomain.POTENTIAL
+        assert out.output_domain == SignalDomain.POTENTIAL
+
     def test_general_add_from_scalar_propagates_value_domain(self):
         graph = torch_to_paiir(AddScalarDomain(), torch.randn(1, 3, 8, 8), strict=False)
 

--- a/tests/paiir/tracing.py
+++ b/tests/paiir/tracing.py
@@ -1,0 +1,59 @@
+"""Shared FX tracing helpers used by PAIIR tests."""
+
+from typing import Any
+
+from torch import Tensor, fx, nn
+from torch.fx.passes.shape_prop import ShapeProp
+
+from paibox.paiir.lowering.converter import (
+    _DEFAULT_MODULE_MAP,
+    TRACE_LEAF_MODULE_TYPES,
+    _EraseModuleTransformer,
+    _PAIIRTracer,
+    _propagate_dims,
+    _propagate_shapes,
+)
+from paibox.paiir.lowering.dims_prop import DimsProp
+
+
+def trace_with_fx_shape_and_dims(
+    model: nn.Module,
+    *sample_inputs: Tensor,
+    concrete_args: dict[str, Any] | None = None,
+) -> fx.GraphModule:
+    """Trace with vanilla FX, then run ShapeProp and DimsProp."""
+    if not sample_inputs:
+        raise ValueError(
+            "trace_with_fx_shape_and_dims() requires at least one sample input."
+        )
+
+    gm = fx.symbolic_trace(model, concrete_args=concrete_args)
+    ShapeProp(gm).propagate(*sample_inputs)
+    DimsProp().propagate(gm)
+    return gm
+
+
+def trace_with_paiir_tracer(
+    model: nn.Module, concrete_args: dict[str, Any] | None = None
+) -> fx.GraphModule:
+    """Trace with the project-specific PAIIR tracer configuration."""
+    leaf_types = tuple(_DEFAULT_MODULE_MAP.keys()) + TRACE_LEAF_MODULE_TYPES
+    tracer = _PAIIRTracer(custom_leaf_modules=leaf_types)
+    traced = tracer.trace(model, concrete_args)
+    return fx.GraphModule(tracer.root, traced)
+
+
+def trace_for_lowering(
+    model: nn.Module,
+    *sample_inputs: Tensor,
+    concrete_args: dict[str, Any] | None = None,
+) -> fx.GraphModule:
+    """Trace with the PAIIR tracer and run lowering pre-analysis propagation."""
+    if not sample_inputs:
+        raise ValueError("trace_for_lowering() requires at least one sample input.")
+
+    gm = trace_with_paiir_tracer(model, concrete_args=concrete_args)
+    gm = _EraseModuleTransformer(gm).transform()
+    _propagate_shapes(gm, *sample_inputs)
+    _propagate_dims(gm)
+    return gm

--- a/uv.lock
+++ b/uv.lock
@@ -670,6 +670,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "mdurl", marker = "platform_machine != 'armv7l'" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
@@ -800,6 +812,15 @@ wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/04/30/3afaa31c757f34b7725ab9d2ba8b48b5e89c2019c003e7d0ead143aabc5a/matplotlib-3.10.8-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6da7c2ce169267d0d066adcf63758f0604aa6c3eebf67458930f9d9b79ad1db1", size = 8249198, upload-time = "2025-12-10T22:56:45.584Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/48/2f/6334aec331f57485a642a7c8be03cb286f29111ae71c46c38b363230063c/matplotlib-3.10.8-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9153c3292705be9f9c64498a8872118540c3f4123d1a1c840172edf262c8be4a", size = 8136817, upload-time = "2025-12-10T22:56:47.339Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/73/e4/6d6f14b2a759c622f191b2d67e9075a3f56aaccb3be4bb9bb6890030d0a0/matplotlib-3.10.8-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ae029229a57cd1e8fe542485f27e7ca7b23aa9e8944ddb4985d0bc444f1eca2", size = 8713867, upload-time = "2025-12-10T22:56:48.954Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -1216,6 +1237,7 @@ source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version < '3.11' and platform_machine != 'armv7l'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version >= '3.11' and platform_machine != 'armv7l'" },
+    { name = "rich", marker = "platform_machine != 'armv7l'" },
 ]
 
 [package.dev-dependencies]
@@ -1232,19 +1254,22 @@ dev = [
     { name = "tabulate", marker = "platform_machine != 'armv7l'" },
     { name = "torch", version = "2.1.2", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.12' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (python_full_version < '3.12' and platform_machine != 'armv7l' and sys_platform == 'darwin')" },
     { name = "torch", version = "2.1.2+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'armv7l' and sys_platform == 'linux') or (python_full_version < '3.12' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version < '3.12' and platform_machine != 'armv7l' and sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l' and sys_platform != 'darwin'" },
+    { name = "torch", version = "2.9.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.9.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l' and sys_platform != 'darwin'" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "numpy", specifier = ">=2.1.0,<3.0.0" }]
+requires-dist = [
+    { name = "numpy", specifier = ">=2.1.0,<3.0.0" },
+    { name = "rich", specifier = ">=14.0.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "orjson", specifier = ">=3.11.6" },
     { name = "ortools", marker = "python_full_version < '3.14'", specifier = "==9.14.6206" },
     { name = "ortools", marker = "python_full_version >= '3.14'", specifier = "==9.15.6755" },
-    { name = "paicorelib", marker = "platform_machine != 'armv7l'", specifier = ">=2.0.0a2" },
+    { name = "paicorelib", marker = "platform_machine != 'armv7l'", specifier = ">=2.0.0a3" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=7.0" },
     { name = "pytest-md", specifier = ">=0.2" },
@@ -1257,16 +1282,16 @@ dev = [
 
 [[package]]
 name = "paicorelib"
-version = "2.0.0a2"
+version = "2.0.0a3"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version < '3.11' and platform_machine != 'armv7l'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version >= '3.11' and platform_machine != 'armv7l'" },
     { name = "pydantic", marker = "platform_machine != 'armv7l'" },
 ]
-sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/81/28/8f8b8bb466d27b2905f84166a41801eb8eaa6fe0c85e8d0252fd3d5b0819/paicorelib-2.0.0a2.tar.gz", hash = "sha256:7a7eedbfccf281c336107cdbdd9287bd4b1260eb5d7581e72ec398a80c1521d2", size = 60605, upload-time = "2026-03-13T07:54:23.966Z" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/32/2a/54443f54ae5b6e5d91ec58904a216bf6c126b8d1703ea392cbf8550f69fa/paicorelib-2.0.0a3.tar.gz", hash = "sha256:2c05f00c5d0de8583fd472521404266b8cf7eca9f27ac6661b1a9b6aff2275f3", size = 60741, upload-time = "2026-03-27T10:32:29.477Z" }
 wheels = [
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/61/70/fc041068a73006b7cd3e3357f34926310bb24433524b7c20856e858e8862/paicorelib-2.0.0a2-py3-none-any.whl", hash = "sha256:c80264e83aa6fdd7d6f5a39112fb871892b46f87e0ecfc902ca20ca3fd5f4e72", size = 69320, upload-time = "2026-03-13T07:54:25.05Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7c/de/a911f8f67bd17c8748d9fedb82c8dddb957208135c29ddc350d35dcb7033/paicorelib-2.0.0a3-py3-none-any.whl", hash = "sha256:27149559bb599810fd3cd054e88af3c071f49771a8423ff58870693ed0d585a6", size = 69434, upload-time = "2026-03-27T10:32:28.564Z" },
 ]
 
 [[package]]
@@ -1807,6 +1832,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "markdown-it-py", marker = "platform_machine != 'armv7l'" },
+    { name = "pygments", marker = "platform_machine != 'armv7l'" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
@@ -1981,10 +2019,10 @@ dependencies = [
     { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version >= '3.11' and platform_machine != 'armv7l'" },
     { name = "torch", version = "2.1.2", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.12' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (python_full_version < '3.12' and platform_machine != 'armv7l' and sys_platform == 'darwin')" },
     { name = "torch", version = "2.1.2+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'armv7l' and sys_platform == 'linux') or (python_full_version < '3.12' and platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version < '3.12' and platform_machine != 'armv7l' and sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l' and sys_platform != 'darwin'" },
+    { name = "torch", version = "2.9.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.9.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l' and sys_platform != 'darwin'" },
     { name = "torchvision", version = "0.16.2", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version < '3.12' and platform_machine != 'armv7l'" },
-    { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l'" },
+    { name = "torchvision", version = "0.24.1", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l'" },
     { name = "tqdm", marker = "platform_machine != 'armv7l'" },
 ]
 sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/eb/81/e74b2dad5c0d9c0df166798ab9c93091f478ca8413feca876f2935ba5940/spikingjelly-0.0.0.0.14.tar.gz", hash = "sha256:c05969509dd27ff7e349c09f3b0c317d4b37cb4f034bb3f608562e9d798f9335", size = 225574, upload-time = "2023-03-20T02:11:48.597Z" }
@@ -2116,7 +2154,7 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.11.0"
+version = "2.9.1"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine != 'armv7l' and sys_platform == 'darwin'",
@@ -2132,18 +2170,18 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version >= '3.12' and platform_machine != 'armv7l' and sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:91209c7d8a2460b76e8ff5b28b7623da4ab1d27474b79e1de83e954871985afe" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d75eadcd97fe0dc7cd0eedc4d72152484c19cb2cfe46ce55766c8e129116425f" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:43b35116802c85fb88d99f4a396b8bd4472bfca1dd82e69499e5a4f9b8b4e252" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:442ec9dc78592564fdad69cf0beaa9da2f82ab810ccb4f13903869a90bf3f15d" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cc3a195701bba2239c313ee311487f80f8aaebe9e89b9073dddbcf2f93b5a0ba" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:072a0d6e4865e8b0dc0dbfe6ebed68fae235124222835ef03e5814d414d8c012" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23ec7789017da9d95b6d543d790814785e6f30905c5443efa8257d1490d73f79" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:bf1e68cfb935ae2046374ff02a7aa73dda70351b46342846f557055b3a540bf0" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:a52952a8c90a422c14627ea99b9826b7557203b46b4d0772d3ca5c7699692425" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:287242dd1f830846098b5eca847f817aa5c6015ea57ab4c1287809efea7b77eb" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8924d10d36eac8fe0652a060a03fc2ae52980841850b9a1a2ddb0f27a4f181cd" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:bcee64ae7aa65876ceeae6dcaebe75109485b213528c74939602208a20706e3f" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:defadbeb055cfcf5def58f70937145aecbd7a4bc295238ded1d0e85ae2cf0e1d" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:886f84b181f766f53265ba0a1d503011e60f53fff9d569563ef94f24160e1072" },
 ]
 
 [[package]]
 name = "torch"
-version = "2.11.0+cpu"
+version = "2.9.1+cpu"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine != 'armv7l' and sys_platform == 'win32'",
@@ -2163,34 +2201,30 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version >= '3.12' and platform_machine != 'armv7l' and sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-linux_s390x.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-linux_s390x.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-linux_s390x.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-linux_s390x.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-linux_s390x.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-linux_s390x.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-linux_s390x.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-win_amd64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:10866c8a48c4aa5ae3f48538dc8a055b99c57d9c6af2bf5dd715374d9d6ddca3" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:7210713b66943fdbfcc237b2e782871b649123ac5d29f548ce8c85be4223ab38" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp310-cp310-win_amd64.whl", hash = "sha256:d6e8441453dc27524e3f1037fbf27b90a02644b84e42944b9354b4024cb51cc1" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0e611cfb16724e62252b67d31073bc5c490cb83e92ecdc1192762535e0e44487" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:3de2adb9b4443dc9210ef1f1b16da3647ace53553166d6360bbbd7edd6f16e4d" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:69b3785d28be5a9c56ab525788ec5000349ec59132a74b7d5e954b905015b992" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp311-cp311-win_arm64.whl", hash = "sha256:15b4ae6fe371d96bffb8e1e9af62164797db20a0dc1337345781659cfd0b8bb1" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3bf9b442a51a2948e41216a76d7ab00f0694cfcaaa51b6f9bcab57b7f89843e6" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7417d8c565f219d3455654cb431c6d892a3eb40246055e14d645422de13b9ea1" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:a4e06b4f441675d26b462123c8a83e77c55f1ec8ebc081203be2db1ea8054add" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:1abe31f14b560c1f062699e966cb08ef5b67518a1cfac2d8547a3dbcd8387b06" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:3e532e553b37ee859205a9b2d1c7977fd6922f53bbb1b9bfdd5bdc00d1a60ed4" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:39b3dff6d8fba240ae0d1bede4ca11c2531ae3b47329206512d99e17907ff74b" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:404a7ab2fffaf2ca069e662f331eb46313692b2f1630df2720094284f390ccef" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:161decbff26a33f13cb5ba6d2c8f458bbf56193bcc32ecc70be6dd4c7a3ee79d" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:01b1884f724977a20c7da2f640f1c7b37f4a2c117a7f4a6c1c0424d14cb86322" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:031a597147fa81b1e6d79ccf1ad3ccc7fafa27941d6cf26ff5caaa384fb20e92" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:e586ab1363e3f86aa4cc133b7fdcf98deb1d2c13d43a7a6e5a6a18e9c5364893" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:65010ab4aacce6c9a1ddfc935f986c003ca8638ded04348fd326c3e74346237c" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:88adf5157db5da1d54b1c9fe4a6c1d20ceef00e75d854e206a87dbf69e3037dc" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:f60e2565f261542efac07e25208fb3fc55c6fe82314a5a9cbee971edb5f27713" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:3ac2b8df2c55430e836dcda31940d47f1f5f94b8731057b6f20300ebea394dd9" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:5b688445f928f13563b7418b17c57e97bf955ab559cf73cd8f2b961f8572dbb3" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:cf9c3e50b595721ca6b488bdcc326e0f1af73ed28b9b66eff504a96649bb5c96" },
 ]
 
 [[package]]
@@ -2228,7 +2262,7 @@ wheels = [
 
 [[package]]
 name = "torchvision"
-version = "0.26.0"
+version = "0.24.1"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine != 'armv7l' and sys_platform == 'win32'",
@@ -2243,38 +2277,38 @@ resolution-markers = [
 dependencies = [
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l'" },
     { name = "pillow", marker = "python_full_version >= '3.12' and platform_machine != 'armv7l'" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l' and sys_platform != 'darwin'" },
+    { name = "torch", version = "2.9.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.9.1+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.12' and platform_machine != 'armv7l' and sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/74/b4/cdfee31e0402ea035135462cb0ab496e974d56fab6b4e7a1f0cbccb8cd28/torchvision-0.26.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a06d4772a8e13e772906ed736cc53ec6639e5e60554f8e5fa6ca165aabebc464", size = 1863503, upload-time = "2026-03-23T18:13:01.384Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e4/74/11fee109841e80ad14e5ca2d80bff6b10eb11b7838ff06f35bfeaa9f7251/torchvision-0.26.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:2adfbe438473236191ff077a4a9a0c767436879c89628aa97137e959b0c11a94", size = 7766423, upload-time = "2026-03-23T18:12:56.049Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5e/00/24d8c7845c3f270153fb81395a5135b2778e2538e81d14c6aea5106c689c/torchvision-0.26.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:b6f9ad1ecc0eab52647298b379ee9426845f8903703e6127973f8f3d049a798b", size = 7518249, upload-time = "2026-03-23T18:12:51.743Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d7/ed/e53cd7c0da7ae002e5e929c1796ebbe7ec0c700c29f7a0a6696497fb3d8b/torchvision-0.26.0-cp310-cp310-win_amd64.whl", hash = "sha256:f13f12b3791a266de2d599cb8162925261622a037d87fc03132848343cf68f75", size = 3669784, upload-time = "2026-03-23T18:12:49.949Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b4/bd/d552a2521bade3295b2c6e7a4a0d1022261cab7ca7011f4e2a330dbb3caa/torchvision-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55bd6ad4ae77be01ba67a410b05b51f53b0d0ee45f146eb6a0dfb9007e70ab3c", size = 1863499, upload-time = "2026-03-23T18:12:58.696Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/33/bf/21b899792b08cae7a298551c68398a79e333697479ed311b3b067aab4bdc/torchvision-0.26.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1c55dc8affbcc0eb2060fbabbe996ae9e5839b24bb6419777f17848945a411b1", size = 7767527, upload-time = "2026-03-23T18:12:44.348Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9a/45/57bbf9e216850d065e66dd31a50f57424b607f1d878ab8956e56a1f4e36b/torchvision-0.26.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:fd10b5f994c210f4f6d6761cf686f82d748554adf486cb0979770c3252868c8f", size = 7519925, upload-time = "2026-03-23T18:12:53.283Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/10/58/ed8f7754299f3e91d6414b6dc09f62b3fa7c6e5d63dfe48d69ab81498a37/torchvision-0.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:de6424b12887ad884f39a0ee446994ae3cd3b6a00a9cafe1bead85a031132af0", size = 3983834, upload-time = "2026-03-23T18:13:00.224Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ae/e7/56b47cc3b132aea90ccce22bcb8975dec688b002150012acc842846039d0/torchvision-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c409e1c3fdebec7a3834465086dbda8bf7680eff79abf7fd2f10c6b59520a7a4", size = 1863502, upload-time = "2026-03-23T18:12:57.326Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f4/ec/5c31c92c08b65662fe9604a4067ae8232582805949f11ddc042cebe818ed/torchvision-0.26.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:406557718e62fdf10f5706e88d8a5ec000f872da913bf629aab9297622585547", size = 7767944, upload-time = "2026-03-23T18:12:42.805Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f5/d8/cb6ccda1a1f35a6597645818641701207b3e8e13553e75fce5d86bac74b2/torchvision-0.26.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d61a5abb6b42a0c0c311996c2ac4b83a94418a97182c83b055a2a4ae985e05aa", size = 7522205, upload-time = "2026-03-23T18:12:54.654Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1c/a9/c272623a0f735c35f0f6cd6dc74784d4f970e800cf063bb76687895a2ab9/torchvision-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:7993c01648e7c61d191b018e84d38fe0825c8fcb2720cd0f37caf7ba14404aa1", size = 4255155, upload-time = "2026-03-23T18:12:32.652Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/da/80/0762f77f53605d10c9477be39bb47722cc8e383bbbc2531471ce0e396c07/torchvision-0.26.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5d63dd43162691258b1b3529b9041bac7d54caa37eae0925f997108268cbf7c4", size = 1860809, upload-time = "2026-03-23T18:12:47.629Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e6/81/0b3e58d1478c660a5af4268713486b2df7203f35abd9195fea87348a5178/torchvision-0.26.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a39c7a26538c41fda453f9a9692b5ff9b35a5437db1d94f3027f6f509c160eac", size = 7727494, upload-time = "2026-03-23T18:12:46.062Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b6/dc/d9ab5d29115aa05e12e30f1397a3eeae1d88a511241dc3bce48dc4342675/torchvision-0.26.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:b7e6213620bbf97742e5f79832f9e9d769e6cf0f744c5b53dad80b76db633691", size = 7521747, upload-time = "2026-03-23T18:12:36.815Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/1b/f1bc86a918c5f6feab1eeff11982e2060f4704332e96185463d27855bdf5/torchvision-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:4280c35ec8cba1fcc8294fb87e136924708726864c379e4c54494797d86bc474", size = 4319880, upload-time = "2026-03-23T18:12:38.168Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/66/28/b4ad0a723ed95b003454caffcc41894b34bd8379df340848cae2c33871de/torchvision-0.26.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:358fc4726d0c08615b6d83b3149854f11efb2a564ed1acb6fce882e151412d23", size = 1951973, upload-time = "2026-03-23T18:12:48.781Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/71/e2/7a89096e6cf2f3336353b5338ba925e0addf9d8601920340e6bdf47e8eb3/torchvision-0.26.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:3daf9cc149cf3cdcbd4df9c59dae69ffca86c6823250442c3bbfd63fc2e26c61", size = 7728679, upload-time = "2026-03-23T18:12:26.196Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/69/1d/4e1eebc17d18ce080a11dcf3df3f8f717f0efdfa00983f06e8ba79259f61/torchvision-0.26.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:82c3965eca27e86a316e31e4c3e5a16d353e0bcbe0ef8efa2e66502c54493c4b", size = 7609138, upload-time = "2026-03-23T18:12:35.327Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f3/a4/f1155e943ae5b32400d7000adc81c79bb0392b16ceb33bcf13e02e48cced/torchvision-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ebc043cc5a4f0bf22e7680806dbba37ffb19e70f6953bbb44ed1a90aeb5c9bea", size = 4248202, upload-time = "2026-03-23T18:12:41.423Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/c8/9bffa9c7f7bdf95b2a0a2dc535c290b9f1cc580c3fb3033ab1246ffffdeb/torchvision-0.26.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:eb61804eb9dbe88c5a2a6c4da8dec1d80d2d0a6f18c999c524e32266cb1ebcd3", size = 1860813, upload-time = "2026-03-23T18:12:39.636Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7b/ac/48f28ffd227991f2e14f4392dde7e8dc14352bb9428c1ef4a4bbf5f7ed85/torchvision-0.26.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:9a904f2131cbfadab4df828088a9f66291ad33f49ff853872aed1f86848ef776", size = 7727777, upload-time = "2026-03-23T18:12:22.549Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a4/21/a2266f7f1b0e58e624ff15fd6f01041f59182c49551ece0db9a183071329/torchvision-0.26.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:0f3e572efe62ad645017ea847e0b5e4f2f638d4e39f05bc011d1eb9ac68d4806", size = 7522174, upload-time = "2026-03-23T18:12:29.565Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fc/ba/1666f90bc0bdd77aaa11dcc42bb9f621a9c3668819c32430452e3d404730/torchvision-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:114bec0c0e98aa4ba446f63e2fe7a2cbca37b39ac933987ee4804f65de121800", size = 4348469, upload-time = "2026-03-23T18:12:24.44Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/45/8f/1f0402ac55c2ae15651ff831957d083fe70b2d12282e72612a30ba601512/torchvision-0.26.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:b7d3e295624a28b3b1769228ce1345d94cf4d390dd31136766f76f2d20f718da", size = 1860826, upload-time = "2026-03-23T18:12:34.1Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d2/6a/18a582fe3c5ee26f49b5c9fb21ad8016b4d1c06d10178894a58653946fda/torchvision-0.26.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:7058c5878262937e876f20c25867b33724586aa4499e2853b2d52b99a5e51953", size = 7729089, upload-time = "2026-03-23T18:12:31.394Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/9b/f7e119b59499edc00c55c03adc9ec3bd96144d9b81c46852c431f9c64a9a/torchvision-0.26.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8008474855623c6ba52876589dc52df0aa66e518c25eca841445348e5f79844c", size = 7522704, upload-time = "2026-03-23T18:12:20.301Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d0/6a/09f3844c10643f6c0de5d95abc863420cfaf194c88c7dffd0ac523e2015f/torchvision-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e9d0e022c19a78552fb055d0414d47fecb4a649309b9968573daea160ba6869c", size = 4454275, upload-time = "2026-03-23T18:12:27.487Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/09/d51aadf8591138e08b74c64a6eb783630c7a31ca2634416277115a9c3a2b/torchvision-0.24.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ded5e625788572e4e1c4d155d1bbc48805c113794100d70e19c76e39e4d53465", size = 1891441, upload-time = "2025-11-12T15:25:01.687Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6b/49/a35df863e7c153aad82af7505abd8264a5b510306689712ef86bea862822/torchvision-0.24.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:54ed17c3d30e718e08d8da3fd5b30ea44b0311317e55647cb97077a29ecbc25b", size = 2386226, upload-time = "2025-11-12T15:25:05.449Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/20/f2d7cd1eea052887c1083afff0b8df5228ec93b53e03759f20b1a3c6d22a/torchvision-0.24.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:f476da4e085b7307aaab6f540219617d46d5926aeda24be33e1359771c83778f", size = 8046093, upload-time = "2025-11-12T15:25:09.425Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d8/cf/0ff4007c09903199307da5f53a192ff5d62b45447069e9ef3a19bdc5ff12/torchvision-0.24.1-cp310-cp310-win_amd64.whl", hash = "sha256:fbdbdae5e540b868a681240b7dbd6473986c862445ee8a138680a6a97d6c34ff", size = 3696202, upload-time = "2025-11-12T15:25:10.657Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e7/69/30f5f03752aa1a7c23931d2519b31e557f3f10af5089d787cddf3b903ecf/torchvision-0.24.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:056c525dc875f18fe8e9c27079ada166a7b2755cea5a2199b0bc7f1f8364e600", size = 1891436, upload-time = "2025-11-12T15:25:04.3Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0c/69/49aae86edb75fe16460b59a191fcc0f568c2378f780bb063850db0fe007a/torchvision-0.24.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1e39619de698e2821d71976c92c8a9e50cdfd1e993507dfb340f2688bfdd8283", size = 2387757, upload-time = "2025-11-12T15:25:06.795Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/11/c9/1dfc3db98797b326f1d0c3f3bb61c83b167a813fc7eab6fcd2edb8c7eb9d/torchvision-0.24.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a0f106663e60332aa4fcb1ca2159ef8c3f2ed266b0e6df88de261048a840e0df", size = 8047682, upload-time = "2025-11-12T15:25:21.125Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fa/bb/cfc6a6f6ccc84a534ed1fdf029ae5716dd6ff04e57ed9dc2dab38bf652d5/torchvision-0.24.1-cp311-cp311-win_amd64.whl", hash = "sha256:a9308cdd37d8a42e14a3e7fd9d271830c7fecb150dd929b642f3c1460514599a", size = 4037588, upload-time = "2025-11-12T15:25:14.402Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f0/af/18e2c6b9538a045f60718a0c5a058908ccb24f88fde8e6f0fc12d5ff7bd3/torchvision-0.24.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e48bf6a8ec95872eb45763f06499f87bd2fb246b9b96cb00aae260fda2f96193", size = 1891433, upload-time = "2025-11-12T15:25:03.232Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9d/43/600e5cfb0643d10d633124f5982d7abc2170dfd7ce985584ff16edab3e76/torchvision-0.24.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:7fb7590c737ebe3e1c077ad60c0e5e2e56bb26e7bccc3b9d04dbfc34fd09f050", size = 2386737, upload-time = "2025-11-12T15:25:08.288Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/93/b1/db2941526ecddd84884132e2742a55c9311296a6a38627f9e2627f5ac889/torchvision-0.24.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:66a98471fc18cad9064123106d810a75f57f0838eee20edc56233fd8484b0cc7", size = 8049868, upload-time = "2025-11-12T15:25:13.058Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/69/98/16e583f59f86cd59949f59d52bfa8fc286f86341a229a9d15cbe7a694f0c/torchvision-0.24.1-cp312-cp312-win_amd64.whl", hash = "sha256:4aa6cb806eb8541e92c9b313e96192c6b826e9eb0042720e2fa250d021079952", size = 4302006, upload-time = "2025-11-12T15:25:16.184Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e4/97/ab40550f482577f2788304c27220e8ba02c63313bd74cf2f8920526aac20/torchvision-0.24.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8a6696db7fb71eadb2c6a48602106e136c785642e598eb1533e0b27744f2cce6", size = 1891435, upload-time = "2025-11-12T15:25:28.642Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/30/65/ac0a3f9be6abdbe4e1d82c915d7e20de97e7fd0e9a277970508b015309f3/torchvision-0.24.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:db2125c46f9cb25dc740be831ce3ce99303cfe60439249a41b04fd9f373be671", size = 2338718, upload-time = "2025-11-12T15:25:26.19Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/10/b5/5bba24ff9d325181508501ed7f0c3de8ed3dd2edca0784d48b144b6c5252/torchvision-0.24.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:f035f0cacd1f44a8ff6cb7ca3627d84c54d685055961d73a1a9fb9827a5414c8", size = 8049661, upload-time = "2025-11-12T15:25:22.558Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5c/ec/54a96ae9ab6a0dd66d4bba27771f892e36478a9c3489fa56e51c70abcc4d/torchvision-0.24.1-cp313-cp313-win_amd64.whl", hash = "sha256:16274823b93048e0a29d83415166a2e9e0bf4e1b432668357b657612a4802864", size = 4319808, upload-time = "2025-11-12T15:25:17.318Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/f3/a90a389a7e547f3eb8821b13f96ea7c0563cdefbbbb60a10e08dda9720ff/torchvision-0.24.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e3f96208b4bef54cd60e415545f5200346a65024e04f29a26cd0006dbf9e8e66", size = 2005342, upload-time = "2025-11-12T15:25:11.871Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a9/fe/ff27d2ed1b524078164bea1062f23d2618a5fc3208e247d6153c18c91a76/torchvision-0.24.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:f231f6a4f2aa6522713326d0d2563538fa72d613741ae364f9913027fa52ea35", size = 2341708, upload-time = "2025-11-12T15:25:25.08Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b1/b9/d6c903495cbdfd2533b3ef6f7b5643ff589ea062f8feb5c206ee79b9d9e5/torchvision-0.24.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:1540a9e7f8cf55fe17554482f5a125a7e426347b71de07327d5de6bfd8d17caa", size = 8177239, upload-time = "2025-11-12T15:25:18.554Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/4f/2b/ba02e4261369c3798310483028495cf507e6cb3f394f42e4796981ecf3a7/torchvision-0.24.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d83e16d70ea85d2f196d678bfb702c36be7a655b003abed84e465988b6128938", size = 4251604, upload-time = "2025-11-12T15:25:34.069Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/42/84/577b2cef8f32094add5f52887867da4c2a3e6b4261538447e9b48eb25812/torchvision-0.24.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cccf4b4fec7fdfcd3431b9ea75d1588c0a8596d0333245dafebee0462abe3388", size = 2005319, upload-time = "2025-11-12T15:25:23.827Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5f/34/ecb786bffe0159a3b49941a61caaae089853132f3cd1e8f555e3621f7e6f/torchvision-0.24.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1b495edd3a8f9911292424117544f0b4ab780452e998649425d1f4b2bed6695f", size = 2338844, upload-time = "2025-11-12T15:25:32.625Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/51/99/a84623786a6969504c87f2dc3892200f586ee13503f519d282faab0bb4f0/torchvision-0.24.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ab211e1807dc3e53acf8f6638df9a7444c80c0ad050466e8d652b3e83776987b", size = 8175144, upload-time = "2025-11-12T15:25:31.355Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/6d/ba/8fae3525b233e109317ce6a9c1de922ab2881737b029a7e88021f81e068f/torchvision-0.24.1-cp314-cp314-win_amd64.whl", hash = "sha256:18f9cb60e64b37b551cd605a3d62c15730c086362b40682d23e24b616a697d41", size = 4234459, upload-time = "2025-11-12T15:25:19.859Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/50/33/481602c1c72d0485d4b3a6b48c9534b71c2957c9d83bf860eb837bf5a620/torchvision-0.24.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec9d7379c519428395e4ffda4dbb99ec56be64b0a75b95989e00f9ec7ae0b2d7", size = 2005336, upload-time = "2025-11-12T15:25:27.225Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d0/7f/372de60bf3dd8f5593bd0d03f4aecf0d1fd58f5bc6943618d9d913f5e6d5/torchvision-0.24.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:af9201184c2712d808bd4eb656899011afdfce1e83721c7cb08000034df353fe", size = 2341704, upload-time = "2025-11-12T15:25:29.857Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/36/9b/0f3b9ff3d0225ee2324ec663de0e7fb3eb855615ca958ac1875f22f1f8e5/torchvision-0.24.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9ef95d819fd6df81bc7cc97b8f21a15d2c0d3ac5dbfaab5cbc2d2ce57114b19e", size = 8177422, upload-time = "2025-11-12T15:25:37.357Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d6/ab/e2bcc7c2f13d882a58f8b30ff86f794210b075736587ea50f8c545834f8a/torchvision-0.24.1-cp314-cp314t-win_amd64.whl", hash = "sha256:480b271d6edff83ac2e8d69bbb4cf2073f93366516a50d48f140ccfceedb002e", size = 4335190, upload-time = "2025-11-12T15:25:35.745Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Improve reshape-like and conv-family lowering, and tighten reshape routing validation and propagation.
- Support AvgPool `divisor_override` compensation while explicitly guarding unsupported `count_include_pad=False` with non-zero padding.
- Narrow PAIIR package exports and expand compile, simulation, and pass coverage.