### PR TITLE
Refactor(paiir): clean up layout IR rewrites & shape metadata validation

### DIFF
--- a/paibox/paiir/ir/_namespace.py
+++ b/paibox/paiir/ir/_namespace.py
@@ -1,49 +1,119 @@
 """IR node namespace management.
 
-Assigns unique names to IR nodes in the format ``{ClassName}_{counter}``.
+Assigns unique names to IR nodes in the format ``{BaseName}_{counter}``.
+The design stays intentionally small, but follows the useful parts of
+``torch.fx.graph._Namespace``:
+
+- object -> name association is stable for the lifetime of the object
+- names are unique within the namespace
+- callers may provide a preferred candidate base instead of always using the class name
 """
 
+import re
 from typing import Any
+from weakref import WeakKeyDictionary
 
 __all__ = ["IRNamespace"]
+
+_NAME_REGEX = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*?)(?:_([0-9]+))?$")
+_ILLEGAL_CHAR_REGEX = re.compile(r"[^A-Za-z0-9_]")
 
 
 class IRNamespace:
     """IR node namespace ensuring globally unique names."""
 
     def __init__(self) -> None:
-        self._obj_to_name: dict[int, str] = {}
+        self._obj_to_name: WeakKeyDictionary[Any, str] = WeakKeyDictionary()
         self._used_names: set[str] = set()
         self._base_count: dict[str, int] = {}
 
-    def create_name(self, obj: Any) -> str:
-        """Assign a unique name to *obj*. Returns the same name on repeated calls."""
-        obj_id = id(obj)
-        if obj_id in self._obj_to_name:
-            return self._obj_to_name[obj_id]
+    def create_name(self, candidate: str | Any, obj: Any | None = None) -> str:
+        """Assign a unique name.
 
-        base = type(obj).__name__
-        num = self._base_count.get(base, 0)
-        candidate = f"{base}_{num}"
-        while candidate in self._used_names:
+        Supported call forms:
+        - ``create_name(obj)``: use ``type(obj).__name__`` as the base
+        - ``create_name(candidate, obj)``: use the provided candidate base
+        """
+        if obj is None and not isinstance(candidate, str):
+            obj = candidate
+            candidate = type(obj).__name__
+
+        if obj is not None and obj in self._obj_to_name:
+            return self._obj_to_name[obj]
+
+        normalized = self._normalize_candidate(candidate)
+        base, explicit_index = self._split_candidate(normalized)
+
+        if explicit_index is None or normalized in self._used_names:
+            num = self._base_count.get(base, 0)
+            name = f"{base}_{num}"
+        else:
+            num = explicit_index
+            name = normalized
+
+        while name in self._used_names:
             num += 1
-            candidate = f"{base}_{num}"
+            name = f"{base}_{num}"
 
-        self._used_names.add(candidate)
+        self._used_names.add(name)
         self._base_count[base] = num + 1
-        self._obj_to_name[obj_id] = candidate
-        return candidate
+        if obj is not None:
+            self._obj_to_name[obj] = name
+        return name
+
+    def associate_name_with_obj(self, name: str, obj: Any) -> None:
+        """Associate an already chosen unique name with an object."""
+        normalized = self._normalize_candidate(name)
+        if obj in self._obj_to_name:
+            raise KeyError(f"object {obj!r} is already registered in namespace")
+        if normalized in self._used_names:
+            raise ValueError(f"name {normalized!r} is already used in namespace")
+
+        self._used_names.add(normalized)
+        base, explicit_index = self._split_candidate(normalized)
+        if explicit_index is not None:
+            self._base_count[base] = max(
+                self._base_count.get(base, 0), explicit_index + 1
+            )
+        self._obj_to_name[obj] = normalized
 
     def rename(self, obj: Any, name: str) -> None:
-        """Rename a registered object."""
-        obj_id = id(obj)
-        if obj_id not in self._obj_to_name:
+        """Rename a registered object to a new unique name."""
+        if obj not in self._obj_to_name:
             raise KeyError(f"object {obj!r} not registered in namespace")
-        self._obj_to_name[obj_id] = name
-        self._used_names.add(name)
+
+        normalized = self._normalize_candidate(name)
+        current_name = self._obj_to_name[obj]
+        if normalized != current_name and normalized in self._used_names:
+            raise ValueError(f"name {normalized!r} is already used in namespace")
+
+        self._used_names.add(normalized)
+        base, explicit_index = self._split_candidate(normalized)
+        if explicit_index is not None:
+            self._base_count[base] = max(
+                self._base_count.get(base, 0), explicit_index + 1
+            )
+        self._obj_to_name[obj] = normalized
 
     def clear(self) -> None:
         """Clear all registered names."""
         self._obj_to_name.clear()
         self._used_names.clear()
         self._base_count.clear()
+
+    @staticmethod
+    def _normalize_candidate(candidate: str) -> str:
+        candidate = _ILLEGAL_CHAR_REGEX.sub("_", candidate)
+        if not candidate:
+            candidate = "_unnamed"
+        if candidate[0].isdigit():
+            candidate = f"_{candidate}"
+        return candidate
+
+    @staticmethod
+    def _split_candidate(candidate: str) -> tuple[str, int | None]:
+        match = _NAME_REGEX.match(candidate)
+        if match is None:
+            return candidate, None
+        base, num = match.group(1, 2)
+        return base, None if num is None else int(num)

--- a/paibox/paiir/ir/add_ops.py
+++ b/paibox/paiir/ir/add_ops.py
@@ -72,10 +72,10 @@ class AddOperandSpec:
         )
 
 
-def _constant_shape(value: Tensor | int | float) -> tuple[int, ...]:
+def _constant_shape(value: Tensor | int | float) -> torch.Size:
     if isinstance(value, Tensor):
-        return tuple(value.shape)
-    return ()
+        return value.shape
+    return torch.Size()
 
 
 def _constant_dims(value: Tensor | int | float) -> tuple[int, ...]:
@@ -125,11 +125,11 @@ class GeneralAddOp(OpNode):
     def has_const_operands(self) -> bool:
         return any(operand.kind is AddOperandKind.CONST for operand in self.operands)
 
-    def operand_shape(self, operand: AddOperandSpec) -> tuple[int, ...]:
+    def operand_shape(self, operand: AddOperandSpec) -> torch.Size:
         if operand.kind is AddOperandKind.TENSOR:
             assert operand.tensor_port is not None
             if operand.tensor_port >= len(self.input_shapes):
-                return ()
+                return torch.Size()
             return self.input_shapes[operand.tensor_port]
 
         assert operand.const_value is not None

--- a/paibox/paiir/ir/graph.py
+++ b/paibox/paiir/ir/graph.py
@@ -11,6 +11,7 @@ from typing import Any
 import torch
 from torch import Tensor, nn
 
+from ..exceptions import GraphValidationError
 from .add_ops import GeneralAddOp
 from .core_neuron import CoreNeuronV25
 from .ir_base import InputNode, OutputNode, PAIIRNode
@@ -54,7 +55,7 @@ class PAIIRGraph:
     Example::
 
         graph = PAIIRGraph("my_model")
-        inp = InputNode(shape=(1, 3, 32, 32))
+        inp = InputNode(shape=torch.Size((1, 3, 32, 32)))
         graph.add_node(inp)
 
         op = SequentialOp(nn.Conv2d(3, 16, 3), LIFNodeV25())
@@ -110,6 +111,147 @@ class PAIIRGraph:
             index.topo_order = tuple(sorter.static_order())
 
         return index.topo_order
+
+    def _collect_reachable_nodes(
+        self, start_names: list[str], *, reverse: bool
+    ) -> set[str]:
+        """Collect nodes reachable from *start_names* in one graph direction."""
+        seen: set[str] = set()
+        stack = list(start_names)
+
+        while stack:
+            name = stack.pop()
+            if name in seen or name not in self.nodes:
+                continue
+            seen.add(name)
+            neighbors = self.predecessors(name) if reverse else self.successors(name)
+            stack.extend(neighbors)
+
+        return seen
+
+    def nodes_on_input_output_paths(self) -> set[str]:
+        """Return nodes that lie on at least one input-to-output path."""
+        reachable_from_inputs = self._collect_reachable_nodes(
+            [node.name for node in self.input_nodes()], reverse=False
+        )
+        reachable_to_outputs = self._collect_reachable_nodes(
+            [node.name for node in self.output_nodes()], reverse=True
+        )
+        return reachable_from_inputs & reachable_to_outputs
+
+    def disconnected_nodes(self) -> list[str]:
+        """Return node names that are not on any input-to-output path."""
+        return sorted(set(self.nodes) - self.nodes_on_input_output_paths())
+
+    def lint(self, *, allow_disconnected: bool = False) -> None:
+        """Validate structural graph invariants.
+
+        Checks graph/container consistency (node names, edge endpoints,
+        duplicate edges, boundary-node constraints, acyclicity), and by default
+        also rejects nodes that do not lie on any input-to-output path.
+
+        Args:
+            allow_disconnected: When True, skip the input-to-output reachability
+                check. This is useful for mid-pipeline cleanup stages that still
+                intend to prune disconnected fragments.
+        """
+        errors: list[str] = []
+
+        input_nodes = self.input_nodes()
+        output_nodes = self.output_nodes()
+        if not input_nodes:
+            errors.append("graph has no input node")
+        if not output_nodes:
+            errors.append("graph has no output node")
+
+        seen_names: set[str] = set()
+        for key, node in self.nodes.items():
+            if key != node.name:
+                errors.append(
+                    f"graph node key '{key}' does not match node.name '{node.name}'"
+                )
+            if node.name in seen_names:
+                errors.append(f"node redefines name '{node.name}'")
+            seen_names.add(node.name)
+
+        seen_edges: set[Edge] = set()
+        incoming_src_by_port: dict[tuple[str, int], str] = {}
+        edge_endpoint_errors = False
+
+        for edge in self.edges:
+            if edge.src not in self.nodes:
+                errors.append(
+                    f"edge {edge.src!r} -> {edge.dst!r} references missing source node"
+                )
+                edge_endpoint_errors = True
+
+            if edge.dst not in self.nodes:
+                errors.append(
+                    f"edge {edge.src!r} -> {edge.dst!r} references missing destination node"
+                )
+                edge_endpoint_errors = True
+
+            if edge.dst_port < 0:
+                errors.append(
+                    f"edge {edge.src!r} -> {edge.dst!r} has negative dst_port={edge.dst_port}"
+                )
+
+            if edge in seen_edges:
+                errors.append(
+                    f"duplicate edge {edge.src!r} -> {edge.dst!r} "
+                    f"(dst_port={edge.dst_port})"
+                )
+            else:
+                seen_edges.add(edge)
+
+            port_key = (edge.dst, edge.dst_port)
+            existing_src = incoming_src_by_port.get(port_key)
+            if existing_src is None:
+                incoming_src_by_port[port_key] = edge.src
+            elif existing_src != edge.src:
+                errors.append(
+                    f"node '{edge.dst}' has multiple incoming edges on "
+                    f"dst_port {edge.dst_port}: '{existing_src}' and '{edge.src}'"
+                )
+
+        if not edge_endpoint_errors:
+            try:
+                self.topo_sort()
+            except graphlib.CycleError as exc:
+                cycle = exc.args[1] if len(exc.args) > 1 else ()
+                if cycle:
+                    cycle_desc = " -> ".join(str(name) for name in cycle)
+                    errors.append(f"graph contains a cycle: {cycle_desc}")
+                else:
+                    errors.append("graph contains a cycle")
+
+            for name, node in self.nodes.items():
+                preds = self.predecessors(name)
+                succs = self.successors(name)
+
+                if isinstance(node, InputNode) and preds:
+                    errors.append(
+                        f"InputNode '{name}' has predecessors {preds} (expected none)"
+                    )
+
+                if isinstance(node, OutputNode) and succs:
+                    errors.append(
+                        f"OutputNode '{name}' has successors {succs} (expected none)"
+                    )
+
+        if (
+            not allow_disconnected
+            and input_nodes
+            and output_nodes
+            and not edge_endpoint_errors
+        ):
+            disconnected = self.disconnected_nodes()
+            if disconnected:
+                names = ", ".join(disconnected)
+                errors.append(f"nodes not on any input-to-output path: {names}")
+
+        if errors:
+            raise GraphValidationError(errors)
 
     def add_node(self, node: PAIIRNode) -> None:
         """Add a node to the graph."""
@@ -177,8 +319,77 @@ class PAIIRGraph:
             raise KeyError(f"source node '{src}' not found in graph")
         if dst not in self.nodes:
             raise KeyError(f"destination node '{dst}' not found in graph")
-        self.edges.append(Edge(src=src, dst=dst, dst_port=dst_port))
+        self.edges.append(Edge(src, dst, dst_port))
         self._invalidate_structure()
+
+    def replace_all_uses_with(
+        self, old_name: str, new_name: str, *, delete_old: bool = False
+    ) -> None:
+        """Rewrite every outgoing use of ``old_name`` to ``new_name``.
+
+        The destination node and destination port are preserved. Duplicate edges
+        created by the rewrite are removed. ``old_name`` remains in the graph
+        unless ``delete_old`` is explicitly requested.
+        """
+        if old_name not in self.nodes:
+            raise KeyError(f"node '{old_name}' not found in graph")
+        if new_name not in self.nodes:
+            raise KeyError(f"node '{new_name}' not found in graph")
+        if old_name == new_name:
+            return
+
+        new_edges: list[Edge] = []
+        seen: set[Edge] = set()
+        for edge in self.edges:
+            updated = (
+                Edge(new_name, edge.dst, edge.dst_port)
+                if edge.src == old_name
+                else edge
+            )
+            if updated in seen:
+                continue
+            seen.add(updated)
+            new_edges.append(updated)
+
+        self.edges = new_edges
+        self._invalidate_structure()
+        if delete_old:
+            self.remove_node(old_name)
+
+    def remove_node_and_reconnect(
+        self, name: str, *, source_name: str | None = None
+    ) -> None:
+        """Remove a node and reconnect one predecessor to all of its outgoing uses.
+
+        If ``source_name`` is omitted, the node must have exactly one predecessor.
+        When provided explicitly, ``source_name`` must be one of the removed
+        node's predecessors.
+        """
+        if name not in self.nodes:
+            raise KeyError(f"node '{name}' not found in graph")
+
+        preds = self.predecessors(name)
+        if source_name is None:
+            if len(preds) != 1:
+                raise ValueError(
+                    f"node '{name}' must have exactly one predecessor to reconnect"
+                )
+            source_name = preds[0]
+        elif source_name not in self.nodes:
+            raise KeyError(f"source node '{source_name}' not found in graph")
+        elif source_name not in preds:
+            raise ValueError(
+                f"source node '{source_name}' is not a predecessor of '{name}'"
+            )
+
+        outgoing = self.outgoing_edges(name)
+        self.remove_node(name)
+
+        for edge in outgoing:
+            candidate = Edge(source_name, edge.dst, edge.dst_port)
+            if candidate in self.edges:
+                continue
+            self.add_edge(source_name, edge.dst, edge.dst_port)
 
     def input_nodes(self) -> list[InputNode]:
         """Return all input nodes."""
@@ -280,9 +491,10 @@ class PAIIRGraph:
     def verify_before_sim(self) -> None:
         """Verify that the graph is ready for simulation.
 
-        Checks that all :class:`OfflineCoreOp` nodes have the required
-        tick parameters for correct simulation.  Call before running
-        simulation to catch configuration errors early.
+        First checks structural graph integrity via :meth:`lint`, then checks
+        that all :class:`OfflineCoreOp` nodes have the required tick parameters
+        for correct simulation. Call before running simulation to catch
+        configuration errors early.
 
         Required parameters:
         - ``tick_start``: Must be set (not None)
@@ -294,6 +506,11 @@ class PAIIRGraph:
             RuntimeError: If any verification check fails.
         """
         errors: list[str] = []
+
+        try:
+            self.lint()
+        except GraphValidationError as exc:
+            errors.extend(exc.errors)
 
         for name, node in self.nodes.items():
             if not isinstance(node, OfflineCoreOp):

--- a/paibox/paiir/ir/ir_base.py
+++ b/paibox/paiir/ir/ir_base.py
@@ -1,5 +1,7 @@
 """PAIIR base types: node base class and graph boundary nodes."""
 
+import torch
+
 from ._namespace import IRNamespace
 from .signal_domain import SignalDomain
 
@@ -31,7 +33,7 @@ class PAIIRNode:
 class InputNode(PAIIRNode):
     """Graph input placeholder carrying shape information."""
 
-    def __init__(self, shape: tuple[int, ...] = ()) -> None:
+    def __init__(self, shape: torch.Size = torch.Size()) -> None:
         super().__init__()
         self.shape = shape
 
@@ -39,6 +41,6 @@ class InputNode(PAIIRNode):
 class OutputNode(PAIIRNode):
     """Graph output node."""
 
-    def __init__(self, shape: tuple[int, ...] = ()) -> None:
+    def __init__(self, shape: torch.Size = torch.Size()) -> None:
         super().__init__()
         self.shape = shape

--- a/paibox/paiir/ir/op_node.py
+++ b/paibox/paiir/ir/op_node.py
@@ -146,8 +146,8 @@ class OpNode(nn.Module, PAIIRNode):
         super(nn.Module, self).__init__()
 
         # Shape info, populated during graph construction
-        self.input_shapes: list[tuple[int, ...]] = []
-        self.output_shape: tuple[int, ...] = ()
+        self.input_shapes: list[torch.Size] = []
+        self.output_shape: torch.Size = torch.Size()
 
         # Axis ordering, populated by DimsProp
         self.input_dims: list[tuple[int, ...]] = []

--- a/paibox/paiir/ir/reshape_semantics.py
+++ b/paibox/paiir/ir/reshape_semantics.py
@@ -5,7 +5,7 @@ target classification and pure shape/dims helpers for reshape-like operators
 without introducing another object layer.
 """
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from typing import Any
 
 import torch
@@ -18,13 +18,12 @@ __all__ = [
     "RESHAPE_METHOD_NAMES",
     "SQUEEZE_FUNCTION_TARGETS",
     "UNSQUEEZE_FUNCTION_TARGETS",
-    "flatten_nested_values",
+    "is_layout_invisible_reshape",
+    "is_layout_invisible_dims",
     "is_dims_reset_target",
-    "is_identity_dims",
     "is_identity_repeat_values",
-    "is_squeeze_target",
-    "is_unsqueeze_target",
     "materialize_logical_layout",
+    "reshape_output_shape",
     "shape_after_dims",
 ]
 
@@ -79,18 +78,95 @@ def is_identity_dims(dims: tuple[int, ...]) -> bool:
     return not dims or dims == tuple(range(len(dims)))
 
 
-def shape_after_dims(
-    shape: tuple[int, ...] | torch.Size, dims: tuple[int, ...]
-) -> tuple[int, ...] | None:
+def is_layout_invisible_dims(shape: torch.Size, dims: tuple[int, ...]) -> bool:
+    """Return whether ``dims`` only changes logical grouping, not chip-visible order.
+
+    A permutation is considered layout-invisible when every non-singleton axis
+    stays in the same relative order and only singleton axes move around it.
+    """
+    if not dims:
+        return True
+    if not shape or len(shape) != len(dims):
+        return False
+    if sorted(dims) != list(range(len(dims))):
+        return False
+    if is_identity_dims(dims):
+        return True
+
+    non_singleton_axes = [axis for axis, size in enumerate(shape) if size != 1]
+    permuted_non_singleton_axes = [axis for axis in dims if shape[axis] != 1]
+    return permuted_non_singleton_axes == non_singleton_axes
+
+
+def canonicalize_layout_view(
+    shape: torch.Size, dims: tuple[int, ...]
+) -> tuple[torch.Size, tuple[int, ...]]:
+    """Normalize a layout-invisible view into ``(logical_shape, identity_dims)``.
+
+    This lets later simulation/layout code treat singleton-axis-only
+    permutations as a reshape-equivalent view instead of a real permute.
+    """
+    if not dims:
+        return shape, dims
+
+    logical_shape = shape_after_dims(shape, dims)
+    if logical_shape is None or not is_layout_invisible_dims(shape, dims):
+        return shape, dims
+
+    return logical_shape, tuple(range(len(logical_shape)))
+
+
+def shape_after_dims(shape: torch.Size, dims: tuple[int, ...]) -> torch.Size | None:
     if not shape or not dims or len(shape) != len(dims):
         return None
     if sorted(dims) != list(range(len(dims))):
         return None
-    return tuple(shape[axis] for axis in dims)
+
+    return torch.Size(shape[axis] for axis in dims)
+
+
+def reshape_output_shape(
+    input_shape: torch.Size,
+    input_dims: tuple[int, ...],
+    shape_fn: Callable[[torch.Size], torch.Size] | None,
+) -> torch.Size:
+    logical_shape = shape_after_dims(input_shape, input_dims)
+    if logical_shape is None:
+        logical_shape = input_shape
+
+    if shape_fn is None:
+        return torch.Size((logical_shape.numel(),))
+
+    return torch.Size(shape_fn(logical_shape))
+
+
+def is_layout_invisible_reshape(
+    input_shape: torch.Size,
+    output_shape: torch.Size,
+    input_dims: tuple[int, ...],
+    output_dims: tuple[int, ...],
+) -> bool:
+    if not input_shape or not output_shape:
+        return False
+    if input_shape.numel() != output_shape.numel():
+        return False
+
+    return is_layout_invisible_dims(
+        input_shape, input_dims
+    ) and is_layout_invisible_dims(output_shape, output_dims)
 
 
 def materialize_logical_layout(x: Tensor, dims: tuple[int, ...]) -> Tensor:
     """Apply a pending logical axis permutation when metadata requires it."""
     if is_identity_dims(dims) or x.dim() != len(dims):
         return x
-    return x.permute(*dims)
+
+    logical_shape, canonical_dims = canonicalize_layout_view(x.shape, dims)
+    if is_identity_dims(canonical_dims):
+        # Singleton-axis-only dims changes are chip-invisible, so a view-like
+        # reshape is sufficient and keeps the simulation closer to deployment.
+        if logical_shape == x.shape:
+            return x
+        return x.reshape(logical_shape)
+
+    return x.permute(*canonical_dims)

--- a/paibox/paiir/lowering/converter.py
+++ b/paibox/paiir/lowering/converter.py
@@ -156,6 +156,16 @@ _DEFAULT_MODULE_MAP: ModuleMapper = {
 
 
 def _propagate_shapes(gm: fx.GraphModule, *inputs: Tensor) -> None:
+    """Populate FX ``tensor_meta`` using the real traced module.
+
+    We intentionally keep this on plain ``ShapeProp`` rather than adding a
+    fake/meta execution path here. PAIIR lowering commonly includes native
+    neuron/LUT modules and custom registered neuron types whose forwards use
+    data-dependent state updates, while later compile passes still require
+    real weight values. A fake/meta branch would therefore need exclusions for
+    common project modules without covering enough of the compile cost to
+    justify the extra complexity and maintenance burden.
+    """
     ShapeProp(gm).propagate(*inputs)
 
 
@@ -182,9 +192,9 @@ def _is_dtype_getattr(node: fx.Node) -> bool:
 
 
 def _make_fixed_shape_fn(
-    target_shape: tuple[int, ...],
+    target_shape: torch.Size,
 ) -> Callable[[torch.Size], torch.Size]:
-    return lambda _input_shape, target=target_shape: torch.Size(target)
+    return lambda _input_shape, target=target_shape: target
 
 
 def _normalize_dim(ndim: int, dim: int) -> int:
@@ -218,7 +228,7 @@ def _make_flatten_shape_fn(
 
 
 def _build_reshape_op(
-    output_shape: tuple[int, ...],
+    output_shape: torch.Size,
     shape_fn: Callable[[torch.Size], torch.Size] | None = None,
 ) -> ReshapeOp | None:
     """Create a ``ReshapeOp`` from analyzed shape metadata or a shape function."""
@@ -445,19 +455,19 @@ def _lower_general_add_ir(
     )
 
 
-def _get_output_shape(node: fx.Node) -> tuple[int, ...]:
+def _get_output_shape(node: fx.Node) -> torch.Size:
     """Extract output shape from an FX node's meta."""
     meta = node.meta.get("tensor_meta")
     if meta is None:
-        return ()
+        return torch.Size()
     if hasattr(meta, "shape"):
-        return tuple(meta.shape)
-    return ()
+        return torch.Size(meta.shape)
+    return torch.Size()
 
 
 def _get_input_shapes(
     node: fx.Node, input_nodes: tuple[fx.Node, ...] | None = None
-) -> list[tuple[int, ...]]:
+) -> list[torch.Size]:
     """Extract input shapes from an FX node's predecessor meta."""
     source_nodes = (
         input_nodes if input_nodes is not None else tuple(node.all_input_nodes)
@@ -753,7 +763,7 @@ def _create_output_nodes(
     paiir_graph: PAIIRGraph, ctx: _LoweringContext, node: fx.Node
 ) -> None:
     for i, arg in enumerate(_iter_output_args(node)):
-        out_shape = _get_output_shape(arg) if isinstance(arg, fx.Node) else ()
+        out_shape = _get_output_shape(arg) if isinstance(arg, fx.Node) else torch.Size()
         ir_node = OutputNode(shape=out_shape)
         paiir_graph.add_node(ir_node)
         ctx.fx_to_ir[f"{node.name}_{i}"] = ir_node.name

--- a/paibox/paiir/lowering/shape_analysis.py
+++ b/paibox/paiir/lowering/shape_analysis.py
@@ -23,15 +23,8 @@ from ..ir.reshape_semantics import (
     is_identity_repeat_values,
 )
 
-__all__ = [
-    "FLATTEN_FUNCTION_TARGETS",
-    "RESHAPE_FUNCTION_TARGETS",
-    "RESHAPE_LEAF_MODULE_TYPES",
-    "RESHAPE_METHOD_NAMES",
-    "ShapeAnalysisResult",
-    "ReshapeSinkInfo",
-    "analyze_shape_helpers",
-]
+__all__ = ["ShapeAnalysisResult", "ReshapeSinkInfo", "analyze_shape_helpers"]
+
 _SHAPE_EXPR_FUNCTION_TARGETS = (
     operator.getitem,
     operator.add,
@@ -72,7 +65,7 @@ class ReshapeSinkInfo:
     kind: Literal["flatten", "reshape"]
     data_input: fx.Node
     shape_seed_nodes: tuple[fx.Node, ...]
-    output_shape: tuple[int, ...]
+    output_shape: torch.Size
     start_dim: int = 0
     end_dim: int = -1
 
@@ -257,17 +250,17 @@ def _iter_nested_fx_nodes(value: Any) -> list[fx.Node]:
     return []
 
 
-def _extract_tensor_output_shape(node: fx.Node) -> tuple[int, ...]:
+def _extract_tensor_output_shape(node: fx.Node) -> torch.Size:
     """Return output tensor shape using Torch-propagated metadata when available."""
     tensor_meta = node.meta.get("tensor_meta")
     if tensor_meta is not None and hasattr(tensor_meta, "shape"):
-        return tuple(tensor_meta.shape)
+        return torch.Size(tensor_meta.shape)
 
     val = node.meta.get("val")
     if isinstance(val, torch.Tensor):
-        return tuple(val.shape)
+        return val.shape
 
-    return ()
+    return torch.Size()
 
 
 def _get_call_arg(node: fx.Node, index: int, name: str, default: Any = None) -> Any:

--- a/paibox/paiir/pipeline/compile.py
+++ b/paibox/paiir/pipeline/compile.py
@@ -52,6 +52,8 @@ from torch import Tensor, nn
 from ..ir.graph import PAIIRGraph
 from ..lowering.converter import torch_to_paiir
 from .data_format import DataFormat
+from .layout_chain_canonicalization import canonicalize_layout_chains
+from .layout_cross_node_elision import elide_layout_invisible_reshapes
 from .passes import (
     TickOverride,
     assign_tick_params,
@@ -213,39 +215,45 @@ def compile_to_paiir(
         model, *sample_inputs, concrete_args=concrete_args, strict=strict
     )
 
-    # Step 2: Narrow expression-layer add nodes into deployable add IR where possible.
+    # Step 2: Canonicalize local layout-only routing chains.
+    graph = canonicalize_layout_chains(graph)
+
+    # Step 3: Narrow expression-layer add nodes into deployable add IR where possible.
     graph = specialize_general_adds(graph)
 
-    # Step 3: Choose topology, fuse atomic nodes, and prepare AvgPool deployment
+    # Step 4: Elide chip-invisible reshape wrappers around eligible nodes.
+    graph = elide_layout_invisible_reshapes(graph)
+
+    # Step 5: Choose topology, fuse atomic nodes, and prepare AvgPool deployment
     graph = fuse_to_offline_cores(
         graph, _enable_split_avgpool_lif, _enable_avgpool_calibration
     )
 
-    # Step 4: Early validation on the fused graph. This stage is allowed to
+    # Step 6: Early validation on the fused graph. This stage is allowed to
     # clean up disconnected regions and enforces only the invariants needed
     # before later passes run.
     validate_graph(graph)
 
-    # Step 5: Infer semantic output domains
+    # Step 7: Infer semantic output domains
     propagate_signal_domain(graph)
 
-    # Step 6: Infer and fill data format parameters
+    # Step 8: Infer and fill data format parameters
     propagate_data_format(graph, _input_formats)
 
-    # Step 7: Assign timing parameters
+    # Step 9: Assign timing parameters
     assign_tick_params(graph, _tick_duration, _auto_reset, tick_overrides)
 
-    # Step 8: Calibrate AvgPool+LIF thresholds (experimental, off by default)
+    # Step 10: Calibrate AvgPool+LIF thresholds (experimental, off by default)
     if _enable_avgpool_calibration:
         calibrate_avgpool_thresholds(graph)
 
-    # Step 9: Final validation after all compile-time annotations are filled.
+    # Step 11: Final validation after all compile-time annotations are filled.
     # Unlike validate_graph(), this stage assumes the graph is in its final
     # compiled form and checks shape/dims completeness, propagated signal
     # domains, propagated data formats, tick parameters, and connectivity.
     validate_compiled_graph(graph)
 
-    # Step 10: The backend only accepts deployable IR nodes. Expression-layer
+    # Step 12: The backend only accepts deployable IR nodes. Expression-layer
     # nodes such as GeneralAddOp must have been specialized away by now.
     validate_deployable_graph(graph)
 

--- a/paibox/paiir/pipeline/layout_chain_canonicalization.py
+++ b/paibox/paiir/pipeline/layout_chain_canonicalization.py
@@ -1,0 +1,115 @@
+"""Canonicalize consecutive layout-only routing chains before fusion."""
+
+from collections.abc import Callable
+
+import torch
+
+from ..ir.graph import PAIIRGraph
+from ..ir.op_node import ReshapeOp
+from ..ir.reshape_semantics import is_layout_invisible_dims, reshape_output_shape
+
+__all__ = ["canonicalize_layout_chains"]
+
+
+def canonicalize_layout_chains(graph: PAIIRGraph) -> PAIIRGraph:
+    """Collapse local reshape-only chains until no further rewrite applies."""
+    changed = True
+    while changed:
+        changed = False
+        for name in graph.topo_sort():
+            node = graph.nodes.get(name)
+            if not isinstance(node, ReshapeOp):
+                continue
+
+            if _try_remove_identity_reshape(graph, name):
+                changed = True
+                break
+
+            if _try_collapse_adjacent_reshapes(graph, name):
+                changed = True
+                break
+
+    return graph
+
+
+def _try_remove_identity_reshape(graph: PAIIRGraph, name: str) -> bool:
+    """Delete a reshape when both shape and effective layout are unchanged."""
+    node = graph.nodes.get(name)
+    if not isinstance(node, ReshapeOp):
+        return False
+
+    preds = graph.predecessors(name)
+    if len(preds) != 1:
+        return False
+
+    if len(node.input_shapes) != 1 or not node.input_shapes[0] or not node.output_shape:
+        return False
+
+    if node.input_shapes[0] != node.output_shape:
+        return False
+
+    input_dims = node.input_dims[0] if len(node.input_dims) == 1 else ()
+    if not is_layout_invisible_dims(node.input_shapes[0], input_dims):
+        return False
+    if not is_layout_invisible_dims(node.output_shape, node.output_dims):
+        return False
+
+    graph.remove_node_and_reconnect(name)
+    return True
+
+
+def _try_collapse_adjacent_reshapes(graph: PAIIRGraph, first_name: str) -> bool:
+    first = graph.nodes.get(first_name)
+    if not isinstance(first, ReshapeOp):
+        return False
+
+    succs = graph.successors(first_name)
+    if len(succs) != 1:
+        return False
+
+    second_name = succs[0]
+    second = graph.nodes.get(second_name)
+    if not isinstance(second, ReshapeOp):
+        return False
+
+    if len(graph.predecessors(second_name)) != 1:
+        return False
+
+    if (
+        len(first.input_shapes) != 1
+        or not first.input_shapes[0]
+        or not second.output_shape
+    ):
+        return False
+
+    if len(second.input_shapes) != 1 or not second.input_shapes[0]:
+        return False
+
+    if len(first.input_dims) != 1 or len(second.input_dims) != 1:
+        return False
+
+    composed = ReshapeOp(shape_fn=_compose_shape_fns([first, second]))
+    composed.input_shapes = list(first.input_shapes)
+    composed.output_shape = second.output_shape
+    composed.input_dims = list(first.input_dims)
+    composed.output_dims = second.output_dims
+
+    graph.add_node(composed)
+    graph.add_edge(graph.predecessors(first_name)[0], composed.name, 0)
+    graph.replace_all_uses_with(second_name, composed.name, delete_old=True)
+
+    graph.remove_node(first_name)
+    return True
+
+
+def _compose_shape_fns(chain: list[ReshapeOp]) -> Callable[[torch.Size], torch.Size]:
+    """Compose reshape functions using each op's logical input view."""
+
+    def _composed(input_shape: torch.Size) -> torch.Size:
+        current = input_shape
+        for op in chain:
+            dims = op.input_dims[0] if len(op.input_dims) == 1 else ()
+            current = reshape_output_shape(current, dims, op.shape_fn)
+        return current
+
+    return _composed

--- a/paibox/paiir/pipeline/layout_cross_node_elision.py
+++ b/paibox/paiir/pipeline/layout_cross_node_elision.py
@@ -1,0 +1,98 @@
+"""Elide layout-invisible reshape wrappers around deployable operators."""
+
+from ..ir.graph import PAIIRGraph
+from ..ir.op_node import ReshapeOp, StandaloneActOp, StandaloneCompOp
+from ..ir.reshape_semantics import is_layout_invisible_reshape
+
+__all__ = ["elide_layout_invisible_reshapes"]
+
+
+def elide_layout_invisible_reshapes(graph: PAIIRGraph) -> PAIIRGraph:
+    """Remove chip-invisible reshape wrappers around standalone activations."""
+    changed = True
+    while changed:
+        changed = False
+        for name in graph.topo_sort():
+            node = graph.nodes.get(name)
+            if not isinstance(node, StandaloneActOp):
+                continue
+
+            if _try_elide_comp_act_reshape_sandwich(graph, name):
+                changed = True
+                break
+
+    return graph
+
+
+def _try_elide_comp_act_reshape_sandwich(graph: PAIIRGraph, act_name: str) -> bool:
+    """Elide a balanced ``Comp -> Reshape -> Act -> Reshape`` sandwich.
+
+    The trailing reshape matters: we only remove the pair when the post-reshape
+    restores the compute node's visible output contract, so downstream users
+    continue to observe the same shape after the rewrite.
+    """
+    act = graph.nodes.get(act_name)
+    if not isinstance(act, StandaloneActOp):
+        return False
+
+    act_preds = graph.predecessors(act_name)
+    act_succs = graph.successors(act_name)
+    if len(act_preds) != 1 or len(act_succs) != 1:
+        return False
+
+    pre_name = act_preds[0]
+    post_name = act_succs[0]
+    pre = graph.nodes.get(pre_name)
+    post = graph.nodes.get(post_name)
+    if not isinstance(pre, ReshapeOp) or not isinstance(post, ReshapeOp):
+        return False
+
+    pre_preds = graph.predecessors(pre_name)
+    if len(pre_preds) != 1:
+        return False
+
+    if graph.successors(pre_name) != [act_name]:
+        return False
+
+    comp_name = pre_preds[0]
+    comp = graph.nodes.get(comp_name)
+    if not isinstance(comp, StandaloneCompOp):
+        return False
+
+    if graph.successors(comp_name) != [pre_name]:
+        return False
+    if graph.predecessors(post_name) != [act_name]:
+        return False
+
+    if not _is_layout_invisible(pre) or not _is_layout_invisible(post):
+        return False
+
+    if not comp.output_shape or pre.input_shapes != [comp.output_shape]:
+        return False
+    if not pre.output_shape or act.input_shapes != [pre.output_shape]:
+        return False
+    if not act.output_shape or post.input_shapes != [act.output_shape]:
+        return False
+    if post.output_shape != comp.output_shape:
+        return False
+
+    act.input_shapes = [comp.output_shape]
+    act.output_shape = comp.output_shape
+    act.input_dims = [comp.output_dims]
+    act.output_dims = comp.output_dims
+
+    graph.replace_all_uses_with(post_name, act_name, delete_old=True)
+    graph.remove_node(pre_name)
+    graph.add_edge(comp_name, act_name, 0)
+
+    return True
+
+
+def _is_layout_invisible(node: ReshapeOp) -> bool:
+    if len(node.input_shapes) != 1 or not node.input_shapes[0] or not node.output_shape:
+        return False
+
+    input_dims = node.input_dims[0] if len(node.input_dims) == 1 else ()
+    return is_layout_invisible_reshape(
+        node.input_shapes[0], node.output_shape, input_dims, node.output_dims
+    )

--- a/paibox/paiir/pipeline/passes.py
+++ b/paibox/paiir/pipeline/passes.py
@@ -306,38 +306,31 @@ def validate_graph(graph: PAIIRGraph) -> None:
     Use :func:`validate_compiled_graph` for the final post-pass validation of a
     fully compiled graph.
     """
-    errors: list[str] = []
-    to_remove: list[str] = []
-    missing_shape_nodes: list[str] = []
+    graph.lint(allow_disconnected=True)
+
+    to_remove = graph.disconnected_nodes()
+    if to_remove:
+        for name in to_remove:
+            _remove_node(graph, name)
+        warnings.warn(GraphCleanupWarning(to_remove))
 
     if not graph.input_nodes():
-        errors.append("graph has no input node")
+        raise GraphValidationError(
+            ["graph has no input node after cleanup (all were disconnected)"]
+        )
     if not graph.output_nodes():
-        errors.append("graph has no output node")
+        raise GraphValidationError(
+            ["graph has no output node after cleanup (all were disconnected)"]
+        )
+
+    graph.lint()
+
+    errors: list[str] = []
+    missing_shape_nodes: list[str] = []
 
     for name, node in graph.nodes.items():
-        preds = graph.predecessors(name)
-        succs = graph.successors(name)
-
-        if isinstance(node, InputNode):
-            if preds:
-                errors.append(
-                    f"InputNode '{name}' has predecessors {preds} (expected none)"
-                )
-            elif not succs:
-                to_remove.append(name)
-        elif isinstance(node, OutputNode):
-            if succs:
-                errors.append(
-                    f"OutputNode '{name}' has successors {succs} (expected none)"
-                )
-            elif not preds:
-                to_remove.append(name)
-        elif isinstance(node, OpNode):
-            if not preds or not succs:
-                to_remove.append(name)
-            elif not node.output_shape:
-                missing_shape_nodes.append(name)
+        if isinstance(node, OpNode) and not node.output_shape:
+            missing_shape_nodes.append(name)
 
     if missing_shape_nodes:
         names = ", ".join(missing_shape_nodes)
@@ -356,20 +349,6 @@ def validate_graph(graph: PAIIRGraph) -> None:
     if errors:
         raise GraphValidationError(errors)
 
-    if to_remove:
-        for name in to_remove:
-            _remove_node(graph, name)
-        warnings.warn(GraphCleanupWarning(to_remove))
-
-    if not graph.input_nodes():
-        raise GraphValidationError(
-            ["graph has no input node after cleanup (all were disconnected)"]
-        )
-    if not graph.output_nodes():
-        raise GraphValidationError(
-            ["graph has no output node after cleanup (all were disconnected)"]
-        )
-
 
 def validate_compiled_graph(graph: PAIIRGraph) -> None:
     """Validate a fully compiled graph before returning it to callers.
@@ -383,49 +362,17 @@ def validate_compiled_graph(graph: PAIIRGraph) -> None:
     - every :class:`OfflineCoreOp` has propagated data formats
     - every :class:`OfflineCoreOp` has valid tick parameters
     """
+    graph.lint()
+
     errors: list[str] = []
 
-    input_nodes = graph.input_nodes()
-    output_nodes = graph.output_nodes()
-    if not input_nodes:
-        errors.append("graph has no input node")
-    if not output_nodes:
-        errors.append("graph has no output node")
-
-    reachable_from_inputs = _collect_reachable_nodes(
-        graph, [node.name for node in input_nodes], reverse=False
-    )
-    reachable_to_outputs = _collect_reachable_nodes(
-        graph, [node.name for node in output_nodes], reverse=True
-    )
-    valid_path_nodes = reachable_from_inputs & reachable_to_outputs
-    missing_path_nodes = sorted(set(graph.nodes) - valid_path_nodes)
-    if missing_path_nodes:
-        names = ", ".join(missing_path_nodes)
-        errors.append(f"nodes not on any input-to-output path: {names}")
-
     for name, node in graph.nodes.items():
-        preds = graph.predecessors(name)
-        succs = graph.successors(name)
-
         if isinstance(node, InputNode):
-            if preds:
-                errors.append(
-                    f"InputNode '{name}' has predecessors {preds} (expected none)"
-                )
-            if not succs:
-                errors.append(f"InputNode '{name}' is disconnected from the graph")
             if node.output_domain is None:
                 errors.append(f"InputNode '{name}' is missing output_domain")
             continue
 
         if isinstance(node, OutputNode):
-            if succs:
-                errors.append(
-                    f"OutputNode '{name}' has successors {succs} (expected none)"
-                )
-            if not preds:
-                errors.append(f"OutputNode '{name}' is disconnected from the graph")
             if node.output_domain is None:
                 errors.append(f"OutputNode '{name}' is missing output_domain")
             continue
@@ -433,10 +380,6 @@ def validate_compiled_graph(graph: PAIIRGraph) -> None:
         if not isinstance(node, OpNode):
             continue
 
-        if not preds:
-            errors.append(f"OpNode '{name}' has no predecessors")
-        if not succs:
-            errors.append(f"OpNode '{name}' has no successors")
         if not node.input_shapes or any(not shape for shape in node.input_shapes):
             errors.append(f"OpNode '{name}' is missing input_shapes")
         if not node.output_shape:
@@ -476,14 +419,14 @@ def validate_compiled_graph(graph: PAIIRGraph) -> None:
         raise GraphValidationError(errors)
 
 
-def _get_node_output_shape(node: PAIIRNode) -> tuple[int, ...]:
+def _get_node_output_shape(node: PAIIRNode) -> torch.Size:
     if isinstance(node, InputNode):
         return node.shape
     if isinstance(node, OutputNode):
         return node.shape
     if isinstance(node, OpNode):
         return node.output_shape
-    return ()
+    return torch.Size()
 
 
 def _validate_concat_contract(
@@ -808,24 +751,6 @@ def validate_deployable_graph(graph: PAIIRGraph) -> None:
 def _remove_node(graph: PAIIRGraph, name: str) -> None:
     """Remove a node and all its edges from the graph."""
     graph.remove_node(name)
-
-
-def _collect_reachable_nodes(
-    graph: PAIIRGraph, start_names: list[str], reverse: bool
-) -> set[str]:
-    """Collect nodes reachable from *start_names* in forward or reverse mode."""
-    seen: set[str] = set()
-    stack = list(start_names)
-
-    while stack:
-        name = stack.pop()
-        if name in seen or name not in graph.nodes:
-            continue
-        seen.add(name)
-        neighbors = graph.predecessors(name) if reverse else graph.successors(name)
-        stack.extend(neighbors)
-
-    return seen
 
 
 def _validate_potential_add_contract(

--- a/tests/paiir/conftest.py
+++ b/tests/paiir/conftest.py
@@ -10,6 +10,12 @@ from paibox.paiir.ir.lut_activation import LutCustom
 from paibox.paiir.ir.op_node import OfflineCoreOp
 from paibox.paiir.lowering.converter import torch_to_paiir
 from paibox.paiir.pipeline.data_format import DataFormat
+from paibox.paiir.pipeline.layout_chain_canonicalization import (
+    canonicalize_layout_chains,
+)
+from paibox.paiir.pipeline.layout_cross_node_elision import (
+    elide_layout_invisible_reshapes,
+)
 from paibox.paiir.pipeline.passes import (
     fuse_to_offline_cores,
     propagate_data_format,
@@ -357,7 +363,9 @@ def offline_nodes(graph: PAIIRGraph) -> list[OfflineCoreOp]:
 def convert_and_fuse(model: nn.Module, *sample_inputs: Tensor) -> PAIIRGraph:
     """Trace a PyTorch model to PAIIR and fuse."""
     unfused = torch_to_paiir(model, *sample_inputs)
+    unfused = canonicalize_layout_chains(unfused)
     unfused = specialize_general_adds(unfused)
+    unfused = elide_layout_invisible_reshapes(unfused)
     return fuse_to_offline_cores(unfused)
 
 

--- a/tests/paiir/ir/test_core_neuron.py
+++ b/tests/paiir/ir/test_core_neuron.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from paicorelib import RM
+from paicorelib import RM, ThresholdPosMode
 from spikingjelly.activation_based import functional
 from torch import nn
 
@@ -423,8 +423,6 @@ class TestCoreNeuronV25ANN:
         neuron.eval()
         # Large positive input should be clamped by CEILING (thres_pos_mode default is FIRE not CEILING)
         # Use CEILING mode explicitly
-        from paicorelib import ThresholdPosMode
-
         neuron.thres_pos_mode = ThresholdPosMode.CEILING
         x = torch.tensor([[1000.0]])
         neuron(x)

--- a/tests/paiir/ir/test_graph.py
+++ b/tests/paiir/ir/test_graph.py
@@ -1,22 +1,20 @@
 import pytest
+import torch
 from torch import nn
 
+from paibox.paiir.exceptions import GraphValidationError
 from paibox.paiir.ir.add_ops import PotentialAddOp
 from paibox.paiir.ir.core_neuron import IFNodeV25
-from paibox.paiir.ir.graph import PAIIRGraph
+from paibox.paiir.ir.graph import Edge, PAIIRGraph
 from paibox.paiir.ir.ir_base import InputNode, OutputNode
-from paibox.paiir.ir.op_node import (
-    SequentialOp,
-    StandaloneActOp,
-    StandaloneCompOp,
-)
+from paibox.paiir.ir.op_node import SequentialOp, StandaloneActOp, StandaloneCompOp
 
 
 class TestPAIIRGraph:
     def _build_simple_graph(self):
         """Build Input -> Conv+IF -> Output."""
         graph = PAIIRGraph("test")
-        inp = InputNode(shape=(1, 3, 8, 8))
+        inp = InputNode(shape=torch.Size((1, 3, 8, 8)))
         seq = SequentialOp(nn.Conv2d(3, 8, 3, padding=1), IFNodeV25())
         out = OutputNode()
         graph.add_node(inp)
@@ -53,7 +51,7 @@ class TestPAIIRGraph:
 
     def test_add_edge_invalidates_cached_predecessors(self):
         graph = PAIIRGraph("port_order_cache")
-        inp = InputNode(shape=(1, 4))
+        inp = InputNode(shape=torch.Size((1, 4)))
         a = StandaloneCompOp(nn.Linear(4, 8))
         b = StandaloneCompOp(nn.Linear(4, 8))
         add = PotentialAddOp(op_signs=(1, 1))
@@ -80,15 +78,106 @@ class TestPAIIRGraph:
         assert graph.successors(inp.name) == []
         assert graph.predecessors(out.name) == []
 
+    def test_replace_all_uses_with(self):
+        graph = PAIIRGraph("replace_uses")
+        inp = InputNode(shape=torch.Size((1, 4)))
+        a = StandaloneCompOp(nn.Linear(4, 8))
+        b = StandaloneCompOp(nn.Linear(4, 8))
+        out1 = OutputNode()
+        out2 = OutputNode()
+
+        for node in (inp, a, b, out1, out2):
+            graph.add_node(node)
+
+        graph.add_edge(inp.name, a.name)
+        graph.add_edge(inp.name, b.name)
+        graph.add_edge(a.name, out1.name)
+        graph.add_edge(a.name, out2.name)
+        graph.add_edge(b.name, out2.name)
+
+        graph.replace_all_uses_with(a.name, b.name)
+
+        assert a.name in graph.nodes
+        assert graph.outgoing_edges(a.name) == []
+        assert graph.predecessors(out1.name) == [b.name]
+        assert graph.predecessors(out2.name) == [b.name]
+        assert len(graph.outgoing_edges(b.name)) == 2
+
+    def test_remove_node_and_reconnect(self):
+        graph = PAIIRGraph("remove_reconnect")
+        inp = InputNode(shape=torch.Size((1, 4)))
+        reshape = StandaloneActOp(IFNodeV25())
+        out1 = OutputNode()
+        out2 = OutputNode()
+
+        for node in (inp, reshape, out1, out2):
+            graph.add_node(node)
+
+        graph.add_edge(inp.name, reshape.name)
+        graph.add_edge(reshape.name, out1.name)
+        graph.add_edge(reshape.name, out2.name)
+
+        graph.remove_node_and_reconnect(reshape.name)
+
+        assert reshape.name not in graph.nodes
+        assert graph.predecessors(out1.name) == [inp.name]
+        assert graph.predecessors(out2.name) == [inp.name]
+
+    def test_remove_node_and_reconnect_rejects_non_predecessor_source(self):
+        graph = PAIIRGraph("remove_reconnect_source_validation")
+        inp = InputNode(shape=torch.Size((1, 4)))
+        other = StandaloneCompOp(nn.Linear(4, 4))
+        reshape = StandaloneActOp(IFNodeV25())
+        out = OutputNode()
+
+        for node in (inp, other, reshape, out):
+            graph.add_node(node)
+
+        graph.add_edge(inp.name, reshape.name)
+        graph.add_edge(reshape.name, out.name)
+
+        with pytest.raises(ValueError, match="is not a predecessor"):
+            graph.remove_node_and_reconnect(reshape.name, source_name=other.name)
+
     def test_input_output_nodes(self):
         graph, inp, seq, out = self._build_simple_graph()
         assert len(graph.input_nodes()) == 1
         assert len(graph.output_nodes()) == 1
 
+    def test_lint_rejects_edge_with_missing_endpoint(self):
+        graph, _, _, out = self._build_simple_graph()
+        graph.edges.append(Edge("missing_node", out.name))
+
+        with pytest.raises(GraphValidationError, match="missing source node"):
+            graph.lint()
+
+    def test_lint_rejects_disconnected_node(self):
+        graph, _, _, _ = self._build_simple_graph()
+        dead_end = StandaloneCompOp(nn.Linear(4, 8))
+        graph.add_node(dead_end)
+
+        with pytest.raises(
+            GraphValidationError, match="nodes not on any input-to-output path"
+        ):
+            graph.lint()
+
+    def test_verify_before_sim_reports_structural_lint_errors(self):
+        graph, _, seq, _ = self._build_simple_graph()
+        seq.output_shape = torch.Size((1, 8, 8, 8))
+        seq.core_params.tick_start = 1
+        seq.core_params.tick_duration = 0
+        seq.core_params.tick_initial = 0
+
+        disconnected_input = InputNode(shape=torch.Size((1, 3, 8, 8)))
+        graph.add_node(disconnected_input)
+
+        with pytest.raises(RuntimeError, match="nodes not on any input-to-output path"):
+            graph.verify_before_sim()
+
     def test_diamond_graph(self):
         """Diamond: Input -> [A, B] -> Add -> Output."""
         graph = PAIIRGraph("diamond")
-        inp = InputNode(shape=(1, 4))
+        inp = InputNode(shape=torch.Size((1, 4)))
         a = StandaloneCompOp(nn.Linear(4, 8))
         b = StandaloneCompOp(nn.Linear(4, 8))
         add = PotentialAddOp(op_signs=(1, 1))
@@ -112,7 +201,7 @@ class TestPAIIRGraph:
 
     def test_summary_prefers_comp_and_act_type_names(self, capsys):
         graph = PAIIRGraph("summary_labels")
-        inp = InputNode(shape=(1, 4))
+        inp = InputNode(shape=torch.Size((1, 4)))
         comp = StandaloneCompOp(nn.Linear(4, 8))
         act = StandaloneActOp(IFNodeV25())
         out = OutputNode()

--- a/tests/paiir/ir/test_namespace.py
+++ b/tests/paiir/ir/test_namespace.py
@@ -1,0 +1,61 @@
+import pytest
+
+from paibox.paiir.ir._namespace import IRNamespace
+
+
+class Dummy:
+    pass
+
+
+class TestIRNamespace:
+    def test_create_name_is_stable_for_same_object(self):
+        namespace = IRNamespace()
+        obj = Dummy()
+
+        name1 = namespace.create_name(obj)
+        name2 = namespace.create_name(obj)
+
+        assert name1 == "Dummy_0"
+        assert name2 == name1
+
+    def test_create_name_uses_candidate_and_suffixes_uniquely(self):
+        namespace = IRNamespace()
+
+        name1 = namespace.create_name("GeneralAddOp", Dummy())
+        name2 = namespace.create_name("GeneralAddOp", Dummy())
+
+        assert name1 == "GeneralAddOp_0"
+        assert name2 == "GeneralAddOp_1"
+
+    def test_create_name_normalizes_invalid_candidate(self):
+        namespace = IRNamespace()
+
+        name = namespace.create_name("9 bad-name", Dummy())
+
+        assert name == "_9_bad_name_0"
+
+    def test_associate_name_with_obj_rejects_duplicate_name(self):
+        namespace = IRNamespace()
+        namespace.associate_name_with_obj("Node_7", Dummy())
+
+        with pytest.raises(ValueError, match="already used"):
+            namespace.associate_name_with_obj("Node_7", Dummy())
+
+    def test_rename_rejects_conflicting_name(self):
+        namespace = IRNamespace()
+        a = Dummy()
+        b = Dummy()
+        namespace.create_name("Node", a)
+        namespace.create_name("Node", b)
+
+        with pytest.raises(ValueError, match="already used"):
+            namespace.rename(b, "Node_0")
+
+    def test_rename_accepts_new_unique_name(self):
+        namespace = IRNamespace()
+        obj = Dummy()
+        namespace.create_name("Node", obj)
+
+        namespace.rename(obj, "SpecializedAdd_9")
+
+        assert namespace.create_name(obj) == "SpecializedAdd_9"

--- a/tests/paiir/ir/test_op_node.py
+++ b/tests/paiir/ir/test_op_node.py
@@ -122,7 +122,7 @@ class TestWeights:
     def test_sequential_conv_returns_weight(self):
         conv = nn.Conv2d(3, 8, 3, padding=1)
         op = SequentialOp(comp=conv, act=ANNNodeV25(lut=LutReLU()))
-        op.output_shape = (1, 8, 8, 8)
+        op.output_shape = torch.Size((1, 8, 8, 8))
         ws = op.weights
         assert ws is not None
         assert len(ws) == 1
@@ -132,14 +132,14 @@ class TestWeights:
     def test_sequential_pool_returns_none(self):
         """Weightless ops (pool etc.) return None, not identity matrices."""
         op = SequentialOp(comp=nn.MaxPool2d(2), act=IFNodeV25())
-        op.output_shape = (1, 4, 4, 4)
+        op.output_shape = torch.Size((1, 4, 4, 4))
         assert op.weights is None
 
     def test_accumulate_returns_per_path_weights(self):
         conv1 = nn.Conv2d(3, 8, 3, padding=1)
         conv2 = nn.Conv2d(3, 8, 3, padding=1)
         op = AccumulateOp(comps=[conv1, conv2], act=IFNodeV25(), op_signs=(1, 1))
-        op.output_shape = (1, 8, 8, 8)
+        op.output_shape = torch.Size((1, 8, 8, 8))
         ws = op.weights
         assert ws is not None
         assert len(ws) == 2
@@ -154,7 +154,7 @@ class TestWeights:
     def test_standalone_comp_linear_returns_weight(self):
         linear = nn.Linear(4, 8, bias=False)
         op = StandaloneCompOp(comp=linear)
-        op.output_shape = (1, 8)
+        op.output_shape = torch.Size((1, 8))
         ws = op.weights
         assert ws is not None
         assert len(ws) == 1
@@ -164,7 +164,7 @@ class TestWeights:
     def test_standalone_comp_pool_returns_none(self):
         """Weightless ops (pool etc.) return None, not identity matrices."""
         op = StandaloneCompOp(comp=nn.AvgPool2d(2))
-        op.output_shape = (1, 3, 4, 4)
+        op.output_shape = torch.Size((1, 3, 4, 4))
         assert op.weights is None
 
     def test_add_op_returns_none(self):
@@ -213,7 +213,7 @@ class TestWeights:
 
     def test_standalone_act_weight_format_uses_implicit_identity_range(self):
         op = StandaloneActOp(act=ANNNodeV25(lut=LutReLU()))
-        op.output_shape = (1, 1024, 1024)
+        op.output_shape = torch.Size((1, 1024, 1024))
 
         assert _infer_node_weight_format(op) == (
             DataSign.UNSIGNED,
@@ -222,7 +222,7 @@ class TestWeights:
 
     def test_add_weight_format_uses_implicit_identity_range(self):
         op = PotentialAddOp(op_signs=(1, -1))
-        op.output_shape = (1, 1024, 1024)
+        op.output_shape = torch.Size((1, 1024, 1024))
 
         assert _infer_node_weight_format(op) == (
             DataSign.UNSIGNED,

--- a/tests/paiir/ir/test_reshape_semantics.py
+++ b/tests/paiir/ir/test_reshape_semantics.py
@@ -1,0 +1,40 @@
+import torch
+
+from paibox.paiir.ir.reshape_semantics import (
+    canonicalize_layout_view,
+    materialize_logical_layout,
+)
+
+
+class TestReshapeSemantics:
+    def test_canonicalizes_singleton_axis_layout_view(self):
+        logical_shape, canonical_dims = canonicalize_layout_view(
+            torch.Size((1, 3, 4)), (1, 0, 2)
+        )
+
+        assert logical_shape == (3, 1, 4)
+        assert canonical_dims == (0, 1, 2)
+
+    def test_keeps_non_singleton_permutation(self):
+        logical_shape, canonical_dims = canonicalize_layout_view(
+            torch.Size((2, 3, 4)), (1, 0, 2)
+        )
+
+        assert logical_shape == (2, 3, 4)
+        assert canonical_dims == (1, 0, 2)
+
+    def test_materializes_singleton_axis_layout_with_reshape_equivalent(self):
+        x = torch.arange(12).reshape(1, 3, 4)
+
+        result = materialize_logical_layout(x, (1, 0, 2))
+
+        assert result.shape == (3, 1, 4)
+        assert torch.equal(result, x.permute(1, 0, 2))
+
+    def test_materializes_non_singleton_layout_with_permute_semantics(self):
+        x = torch.arange(24).reshape(2, 3, 4)
+
+        result = materialize_logical_layout(x, (1, 0, 2))
+
+        assert result.shape == (3, 2, 4)
+        assert torch.equal(result, x.permute(1, 0, 2))

--- a/tests/paiir/lowering/test_converter.py
+++ b/tests/paiir/lowering/test_converter.py
@@ -10,6 +10,7 @@ from paibox.paiir.ir.lut_activation import LutCustom
 from paibox.paiir.ir.op_node import SequentialOp, StandaloneCompOp
 from paibox.paiir.lowering.converter import register_neuron, torch_to_paiir
 from tests.paiir.conftest import (
+    MultiSpike4,
     UnsupportedSinModel,
     convert_and_fuse,
     find_nodes,
@@ -92,8 +93,6 @@ class TestRegisterNeuron:
 
     def test_register_custom_neuron(self):
         """Register MultiSpike4 -> compile a model -> verify graph structure."""
-        from tests.paiir.conftest import MultiSpike4
-
         register_neuron(
             MultiSpike4, converter=lambda _: ANNNodeV25(make_multispike4_lut())
         )

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -203,9 +203,9 @@ class TestCompileBasic:
             if isinstance(node.comp, nn.MaxPool2d)
         ]
 
-        assert len(reshape_nodes) == 1
+        assert len(reshape_nodes) == 0
         assert len(pool_nodes) == 1
-        assert graph.predecessors(pool_nodes[0].name) == [reshape_nodes[0].name]
+        assert graph.predecessors(pool_nodes[0].name) == ["InputNode_0"]
         assert pool_nodes[0].core_params.input_sign is not None
         assert pool_nodes[0].core_params.input_width is not None
 
@@ -229,11 +229,10 @@ class TestCompileBasic:
             if isinstance(node.comp, nn.Linear)
         ]
 
-        assert len(reshape_nodes) == 2
+        assert len(reshape_nodes) == 1
         assert len(linear_nodes) == 1
         assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
-        assert graph.predecessors(reshape_nodes[1].name) == [reshape_nodes[0].name]
-        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[1].name]
+        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[0].name]
 
     def test_tuple_repeat_all_ones_before_linear_compiles(self):
         class TupleRepeatLinear(nn.Module):
@@ -255,11 +254,10 @@ class TestCompileBasic:
             if isinstance(node.comp, nn.Linear)
         ]
 
-        assert len(reshape_nodes) == 2
+        assert len(reshape_nodes) == 1
         assert len(linear_nodes) == 1
         assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
-        assert graph.predecessors(reshape_nodes[1].name) == [reshape_nodes[0].name]
-        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[1].name]
+        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[0].name]
 
     def test_method_squeeze_before_linear_compiles(self):
         class MethodSqueezeLinear(nn.Module):
@@ -281,11 +279,10 @@ class TestCompileBasic:
             if isinstance(node.comp, nn.Linear)
         ]
 
-        assert len(reshape_nodes) == 2
+        assert len(reshape_nodes) == 1
         assert len(linear_nodes) == 1
         assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
-        assert graph.predecessors(reshape_nodes[1].name) == [reshape_nodes[0].name]
-        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[1].name]
+        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[0].name]
 
     def test_function_squeeze_before_linear_compiles(self):
         class FunctionSqueezeLinear(nn.Module):
@@ -307,11 +304,10 @@ class TestCompileBasic:
             if isinstance(node.comp, nn.Linear)
         ]
 
-        assert len(reshape_nodes) == 2
+        assert len(reshape_nodes) == 1
         assert len(linear_nodes) == 1
         assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
-        assert graph.predecessors(reshape_nodes[1].name) == [reshape_nodes[0].name]
-        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[1].name]
+        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[0].name]
 
 
 class TestDataFormat:
@@ -664,7 +660,8 @@ class TestFunctionalConv:
 
         assert reshape_nodes
         assert comp_nodes
-        assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
+        assert graph.predecessors(comp_nodes[0].name) == ["InputNode_0"]
+        assert graph.predecessors(reshape_nodes[0].name) == [comp_nodes[0].name]
 
     def test_view_as_reference_path_does_not_become_data_predecessor(self):
         class ViewAsReferenceFromFlatten(nn.Module):

--- a/tests/paiir/pipeline/test_graph_simulation.py
+++ b/tests/paiir/pipeline/test_graph_simulation.py
@@ -23,7 +23,19 @@ from paibox.paiir.pipeline.avgpool import (
     AvgPoolLIFCandidateScore,
 )
 from paibox.paiir.pipeline.passes import GraphCleanupWarning
-from tests.paiir.conftest import MultiInputMerge, find_nodes
+from tests.paiir.conftest import (
+    ANNClassifier,
+    ANNResidualSubtract,
+    MultiInputMerge,
+    SNNDepthwiseSeparable,
+    SNNFlattenTransition,
+    SNNResidualAdd,
+    SNNTwoLayer,
+    SNNWithAvgPoolIF,
+    SNNWithMaxPool,
+    SPPFBlock,
+    find_nodes,
+)
 
 
 def _make_snn_input(
@@ -667,8 +679,6 @@ class TestMultiLayerSNN:
         For multi-layer networks, the output is available at step = max(tick_start).
         This is because each layer's tick_start is assigned based on DAG depth.
         """
-        from tests.paiir.conftest import SNNTwoLayer
-
         model = SNNTwoLayer()
         _set_quantized_weights(model)
 
@@ -700,8 +710,6 @@ class TestMultiLayerSNN:
         Tests spatial-to-dense transition in SNN context now that flatten is
         materialized as a routing ``ReshapeOp`` for graph simulation.
         """
-        from tests.paiir.conftest import SNNFlattenTransition
-
         model = SNNFlattenTransition()
         _set_quantized_weights(model)
 
@@ -732,8 +740,6 @@ class TestMultiLayerSNN:
 
         Verifies grouped conv handling in multi-layer SNN.
         """
-        from tests.paiir.conftest import SNNDepthwiseSeparable
-
         model = SNNDepthwiseSeparable()
         _set_quantized_weights(model)
 
@@ -763,8 +769,6 @@ class TestMultiLayerSNN:
 
         Verifies MaxPool fusion in multi-layer SNN context.
         """
-        from tests.paiir.conftest import SNNWithMaxPool
-
         model = SNNWithMaxPool()
         _set_quantized_weights(model)
 
@@ -799,8 +803,6 @@ class TestMultiLayerSNN:
         Both power-of-2 and non-power-of-2 kernels should match SpikingJelly exactly,
         since Core 1 passes through the true sum and Core 2 compensates with window_size.
         """
-        from tests.paiir.conftest import SNNWithAvgPoolIF
-
         model = SNNWithAvgPoolIF(kernel_size)
         _set_quantized_weights(model)
 
@@ -950,8 +952,6 @@ class TestMultiLayerANN:
             "The multi-step execution pattern is implemented correctly."
         )
 
-        from tests.paiir.conftest import ANNClassifier
-
         model = ANNClassifier()
         _set_quantized_weights(model)
 
@@ -996,8 +996,6 @@ class TestAccumulateOpSimulation:
 
         Verifies signs=(1, 1) accumulation, exact match with SpikingJelly.
         """
-        from tests.paiir.conftest import SNNResidualAdd
-
         model = SNNResidualAdd()
         _set_quantized_weights(model)
 
@@ -1033,9 +1031,6 @@ class TestAccumulateOpSimulation:
             "LUT Tanh requires input domain mapping fix. "
             "The AccumulateOp structure is verified correctly."
         )
-
-        from paibox.paiir.ir.op_node import AccumulateOp
-        from tests.paiir.conftest import ANNResidualSubtract
 
         model = ANNResidualSubtract()
         _set_quantized_weights(model)
@@ -1073,8 +1068,6 @@ class TestAccumulateOpSimulation:
 
         Tests multiple InputNodes handling in accumulation context.
         """
-        from paibox.paiir.ir.op_node import AccumulateOp
-
         model = MultiInputMerge()
         _set_quantized_weights(model)
 
@@ -1114,8 +1107,6 @@ class TestConcatOpSimulation:
 
         Need to run max_tick_start=5 steps to get final output.
         """
-        from tests.paiir.conftest import SPPFBlock
-
         model = SPPFBlock()
         _set_quantized_weights(model)
 
@@ -1289,7 +1280,7 @@ class TestStandaloneOpSimulation:
 
         graph = compile_to_paiir(model, x_compile)
         reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
-        assert len(reshape_nodes) == 2
+        assert len(reshape_nodes) == 1
 
         graph.reset()
         max_tick_start = max(
@@ -1407,7 +1398,7 @@ class TestStandaloneOpSimulation:
 
         graph = compile_to_paiir(model, x_compile)
         reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
-        assert len(reshape_nodes) == 2
+        assert len(reshape_nodes) == 1
 
         graph.reset()
         max_tick_start = max(
@@ -1446,7 +1437,7 @@ class TestStandaloneOpSimulation:
 
         graph = compile_to_paiir(model, x_compile)
         reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
-        assert len(reshape_nodes) == 2
+        assert len(reshape_nodes) == 1
 
         graph.reset()
         max_tick_start = max(
@@ -1485,7 +1476,7 @@ class TestStandaloneOpSimulation:
 
         graph = compile_to_paiir(model, x_compile)
         reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
-        assert len(reshape_nodes) == 2
+        assert len(reshape_nodes) == 1
 
         graph.reset()
         max_tick_start = max(
@@ -1524,7 +1515,7 @@ class TestStandaloneOpSimulation:
 
         graph = compile_to_paiir(model, x_compile)
         reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
-        assert len(reshape_nodes) == 2
+        assert len(reshape_nodes) == 1
 
         graph.reset()
         max_tick_start = max(
@@ -1615,7 +1606,11 @@ class TestStandaloneOpSimulation:
         assert torch.equal(paiir_out, pytorch_out)
 
     def test_flatten_then_reshape_chain_before_linear(self) -> None:
-        """Chained `flatten -> reshape(size arithmetic) -> flatten -> Linear` simulates."""
+        """Chained `flatten -> reshape(size arithmetic) -> flatten -> Linear` simulates.
+
+        The pre-fusion layout canonicalization pass now collapses the reshape
+        chain to a single effective `ReshapeOp`.
+        """
 
         class FlattenReshapeLinear(nn.Module):
             def __init__(self) -> None:
@@ -1640,7 +1635,7 @@ class TestStandaloneOpSimulation:
 
         graph = compile_to_paiir(model, x_compile)
         reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
-        assert len(reshape_nodes) == 3
+        assert len(reshape_nodes) == 1
 
         graph.reset()
         max_tick_start = max(

--- a/tests/paiir/pipeline/test_layout_chain_canonicalization.py
+++ b/tests/paiir/pipeline/test_layout_chain_canonicalization.py
@@ -31,9 +31,7 @@ def _reshape(
 class TestLayoutChainCanonicalization:
     def test_singleton_axis_dims_permutation_is_layout_invisible(self):
         assert is_layout_invisible_dims(torch.Size((1, 3, 4)), (1, 0, 2))
-        assert is_layout_invisible_dims(
-            torch.Size((1, 1, 64, 40, 40)), (1, 0, 2, 3, 4)
-        )
+        assert is_layout_invisible_dims(torch.Size((1, 1, 64, 40, 40)), (1, 0, 2, 3, 4))
         assert not is_layout_invisible_dims(torch.Size((2, 3, 4)), (1, 0, 2))
 
     def test_collapses_three_identity_reshape_nodes(self):

--- a/tests/paiir/pipeline/test_layout_chain_canonicalization.py
+++ b/tests/paiir/pipeline/test_layout_chain_canonicalization.py
@@ -1,0 +1,119 @@
+import torch
+
+from paibox.paiir.ir.graph import PAIIRGraph
+from paibox.paiir.ir.ir_base import InputNode, OutputNode
+from paibox.paiir.ir.op_node import ReshapeOp
+from paibox.paiir.ir.reshape_semantics import is_layout_invisible_dims
+from paibox.paiir.pipeline.layout_chain_canonicalization import (
+    canonicalize_layout_chains,
+)
+
+
+def _fixed_shape(shape: tuple[int, ...]):
+    target = torch.Size(shape)
+    return lambda _input_shape, bound=target: bound
+
+
+def _reshape(
+    input_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+    input_dims: tuple[int, ...],
+    output_dims: tuple[int, ...],
+) -> ReshapeOp:
+    node = ReshapeOp(shape_fn=_fixed_shape(output_shape))
+    node.input_shapes = [torch.Size(input_shape)]
+    node.output_shape = torch.Size(output_shape)
+    node.input_dims = [input_dims]
+    node.output_dims = output_dims
+    return node
+
+
+class TestLayoutChainCanonicalization:
+    def test_singleton_axis_dims_permutation_is_layout_invisible(self):
+        assert is_layout_invisible_dims(torch.Size((1, 3, 4)), (1, 0, 2))
+        assert is_layout_invisible_dims(
+            torch.Size((1, 1, 64, 40, 40)), (1, 0, 2, 3, 4)
+        )
+        assert not is_layout_invisible_dims(torch.Size((2, 3, 4)), (1, 0, 2))
+
+    def test_collapses_three_identity_reshape_nodes(self):
+        graph = PAIIRGraph("reshape_chain")
+        inp = InputNode(shape=torch.Size((1, 3, 4)))
+        r1 = _reshape((1, 3, 4), (1, 1, 3, 4), (0, 1, 2), (0, 1, 2, 3))
+        r2 = _reshape((1, 1, 3, 4), (1, 12), (0, 1, 2, 3), (0, 1))
+        r3 = _reshape((1, 12), (1, 3, 4), (0, 1), (0, 1, 2))
+        out = OutputNode(shape=torch.Size((1, 3, 4)))
+
+        for node in (inp, r1, r2, r3, out):
+            graph.add_node(node)
+        graph.add_edge(inp.name, r1.name)
+        graph.add_edge(r1.name, r2.name)
+        graph.add_edge(r2.name, r3.name)
+        graph.add_edge(r3.name, out.name)
+
+        canonicalize_layout_chains(graph)
+
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert reshape_nodes == []
+        assert graph.predecessors(out.name) == [inp.name]
+
+    def test_collapses_reshape_pair_with_leading_layout_metadata(self):
+        graph = PAIIRGraph("reshape_pair")
+        inp = InputNode(shape=torch.Size((1, 2, 3)))
+        r1 = _reshape((1, 2, 3), (1, 3, 2), (0, 2, 1), (0, 1, 2))
+        r2 = _reshape((1, 3, 2), (1, 6), (0, 1, 2), (0, 1))
+        out = OutputNode(shape=torch.Size((1, 6)))
+
+        for node in (inp, r1, r2, out):
+            graph.add_node(node)
+        graph.add_edge(inp.name, r1.name)
+        graph.add_edge(r1.name, r2.name)
+        graph.add_edge(r2.name, out.name)
+
+        canonicalize_layout_chains(graph)
+
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 1
+        reshape = reshape_nodes[0]
+        assert reshape.input_shapes == [(1, 2, 3)]
+        assert reshape.output_shape == (1, 6)
+        assert reshape.input_dims == [(0, 2, 1)]
+
+    def test_removes_identity_shape_when_dims_only_swap_singleton_axes(self):
+        graph = PAIIRGraph("reshape_singleton_dims")
+        inp = InputNode(shape=torch.Size((1, 3, 4)))
+        reshape = _reshape((1, 3, 4), (1, 3, 4), (1, 0, 2), (1, 0, 2))
+        out = OutputNode(shape=torch.Size((1, 3, 4)))
+
+        for node in (inp, reshape, out):
+            graph.add_node(node)
+        graph.add_edge(inp.name, reshape.name)
+        graph.add_edge(reshape.name, out.name)
+
+        canonicalize_layout_chains(graph)
+
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert reshape_nodes == []
+        assert graph.predecessors(out.name) == [inp.name]
+
+    def test_keeps_pair_when_second_requires_nonidentity_input_dims(self):
+        graph = PAIIRGraph("reshape_pair_nonidentity")
+        inp = InputNode(shape=torch.Size((1, 2, 3)))
+        r1 = _reshape((1, 2, 3), (1, 3, 2), (0, 2, 1), (0, 1, 2))
+        r2 = _reshape((1, 3, 2), (1, 6), (0, 2, 1), (0, 1))
+        out = OutputNode(shape=torch.Size((1, 6)))
+
+        for node in (inp, r1, r2, out):
+            graph.add_node(node)
+        graph.add_edge(inp.name, r1.name)
+        graph.add_edge(r1.name, r2.name)
+        graph.add_edge(r2.name, out.name)
+
+        canonicalize_layout_chains(graph)
+
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 1
+        reshape = reshape_nodes[0]
+        assert reshape.input_shapes == [(1, 2, 3)]
+        assert reshape.output_shape == (1, 6)
+        assert reshape.input_dims == [(0, 2, 1)]

--- a/tests/paiir/pipeline/test_layout_cross_node_elision.py
+++ b/tests/paiir/pipeline/test_layout_cross_node_elision.py
@@ -1,0 +1,104 @@
+import torch
+from torch import nn
+
+from paibox.paiir.ir.core_neuron import ANNNodeV25
+from paibox.paiir.ir.graph import PAIIRGraph
+from paibox.paiir.ir.ir_base import InputNode, OutputNode
+from paibox.paiir.ir.lut_activation import LutReLU
+from paibox.paiir.ir.op_node import (
+    ReshapeOp,
+    SequentialOp,
+    StandaloneActOp,
+    StandaloneCompOp,
+)
+from paibox.paiir.pipeline.layout_cross_node_elision import (
+    elide_layout_invisible_reshapes,
+)
+from paibox.paiir.pipeline.passes import fuse_to_offline_cores
+
+
+def _reshape(
+    input_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+    input_dims: tuple[int, ...],
+    output_dims: tuple[int, ...],
+) -> ReshapeOp:
+    target = torch.Size(output_shape)
+    node = ReshapeOp(shape_fn=lambda _shape, bound=target: bound)
+    node.input_shapes = [torch.Size(input_shape)]
+    node.output_shape = target
+    node.input_dims = [input_dims]
+    node.output_dims = output_dims
+    return node
+
+
+def _build_conv_reshape_act_reshape_graph(
+    *, nonidentity_dims: tuple[int, ...] | None = None, shared_predecessor: bool = False
+) -> PAIIRGraph:
+    graph = PAIIRGraph("conv_reshape_act_reshape")
+    inp = InputNode(shape=torch.Size((1, 3, 8, 8)))
+    comp = StandaloneCompOp(nn.Conv2d(3, 4, 1))
+    comp.input_shapes = [inp.shape]
+    comp.output_shape = torch.Size((1, 4, 8, 8))
+    comp.input_dims = [(0, 1, 2, 3)]
+    comp.output_dims = (0, 1, 2, 3)
+
+    pre = _reshape(
+        (1, 4, 8, 8),
+        (1, 1, 4, 8, 8),
+        nonidentity_dims or (0, 1, 2, 3),
+        (0, 1, 2, 3, 4),
+    )
+    act = StandaloneActOp(ANNNodeV25(LutReLU()))
+    act.input_shapes = [pre.output_shape]
+    act.output_shape = pre.output_shape
+    act.input_dims = [pre.output_dims]
+    act.output_dims = pre.output_dims
+    post = _reshape((1, 1, 4, 8, 8), (1, 4, 8, 8), (0, 1, 2, 3, 4), (0, 1, 2, 3))
+    out = OutputNode(shape=torch.Size((1, 4, 8, 8)))
+
+    for node in (inp, comp, pre, act, post, out):
+        graph.add_node(node)
+    graph.add_edge(inp.name, comp.name)
+    graph.add_edge(comp.name, pre.name)
+    graph.add_edge(pre.name, act.name)
+    graph.add_edge(act.name, post.name)
+    graph.add_edge(post.name, out.name)
+
+    if shared_predecessor:
+        extra = OutputNode(shape=torch.Size((1, 1, 4, 8, 8)))
+        graph.add_node(extra)
+        graph.add_edge(pre.name, extra.name)
+
+    return graph
+
+
+class TestLayoutCrossNodeElision:
+    def test_elides_conv_reshape_act_reshape_sandwich(self):
+        graph = _build_conv_reshape_act_reshape_graph()
+
+        elide_layout_invisible_reshapes(graph)
+        fused = fuse_to_offline_cores(graph)
+
+        reshape_nodes = [n for n in fused.nodes.values() if isinstance(n, ReshapeOp)]
+        seq_nodes = [n for n in fused.nodes.values() if isinstance(n, SequentialOp)]
+
+        assert reshape_nodes == []
+        assert len(seq_nodes) == 1
+        assert isinstance(seq_nodes[0].comp, nn.Conv2d)
+
+    def test_keeps_nonidentity_dims_sandwich(self):
+        graph = _build_conv_reshape_act_reshape_graph(nonidentity_dims=(0, 2, 3, 1))
+
+        elide_layout_invisible_reshapes(graph)
+
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 2
+
+    def test_keeps_shared_predecessor_reshape(self):
+        graph = _build_conv_reshape_act_reshape_graph(shared_predecessor=True)
+
+        elide_layout_invisible_reshapes(graph)
+
+        reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
+        assert len(reshape_nodes) == 2

--- a/tests/paiir/pipeline/test_passes.py
+++ b/tests/paiir/pipeline/test_passes.py
@@ -11,7 +11,7 @@ in `PAIBox/paibox/paiir/pipeline/passes.py`:
 
 import pytest
 import torch
-from paicorelib import DataSign, DataWidth, SNNMode
+from paicorelib import DataSign, DataWidth, PoolingMode, SNNMode
 from spikingjelly.activation_based import neuron as sj
 from torch import nn
 
@@ -54,6 +54,7 @@ from tests.paiir.conftest import (
     SNNDepthwiseSeparable,
     SNNFlattenTransition,
     SNNResidualAdd,
+    SNNTwoLayer,
     SNNWithMaxPool,
     SPPFBlock,
     convert_and_fuse,
@@ -72,8 +73,6 @@ class TestSNNConversion:
 
     def test_two_layer_snn(self):
         """Conv-LIF -> Conv-IF: two SequentialOps after fusion."""
-        from tests.paiir.conftest import SNNTwoLayer
-
         model = SNNTwoLayer()
         fused = convert_and_fuse(model, make_img_3ch_8x8())
 
@@ -112,8 +111,6 @@ class TestSNNConversion:
 
         pool_ops = [n for n in seq_nodes if isinstance(n.comp, nn.MaxPool2d)]
         assert len(pool_ops) == 1
-
-        from paicorelib import PoolingMode
 
         assert pool_ops[0].core_params.pooling_mode == PoolingMode.MAX
 
@@ -219,6 +216,7 @@ class TestComplexPatterns:
 
         y_ref = AddScalar()(x)
         y_ir = graph.forward(x)
+        assert torch.is_tensor(y_ir)
         assert torch.allclose(y_ir, y_ref)
 
     def test_general_add_specializes_to_potential_add(self):
@@ -296,8 +294,6 @@ class TestShapeAndDims:
 
     def test_shape_propagation(self):
         """Shapes propagate correctly through a two-layer SNN."""
-        from tests.paiir.conftest import SNNTwoLayer
-
         model = SNNTwoLayer()
         fused = convert_and_fuse(model, make_img_3ch_8x8())
 
@@ -308,8 +304,6 @@ class TestShapeAndDims:
 
     def test_no_sample_input(self):
         """Converter works without sample input, shapes default to ()."""
-        from tests.paiir.conftest import SNNTwoLayer
-
         model = SNNTwoLayer()
         unfused = torch_to_paiir(model)
         fused = fuse_to_offline_cores(specialize_general_adds(unfused))
@@ -317,12 +311,10 @@ class TestShapeAndDims:
         seq_nodes = find_nodes(fused, SequentialOp)
         assert len(seq_nodes) == 2
         for node in seq_nodes:
-            assert node.output_shape == ()
+            assert node.output_shape == torch.Size()
 
     def test_dims_identity(self):
         """Identity dims for standard conv/linear (no transpose)."""
-        from tests.paiir.conftest import SNNTwoLayer
-
         model = SNNTwoLayer()
         fused = convert_and_fuse(model, make_img_3ch_8x8())
 
@@ -347,8 +339,6 @@ class TestAssignTickParams:
     @pytest.fixture
     def fused_snn(self):
         """Fixture: fused SNNTwoLayer graph."""
-        from tests.paiir.conftest import SNNTwoLayer
-
         return convert_and_fuse(SNNTwoLayer(), make_img_3ch_8x8())
 
     def test_tick_start_from_depth(self, fused_snn):
@@ -479,8 +469,6 @@ class TestAssignTickParams:
 
     def test_override_unknown_node_raises(self):
         """Override key for non-existent node raises KeyError."""
-        from tests.paiir.conftest import SNNTwoLayer
-
         fused = convert_and_fuse(SNNTwoLayer(), make_img_3ch_8x8())
         with pytest.raises(KeyError, match="does not match any node"):
             assign_tick_params(fused, overrides={"nonexistent_node": {"tick_start": 1}})
@@ -563,8 +551,8 @@ class TestUnrecoverableErrors:
     def test_no_input_node(self):
         graph = PAIIRGraph("no_input")
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [(1, 8)]
-        op.output_shape = (1, 4)
+        op.input_shapes = [torch.Size((1, 8))]
+        op.output_shape = torch.Size((1, 4))
         out = OutputNode()
         graph.add_node(op)
         graph.add_node(out)
@@ -575,10 +563,10 @@ class TestUnrecoverableErrors:
 
     def test_no_output_node(self):
         graph = PAIIRGraph("no_output")
-        inp = InputNode(shape=(1, 8))
+        inp = InputNode(shape=torch.Size((1, 8)))
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [(1, 8)]
-        op.output_shape = (1, 4)
+        op.input_shapes = [torch.Size((1, 8))]
+        op.output_shape = torch.Size((1, 4))
         graph.add_node(inp)
         graph.add_node(op)
         graph.add_edge(inp.name, op.name)
@@ -589,10 +577,10 @@ class TestUnrecoverableErrors:
     def test_input_has_predecessors(self):
         """InputNode with predecessors is a structural error."""
         graph = PAIIRGraph("bad_input")
-        inp = InputNode(shape=(1, 8))
+        inp = InputNode(shape=torch.Size((1, 8)))
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [(1, 8)]
-        op.output_shape = (1, 4)
+        op.input_shapes = [torch.Size((1, 8))]
+        op.output_shape = torch.Size((1, 4))
         out = OutputNode()
         graph.add_node(inp)
         graph.add_node(op)
@@ -608,10 +596,10 @@ class TestUnrecoverableErrors:
     def test_output_has_successors(self):
         """OutputNode with successors is a structural error."""
         graph = PAIIRGraph("bad_output")
-        inp = InputNode(shape=(1, 8))
+        inp = InputNode(shape=torch.Size((1, 8)))
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [(1, 8)]
-        op.output_shape = (1, 4)
+        op.input_shapes = [torch.Size((1, 8))]
+        op.output_shape = torch.Size((1, 4))
         out = OutputNode()
         graph.add_node(inp)
         graph.add_node(op)
@@ -629,8 +617,8 @@ class TestUnrecoverableErrors:
         graph = PAIIRGraph("multiple_errors")
         # No InputNode, no OutputNode
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [(1, 8)]
-        op.output_shape = (1, 4)
+        op.input_shapes = [torch.Size((1, 8))]
+        op.output_shape = torch.Size((1, 4))
         graph.add_node(op)
 
         with pytest.raises(GraphValidationError) as exc_info:
@@ -673,13 +661,13 @@ class TestAutoCleanup:
     def test_orphan_op_removed_with_warning(self):
         """Orphan OpNode is removed and a warning is emitted."""
         graph = PAIIRGraph("orphan_op")
-        inp = InputNode(shape=(1, 8))
+        inp = InputNode(shape=torch.Size((1, 8)))
         op1 = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op1.input_shapes = [(1, 8)]
-        op1.output_shape = (1, 4)
+        op1.input_shapes = [torch.Size((1, 8))]
+        op1.output_shape = torch.Size((1, 4))
         op2 = SequentialOp(nn.Linear(8, 4), IFNodeV25())  # orphan
-        op2.input_shapes = [(1, 8)]
-        op2.output_shape = (1, 4)
+        op2.input_shapes = [torch.Size((1, 8))]
+        op2.output_shape = torch.Size((1, 4))
         out = OutputNode()
         graph.add_node(inp)
         graph.add_node(op1)
@@ -699,13 +687,13 @@ class TestAutoCleanup:
     def test_dead_end_op_removed(self):
         """OpNode with input but no output is removed."""
         graph = PAIIRGraph("dead_end")
-        inp = InputNode(shape=(1, 8))
+        inp = InputNode(shape=torch.Size((1, 8)))
         op1 = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op1.input_shapes = [(1, 8)]
-        op1.output_shape = (1, 4)
+        op1.input_shapes = [torch.Size((1, 8))]
+        op1.output_shape = torch.Size((1, 4))
         op2 = SequentialOp(nn.Linear(4, 2), IFNodeV25())  # dead end
-        op2.input_shapes = [(1, 4)]
-        op2.output_shape = (1, 2)
+        op2.input_shapes = [torch.Size((1, 4))]
+        op2.output_shape = torch.Size((1, 2))
         out = OutputNode()
         graph.add_node(inp)
         graph.add_node(op1)
@@ -725,11 +713,11 @@ class TestAutoCleanup:
     def test_disconnected_input_removed(self):
         """Disconnected InputNode is removed with warning."""
         graph = PAIIRGraph("disconnected_input")
-        inp1 = InputNode(shape=(1, 8))
-        inp2 = InputNode(shape=(1, 8))  # disconnected
+        inp1 = InputNode(shape=torch.Size((1, 8)))
+        inp2 = InputNode(shape=torch.Size((1, 8)))  # disconnected
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [(1, 8)]
-        op.output_shape = (1, 4)
+        op.input_shapes = [torch.Size((1, 8))]
+        op.output_shape = torch.Size((1, 4))
         out = OutputNode()
         graph.add_node(inp1)
         graph.add_node(inp2)
@@ -747,10 +735,10 @@ class TestAutoCleanup:
     def test_disconnected_output_removed(self):
         """Disconnected OutputNode is removed with warning."""
         graph = PAIIRGraph("disconnected_output")
-        inp = InputNode(shape=(1, 8))
+        inp = InputNode(shape=torch.Size((1, 8)))
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [(1, 8)]
-        op.output_shape = (1, 4)
+        op.input_shapes = [torch.Size((1, 8))]
+        op.output_shape = torch.Size((1, 4))
         out1 = OutputNode()
         out2 = OutputNode()  # disconnected
         graph.add_node(inp)
@@ -769,10 +757,10 @@ class TestAutoCleanup:
     def test_all_inputs_disconnected_raises_after_cleanup(self):
         """If all InputNodes are disconnected, cleanup leaves no inputs -> error."""
         graph = PAIIRGraph("all_disconnected")
-        inp = InputNode(shape=(1, 8))  # disconnected
+        inp = InputNode(shape=torch.Size((1, 8)))  # disconnected
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [(1, 8)]
-        op.output_shape = (1, 4)
+        op.input_shapes = [torch.Size((1, 8))]
+        op.output_shape = torch.Size((1, 4))
         out = OutputNode()
         graph.add_node(inp)
         graph.add_node(op)
@@ -792,10 +780,10 @@ class TestSNNModeLUTConsistency:
     def _build_graph(self, act: CoreNeuronV25) -> PAIIRGraph:
         """Build a minimal valid graph with a single SequentialOp."""
         graph = PAIIRGraph("test")
-        inp = InputNode(shape=(1, 8))
+        inp = InputNode(shape=torch.Size((1, 8)))
         op = SequentialOp(nn.Linear(8, 4), act)
-        op.input_shapes = [(1, 8)]
-        op.output_shape = (1, 4)
+        op.input_shapes = [torch.Size((1, 8))]
+        op.output_shape = torch.Size((1, 4))
         out = OutputNode()
         graph.add_node(inp)
         graph.add_node(op)
@@ -844,10 +832,10 @@ class TestSNNModeLUTConsistency:
 class TestValidateCompiledGraph:
     def _build_compiled_graph(self) -> tuple[PAIIRGraph, SequentialOp]:
         graph = PAIIRGraph("compiled")
-        inp = InputNode(shape=(1, 8))
+        inp = InputNode(shape=torch.Size((1, 8)))
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [(1, 8)]
-        op.output_shape = (1, 4)
+        op.input_shapes = [torch.Size((1, 8))]
+        op.output_shape = torch.Size((1, 4))
         op.input_dims = [(0, 1)]
         op.output_dims = (0, 1)
         op.core_params.set_input_format((DataSign.SIGNED, DataWidth.WIDTH_8BIT))
@@ -885,12 +873,12 @@ class TestValidateCompiledGraph:
         branch = SequentialOp(nn.Linear(8, 4), IFNodeV25())
         dead_end = SequentialOp(nn.Linear(4, 2), IFNodeV25())
 
-        branch.input_shapes = [(1, 8)]
-        branch.output_shape = (1, 4)
+        branch.input_shapes = [torch.Size((1, 8))]
+        branch.output_shape = torch.Size((1, 4))
         branch.input_dims = [(0, 1)]
         branch.output_dims = (0, 1)
-        dead_end.input_shapes = [(1, 4)]
-        dead_end.output_shape = (1, 2)
+        dead_end.input_shapes = [torch.Size((1, 4))]
+        dead_end.output_shape = torch.Size((1, 2))
         dead_end.input_dims = [(0, 1)]
         dead_end.output_dims = (0, 1)
 
@@ -911,9 +899,6 @@ class TestValidateCompiledGraph:
         graph.add_edge(inp.name, branch.name)
         graph.add_edge(branch.name, dead_end.name)
 
-        with pytest.warns(GraphCleanupWarning):
-            validate_graph(graph)
-
         with pytest.raises(
             GraphValidationError, match="nodes not on any input-to-output path"
         ):
@@ -921,8 +906,8 @@ class TestValidateCompiledGraph:
 
     def test_rejects_concat_predecessor_shape_mismatch(self):
         graph = PAIIRGraph("bad_concat_shapes")
-        inp_a = InputNode(shape=(1, 2, 4, 4))
-        inp_b = InputNode(shape=(1, 2, 4))
+        inp_a = InputNode(shape=torch.Size((1, 2, 4, 4)))
+        inp_b = InputNode(shape=torch.Size((1, 2, 4)))
         cat = ConcatOp(dim=1)
         out = OutputNode()
 
@@ -931,8 +916,8 @@ class TestValidateCompiledGraph:
         cat.output_domain = SignalDomain.VALUE
         out.output_domain = SignalDomain.VALUE
 
-        cat.input_shapes = [(1, 32), (1, 8)]
-        cat.output_shape = (1, 40)
+        cat.input_shapes = [torch.Size((1, 32)), torch.Size((1, 8))]
+        cat.output_shape = torch.Size((1, 40))
         cat.input_dims = [(0, 1), (0, 1)]
         cat.output_dims = (0, 1)
 
@@ -953,7 +938,7 @@ class TestValidateCompiledGraph:
 class TestValidateDeployableGraph:
     def test_rejects_non_backend_ready_node_type(self):
         graph = PAIIRGraph("non_backend_ready")
-        inp = InputNode(shape=(1, 8))
+        inp = InputNode(shape=torch.Size((1, 8)))
         cpu = CPUOp()
         out = OutputNode()
 
@@ -971,11 +956,9 @@ class TestValidateDeployableGraph:
             validate_deployable_graph(graph)
 
     def test_rechecks_potential_add_predecessor_domains(self):
-        from paibox.paiir.ir.add_ops import PotentialAddOp
-
         graph = PAIIRGraph("bad_potential_add_domain")
-        inp_a = InputNode(shape=(1, 4))
-        inp_b = InputNode(shape=(1, 4))
+        inp_a = InputNode(shape=torch.Size((1, 4)))
+        inp_b = InputNode(shape=torch.Size((1, 4)))
         add = PotentialAddOp(op_signs=(1, 1))
         out = OutputNode()
 
@@ -997,8 +980,8 @@ class TestValidateDeployableGraph:
 
     def test_rechecks_concat_predecessor_domains(self):
         graph = PAIIRGraph("bad_concat_domain")
-        inp_a = InputNode(shape=(1, 4))
-        inp_b = InputNode(shape=(1, 4))
+        inp_a = InputNode(shape=torch.Size((1, 4)))
+        inp_b = InputNode(shape=torch.Size((1, 4)))
         cat = ConcatOp(dim=1)
         out = OutputNode()
 
@@ -1020,8 +1003,8 @@ class TestValidateDeployableGraph:
 
     def test_rechecks_accumulate_path_counts(self):
         graph = PAIIRGraph("bad_accumulate_counts")
-        inp_a = InputNode(shape=(1, 4))
-        inp_b = InputNode(shape=(1, 4))
+        inp_a = InputNode(shape=torch.Size((1, 4)))
+        inp_b = InputNode(shape=torch.Size((1, 4)))
         acc = AccumulateOp(
             comps=[nn.Linear(4, 4), nn.Linear(4, 4)],
             act=IFNodeV25(),
@@ -1033,8 +1016,8 @@ class TestValidateDeployableGraph:
         inp_b.output_domain = SignalDomain.VALUE
         acc.output_domain = SignalDomain.VALUE
         out.output_domain = SignalDomain.VALUE
-        acc.input_shapes = [(1, 4)]
-        acc.output_shape = (1, 4)
+        acc.input_shapes = [torch.Size((1, 4))]
+        acc.output_shape = torch.Size((1, 4))
         acc.input_dims = [(0, 1)]
         acc.output_dims = (0, 1)
 
@@ -1169,8 +1152,8 @@ class TestSignalDomain:
 
     def test_rechecks_accumulate_signs(self):
         graph = PAIIRGraph("bad_accumulate_signs")
-        inp_a = InputNode(shape=(1, 4))
-        inp_b = InputNode(shape=(1, 4))
+        inp_a = InputNode(shape=torch.Size((1, 4)))
+        inp_b = InputNode(shape=torch.Size((1, 4)))
         acc = AccumulateOp(
             comps=[nn.Linear(4, 4), nn.Linear(4, 4)],
             act=IFNodeV25(),
@@ -1182,8 +1165,8 @@ class TestSignalDomain:
         inp_b.output_domain = SignalDomain.VALUE
         acc.output_domain = SignalDomain.VALUE
         out.output_domain = SignalDomain.VALUE
-        acc.input_shapes = [(1, 4), (1, 4)]
-        acc.output_shape = (1, 4)
+        acc.input_shapes = [torch.Size((1, 4)), torch.Size((1, 4))]
+        acc.output_shape = torch.Size((1, 4))
         acc.input_dims = [(0, 1), (0, 1)]
         acc.output_dims = (0, 1)
         acc.signs = (1, 0)


### PR DESCRIPTION
## Summary

This PR tightens PAIIR layout-related IR handling and shape metadata validation so the compile pipeline can remove layout-only routing noise earlier and validate the final graph against the updated semantics more consistently.

## Changes

- Harden IR naming and graph rewrite behavior so node replacement and reconnect flows remain stable during graph cleanup.
- Add a pre-fusion layout canonicalization pass that collapses local reshape-only chains when they are logically equivalent.
- Add a cross-node elision pass that removes chip-invisible `ReshapeOp` wrappers around eligible `StandaloneCompOp -> StandaloneActOp` paths.
- Align shape metadata and validation logic across lowering and compile passes with the new canonicalized graph topology.
- Update compile and simulation expectations, and add focused tests for reshape semantics, layout-chain canonicalization, cross-node elision, namespace behavior, graph rewrites, and validation.
