### PR TITLE
Feat(paiir): refactor node layout metadata to `TensorLayout`

### DIFF
--- a/docs/paiir_backend_guide.md
+++ b/docs/paiir_backend_guide.md
@@ -214,9 +214,9 @@ class Edge:
 
 ```
 PAIIRNode (基类，自动分配唯一 name)
-├── InputNode         — 图输入占位符，携带 shape
-├── OutputNode        — 图输出节点，携带 shape
-└── OpNode (算子基类，携带形状与维度信息)
+├── InputNode         — 图输入占位符，携带边界 TensorLayout
+├── OutputNode        — 图输出节点，携带边界 TensorLayout
+└── OpNode (算子基类，携带 TensorLayout 元信息)
     ├── OfflineCoreOp (离线核，映射到芯片核心)
     │   ├── SequentialOp      — comp -> act（最常见）
     │   ├── AccumulateOp      — comps -> add/sub -> act（多路径融合）
@@ -255,8 +255,9 @@ output_nodes: list[OutputNode] = graph.output_nodes()
 # 拓扑排序（返回节点名列表，保证依赖顺序）
 ordered_names: list[str] = graph.topo_sort()
 
-# 打印图摘要（直接输出到 stdout，不返回字符串）
+# 打印图摘要；verbose=True 时包含 layout 与端口细节
 graph.summary()
+graph.summary(verbose=True)
 ```
 
 ### 节点级查询
@@ -292,9 +293,9 @@ for name in graph.topo_sort():
     node = graph.nodes[name]
 
     if isinstance(node, InputNode):
-        print(f"Input: {name}, shape={node.shape}")
+        print(f"Input: {name}, shape={node.shape}, dims={node.dims}")
     elif isinstance(node, OutputNode):
-        print(f"Output: {name}, shape={node.shape}")
+        print(f"Output: {name}, shape={node.shape}, dims={node.dims}")
     elif isinstance(node, OfflineCoreOp):
         # 后端关心的节点
         preds = graph.predecessors(name)
@@ -312,21 +313,42 @@ for name in graph.topo_sort():
 
 ```python
 node.name: str                             # 唯一名称
-node.input_shapes: list[tuple[int, ...]]   # 各输入端口的张量形状
-node.output_shape: tuple[int, ...]         # 输出张量形状
-node.input_dims: list[tuple[int, ...]]     # 各输入端口的轴顺序
-node.output_dims: tuple[int, ...]          # 输出轴顺序
+node.input_layouts: tuple[TensorLayout, ...]   # 各输入端口的 layout
+node.output_layouts: tuple[TensorLayout, ...]  # 各输出端口的 layout
+node.num_inputs: int                           # 输入端口数量
+node.num_outputs: int                          # 输出端口数量
 node.output_domain                         # SignalDomain.VALUE / POTENTIAL
 ```
 
+其中：
+
+```python
+@dataclass(frozen=True, slots=True)
+class TensorLayout:
+    shape: torch.Size
+    dims: tuple[int, ...]
+```
+
 轴顺序 `(0, 1, 2, 3)` 表示标准 NCHW；如果模型中有 `transpose` / `permute` 操作，轴顺序会相应改变，后端可据此决定数据排布。
+
+当前接口约定：
+
+- 单输出节点通常满足 `len(node.output_layouts) == 1`
+- 多输出节点（当前典型是 `SplitOp`）通过 `output_layouts[src_port]` 区分具体输出分支
+- 后端和 pass 应优先消费 `TensorLayout`，而不是旧的 `input_shapes / output_shape / input_dims / output_dims`
 
 `output_domain` 是图级语义注解：
 
 - `SignalDomain.VALUE`：值域输出
 - `SignalDomain.POTENTIAL`：膜电位域输出
 
-后端应把它视为节点输出语义，而不是直接等同于芯片寄存器里的 `OutputType`。对有 `neuron_params` 的离线核节点，两者通常一致；对 `InputNode`、`OutputNode`、`ConcatOp`、`GeneralAddOp` 这类非神经元节点，则只能使用 `SignalDomain`。
+当前 `output_domain` 按节点定义，是单值语义，不按输出端口拆分。对当前 routing-only 节点：
+
+- `ReshapeOp` 输出域继承其唯一输入
+- `SplitOp` 虽然是多输出，但所有 split 分支继承同一个输入域
+- `ConcatOp` 要求所有输入域一致，然后输出该共同域
+
+后端应把它视为节点输出语义，而不是直接等同于芯片寄存器里的 `OutputType`。对有 `neuron_params` 的离线核节点，两者通常一致；对 `InputNode`、`OutputNode`、`ConcatOp`、`SplitOp`、`ReshapeOp`、`GeneralAddOp` 这类非神经元或 routing 节点，则只能使用 `SignalDomain`。
 
 ### OfflineCoreOp：离线核参数
 
@@ -465,7 +487,7 @@ acc.lut_data               # LutData | None
 - `graph.predecessors(acc.name)`、`acc.comps`、`acc.signs` 必须一一对应
 - `len(graph.predecessors(acc.name)) == len(acc.comps) == len(acc.signs)`
 - 若 `acc.weights is not None`，则 `len(acc.weights) == len(acc.comps)`
-- 若 `input_shapes` / `input_dims` 已填充，则它们的长度也应与 `acc.comps` 一致
+- 若 `input_layouts` 已填充，则它们的长度也应与 `acc.comps` 一致
 - 当前符号语义只允许 `+/-1`
 
 > **后端注意**：当前 backendv2 会并行消费 predecessor / comp / weight / sign 列表；如果这些列表长度不一致，Python `zip(...)` 会静默截断。因此上面的结构一致性应视为 backend-ready 图的硬约束，而不是“最好满足”的建议。
@@ -526,8 +548,8 @@ def extract_cores(graph):
         core = {
             "name": name,
             "type": type(node).__name__,
-            "input_shapes": node.input_shapes,
-            "output_shape": node.output_shape,
+            "input_layouts": node.input_layouts,
+            "output_layouts": node.output_layouts,
             # 工作模式
             "snn_mode": cp.snn_mode,
             "pooling_mode": cp.pooling_mode,
@@ -745,5 +767,9 @@ class LutData:
 
 - `strict=True` 才表示遇到不支持算子会立即失败
 - `strict=False` 下图中可能存在被旁路的 unsupported 节点，此时返回图适合做结构分析或部分验证，但不应自动等价理解为“全图已严格支持”
-- `graph.summary()`、`graph.predecessors()`、`graph.successors()`、`core_params`、`neuron_params`、`lut_data` 等接口，是后端读取部署信息的主要入口
+- `graph.summary()`、`graph.predecessors()`、`graph.successors()`、`graph.get_edge_output_layout(...)`、`core_params`、`neuron_params`、`lut_data` 等接口，是后端读取部署信息的主要入口
 - 若需要扩展编译流程，请优先在 `paibox.paiir.pipeline.passes` 中新增或调整 pass；`pass_manager` 目前不驱动默认编译路径
+- 当前分支已经将 `OpNode` 的 shape/dims 正式接口切换为 `input_layouts/output_layouts`；`backendv2` 尚未适配这次接口变化，需要单独跟进
+- `Edge.src_port` 与 `Edge.dst_port` 仍然保留：
+  - `src_port` 表示源节点输出索引，`SplitOp` 依赖它选择分支
+  - `dst_port` 表示目标节点输入槽位，`ConcatOp` / `AccumulateOp` / `PotentialAddOp` 等依赖它保持输入顺序

--- a/paibox/paiir/ir/__init__.py
+++ b/paibox/paiir/ir/__init__.py
@@ -13,7 +13,7 @@ and backend deployment:
 from .calc_params import LutData, NeuronParams, OfflineCoreParams, OnlineCoreParams
 from .core_neuron import ANNNodeV25, CoreNeuronV25, IFNodeV25, LIFNodeV25
 from .graph import Edge, PAIIRGraph
-from .ir_base import InputNode, OutputNode, PAIIRNode
+from .ir_base import InputNode, OutputNode, PAIIRNode, TensorLayout
 from .signal_domain import SignalDomain
 from .add_ops import (
     AddOperandKind,
@@ -39,6 +39,7 @@ from .op_node import (
     OnlineCoreOp,
     OpNode,
     ReshapeOp,
+    RoutingOp,
     SequentialOp,
     SplitOp,
     StandaloneActOp,
@@ -78,9 +79,11 @@ __all__ = [
     "PAIIRNode",
     "PotentialAddOp",
     "ReshapeOp",
+    "RoutingOp",
     "SequentialOp",
     "SignalDomain",
     "SplitOp",
     "StandaloneActOp",
     "StandaloneCompOp",
+    "TensorLayout",
 ]

--- a/paibox/paiir/ir/add_ops.py
+++ b/paibox/paiir/ir/add_ops.py
@@ -128,9 +128,9 @@ class GeneralAddOp(OpNode):
     def operand_shape(self, operand: AddOperandSpec) -> torch.Size:
         if operand.kind is AddOperandKind.TENSOR:
             assert operand.tensor_port is not None
-            if operand.tensor_port >= len(self.input_shapes):
+            if operand.tensor_port >= len(self.input_layouts):
                 return torch.Size()
-            return self.input_shapes[operand.tensor_port]
+            return self.input_layouts[operand.tensor_port].shape
 
         assert operand.const_value is not None
         return _constant_shape(operand.const_value)
@@ -138,16 +138,18 @@ class GeneralAddOp(OpNode):
     def operand_dims(self, operand: AddOperandSpec) -> tuple[int, ...]:
         if operand.kind is AddOperandKind.TENSOR:
             assert operand.tensor_port is not None
-            if operand.tensor_port >= len(self.input_dims):
+            if operand.tensor_port >= len(self.input_layouts):
                 return ()
-            return self.input_dims[operand.tensor_port]
+            return self.input_layouts[operand.tensor_port].dims
 
         assert operand.const_value is not None
         return _constant_dims(operand.const_value)
 
     def is_operand_broadcasted(self, operand: AddOperandSpec) -> bool:
         return (
-            bool(self.output_shape) and self.operand_shape(operand) != self.output_shape
+            self.num_outputs > 0
+            and bool(self.output_layouts[0].shape)
+            and self.operand_shape(operand) != self.output_layouts[0].shape
         )
 
     @property

--- a/paibox/paiir/ir/graph.py
+++ b/paibox/paiir/ir/graph.py
@@ -14,8 +14,8 @@ from torch import Tensor, nn
 from ..exceptions import GraphValidationError
 from .add_ops import GeneralAddOp
 from .core_neuron import CoreNeuronV25
-from .ir_base import InputNode, OutputNode, PAIIRNode
-from .op_node import ConcatOp, OfflineCoreOp, OpNode, ReshapeOp, SplitOp
+from .ir_base import InputNode, OutputNode, PAIIRNode, TensorLayout
+from .op_node import OfflineCoreOp, OpNode, RoutingOp
 
 __all__ = ["Edge", "PAIIRGraph"]
 
@@ -497,12 +497,38 @@ class PAIIRGraph:
     def _summary_node_shape(self, node: PAIIRNode) -> torch.Size:
         if isinstance(node, (InputNode, OutputNode)):
             return node.shape
-        if isinstance(node, OpNode):
-            return node.output_shape
+        if isinstance(node, OpNode) and node.num_outputs == 1:
+            return node.output_layouts[0].shape
         return torch.Size()
 
-    def summary(self) -> None:
-        """Generate a text summary of the graph."""
+    @staticmethod
+    def _summary_layout_desc(layout: TensorLayout) -> str:
+        if not layout.shape:
+            return "shape=(), dims=()"
+        return f"shape={tuple(layout.shape)}, dims={layout.dims}"
+
+    def get_node_output_layout(self, name: str, port: int = 0) -> TensorLayout:
+        node = self.nodes[name]
+        if isinstance(node, InputNode):
+            return node.layout
+        if isinstance(node, OutputNode):
+            return node.layout
+        if isinstance(node, OpNode):
+            return node.output_layouts[port]
+        return TensorLayout()
+
+    def get_edge_output_layout(self, edge: Edge) -> TensorLayout:
+        return self.get_node_output_layout(edge.src, edge.src_port)
+
+    def summary(self, verbose: bool | int = False) -> None:
+        """Print a text summary of the graph.
+
+        Args:
+            verbose:
+                - ``False`` / ``0``: compact node/edge summary
+                - ``True`` / ``1``: include layouts and explicit edge ports
+        """
+        verbose = int(verbose)
         lines = [
             f"PAIIRGraph '{self.name}'",
             f"  Nodes: {len(self.nodes)}",
@@ -513,17 +539,54 @@ class PAIIRGraph:
         ]
         for name in self.topo_sort():
             node = self.nodes[name]
-            preds = self.predecessors(name)
-            succs = self.successors(name)
+            incoming = self.incoming_edges(name)
+            outgoing = self.outgoing_edges(name)
             line = f"  {name} ({self._summary_node_label(node)})"
             shape = self._summary_node_shape(node)
             if shape:
                 line += f" {self._summary_shape_without_batch(shape)}"
             lines.append(line)
-            if preds:
-                lines.append(f"    <- {preds}")
-            if succs:
-                lines.append(f"    -> {succs}")
+            if verbose:
+                if isinstance(node, InputNode):
+                    lines.append(f"    layout: {self._summary_layout_desc(node.layout)}")
+                elif isinstance(node, OutputNode):
+                    lines.append(f"    layout: {self._summary_layout_desc(node.layout)}")
+                elif isinstance(node, OpNode):
+                    if node.input_layouts:
+                        rendered_inputs = ", ".join(
+                            f"in[{i}] {self._summary_layout_desc(layout)}"
+                            for i, layout in enumerate(node.input_layouts)
+                        )
+                        lines.append(f"    {rendered_inputs}")
+                    if node.output_layouts:
+                        rendered_outputs = ", ".join(
+                            f"out[{i}] {self._summary_layout_desc(layout)}"
+                            for i, layout in enumerate(node.output_layouts)
+                        )
+                        lines.append(f"    {rendered_outputs}")
+                if incoming:
+                    lines.append(
+                        "    <- "
+                        + ", ".join(
+                            f"{edge.src}[src_port={edge.src_port}] -> dst_port={edge.dst_port}"
+                            for edge in incoming
+                        )
+                    )
+                if outgoing:
+                    lines.append(
+                        "    -> "
+                        + ", ".join(
+                            f"src_port={edge.src_port} -> {edge.dst}[dst_port={edge.dst_port}]"
+                            for edge in outgoing
+                        )
+                    )
+            else:
+                preds = self.predecessors(name)
+                succs = self.successors(name)
+                if preds:
+                    lines.append(f"    <- {preds}")
+                if succs:
+                    lines.append(f"    -> {succs}")
 
         print("\n".join(lines))
 
@@ -548,7 +611,7 @@ class PAIIRGraph:
         - ``tick_start``: Must be set (not None)
         - ``tick_duration``: Must be non-negative
         - ``tick_initial``: Must be non-negative
-        - ``output_shape``: Must be set for zero output generation
+        - output layout on port 0: Must be set for zero output generation
 
         Raises:
             RuntimeError: If any verification check fails.
@@ -582,9 +645,9 @@ class PAIIRGraph:
                     f"'{name}': tick_initial must be non-negative, got {cp.tick_initial}"
                 )
 
-            if not node.output_shape:
+            if node.num_outputs == 0 or not node.output_layouts[0].shape:
                 errors.append(
-                    f"'{name}': output_shape is not set. "
+                    f"'{name}': output layout is not set. "
                     "Pass sample_inputs to torch_to_paiir() for shape inference."
                 )
 
@@ -633,7 +696,7 @@ class PAIIRGraph:
 
     def _zero_output(self, node: OpNode) -> Tensor:
         """Return a zero tensor matching the node's expected output shape."""
-        shape = node.output_shape
+        shape = node.output_layouts[0].shape if node.num_outputs > 0 else torch.Size()
         if shape:
             return torch.zeros(shape)
         return torch.zeros(())
@@ -651,20 +714,28 @@ class PAIIRGraph:
             return value
 
         src_node = self.nodes[edge.src]
-        if not isinstance(src_node, SplitOp):
+        if not isinstance(src_node, OpNode) or src_node.num_outputs <= 1:
             raise RuntimeError(
-                f"node '{edge.src}' produced multiple outputs, but only SplitOp is supported as a graph-internal multi-output node"
+                f"node '{edge.src}' produced multiple outputs, but has no multi-output graph contract"
             )
 
-        # SplitOp is the only internal tuple-output special case. `src_port`
-        # tells us which split branch this edge carries to the destination.
+        if len(value) != src_node.num_outputs:
+            raise RuntimeError(
+                f"node '{edge.src}' produced {len(value)} runtime outputs, "
+                f"but metadata declares {src_node.num_outputs}"
+            )
+
         if edge.src_port < 0 or edge.src_port >= len(value):
             raise RuntimeError(
-                f"SplitOp '{edge.src}' src_port={edge.src_port} is invalid for successor "
+                f"node '{edge.src}' src_port={edge.src_port} is invalid for successor "
                 f"'{edge.dst}' dst_port={edge.dst_port}"
             )
-
-        return value[edge.src_port]
+        branch = value[edge.src_port]
+        if not torch.is_tensor(branch):
+            raise RuntimeError(
+                f"node '{edge.src}' output branch {edge.src_port} is not a tensor"
+            )
+        return branch
 
     def step(self, *inputs: Tensor) -> NodeOutput:
         """Execute one time step (one sync_all cycle) through the graph.
@@ -735,7 +806,7 @@ class PAIIRGraph:
             incoming = self.incoming_edges(name)
             xs = [self._resolve_edge_tensor(edge, node_outputs) for edge in incoming]
 
-            if isinstance(node, (ConcatOp, ReshapeOp, SplitOp, GeneralAddOp)):
+            if isinstance(node, (RoutingOp, GeneralAddOp)):
                 # Routing/shape transformation operation.
                 # Or frontend/general expression operation.
                 # Executes tensor transformation / expression evaluation for simulation.

--- a/paibox/paiir/ir/graph.py
+++ b/paibox/paiir/ir/graph.py
@@ -548,9 +548,13 @@ class PAIIRGraph:
             lines.append(line)
             if verbose:
                 if isinstance(node, InputNode):
-                    lines.append(f"    layout: {self._summary_layout_desc(node.layout)}")
+                    lines.append(
+                        f"    layout: {self._summary_layout_desc(node.layout)}"
+                    )
                 elif isinstance(node, OutputNode):
-                    lines.append(f"    layout: {self._summary_layout_desc(node.layout)}")
+                    lines.append(
+                        f"    layout: {self._summary_layout_desc(node.layout)}"
+                    )
                 elif isinstance(node, OpNode):
                     if node.input_layouts:
                         rendered_inputs = ", ".join(

--- a/paibox/paiir/ir/ir_base.py
+++ b/paibox/paiir/ir/ir_base.py
@@ -1,6 +1,7 @@
 """PAIIR base types: node base class, tensor layout, and graph boundaries."""
 
 from dataclasses import dataclass
+
 import torch
 
 from ._namespace import IRNamespace

--- a/paibox/paiir/ir/ir_base.py
+++ b/paibox/paiir/ir/ir_base.py
@@ -1,13 +1,31 @@
-"""PAIIR base types: node base class and graph boundary nodes."""
+"""PAIIR base types: node base class, tensor layout, and graph boundaries."""
 
+from dataclasses import dataclass
 import torch
 
 from ._namespace import IRNamespace
 from .signal_domain import SignalDomain
 
-__all__ = ["PAIIRNode", "InputNode", "OutputNode"]
+__all__ = ["TensorLayout", "PAIIRNode", "InputNode", "OutputNode"]
 
 _ir_namespace = IRNamespace()
+
+
+@dataclass(frozen=True, slots=True)
+class TensorLayout:
+    """Immutable tensor metadata pairing shape with logical axis order."""
+
+    shape: torch.Size = torch.Size()
+    dims: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.shape and self.dims and len(self.shape) != len(self.dims):
+            raise ValueError(
+                f"shape rank {len(self.shape)} != dims rank {len(self.dims)}"
+            )
+
+    def __bool__(self) -> bool:
+        return bool(self.shape)
 
 
 class PAIIRNode:
@@ -15,6 +33,16 @@ class PAIIRNode:
 
     Each node is automatically assigned a unique name for identification
     within the computation graph.
+
+    ``output_domain`` is a node-level semantic annotation describing the signal
+    domain of the node's output:
+
+    - :class:`~paibox.paiir.ir.signal_domain.SignalDomain.VALUE`
+    - :class:`~paibox.paiir.ir.signal_domain.SignalDomain.POTENTIAL`
+
+    The current IR treats this as one value per node, not one value per output
+    port. This remains valid for today's multi-output ``SplitOp`` because all
+    split branches inherit the same output domain from the split input.
     """
 
     def __init__(self) -> None:
@@ -31,16 +59,40 @@ class PAIIRNode:
 
 
 class InputNode(PAIIRNode):
-    """Graph input placeholder carrying shape information."""
+    """Graph input placeholder carrying explicit boundary layout."""
 
-    def __init__(self, shape: torch.Size = torch.Size()) -> None:
+    def __init__(
+        self, shape: torch.Size = torch.Size(), dims: tuple[int, ...] | None = None
+    ) -> None:
         super().__init__()
-        self.shape = shape
+        if dims is None:
+            dims = tuple(range(len(shape))) if shape else ()
+        self.layout = TensorLayout(shape=shape, dims=dims)
+
+    @property
+    def shape(self) -> torch.Size:
+        return self.layout.shape
+
+    @property
+    def dims(self) -> tuple[int, ...]:
+        return self.layout.dims
 
 
 class OutputNode(PAIIRNode):
-    """Graph output node."""
+    """Graph output node carrying explicit boundary layout."""
 
-    def __init__(self, shape: torch.Size = torch.Size()) -> None:
+    def __init__(
+        self, shape: torch.Size = torch.Size(), dims: tuple[int, ...] | None = None
+    ) -> None:
         super().__init__()
-        self.shape = shape
+        if dims is None:
+            dims = tuple(range(len(shape))) if shape else ()
+        self.layout = TensorLayout(shape=shape, dims=dims)
+
+    @property
+    def shape(self) -> torch.Size:
+        return self.layout.shape
+
+    @property
+    def dims(self) -> tuple[int, ...]:
+        return self.layout.dims

--- a/paibox/paiir/ir/op_node.py
+++ b/paibox/paiir/ir/op_node.py
@@ -24,14 +24,16 @@ from torch import Tensor, nn
 
 from .calc_params import LutData, NeuronParams, OfflineCoreParams, OnlineCoreParams
 from .core_neuron import CoreNeuronV25
-from .ir_base import PAIIRNode
+from .ir_base import PAIIRNode, TensorLayout
 from .reshape_semantics import materialize_logical_layout
 
 if TYPE_CHECKING:
     from ..pipeline.avgpool.metadata import AvgPoolDeployMetadata
 
 __all__ = [
+    "TensorLayout",
     "OpNode",
+    "RoutingOp",
     "OfflineCoreOp",
     "SequentialOp",
     "AccumulateOp",
@@ -135,32 +137,34 @@ class OpNode(nn.Module, PAIIRNode):
             Set to False for simulation-only ops (e.g., ReshapeOp).
 
     Attributes:
-        input_shapes: Tensor shapes at each input port.
-        output_shape: Output tensor shape.
-        input_dims: Axis ordering at each input port.
-        output_dims: Output axis ordering.
+        input_layouts: Tensor layouts at each input port.
+        output_layouts: Tensor layouts at each output port.
     """
 
     deploy: ClassVar[bool] = True
+    input_layouts: tuple[TensorLayout, ...]
+    output_layouts: tuple[TensorLayout, ...]
 
     def __init__(self) -> None:
         super().__init__()
         super(nn.Module, self).__init__()
+        self.input_layouts = ()
+        self.output_layouts = ()
 
-        # Shape info, populated during graph construction
-        self.input_shapes: list[torch.Size] = []
-        self.output_shape: torch.Size = torch.Size()
+    @property
+    def num_inputs(self) -> int:
+        return len(self.input_layouts)
 
-        # Axis ordering, populated by DimsProp
-        self.input_dims: list[tuple[int, ...]] = []
-        self.output_dims: tuple[int, ...] = ()
+    @property
+    def num_outputs(self) -> int:
+        return len(self.output_layouts)
 
     def extra_repr(self) -> str:
         parts = [f"name='{self.name}'"]
-        if self.input_shapes:
-            parts.append(f"input_shapes={self.input_shapes}")
-        if self.output_shape:
-            parts.append(f"output_shape={self.output_shape}")
+        if self.input_layouts:
+            parts.append(f"input_layouts={self.input_layouts}")
+        if self.output_layouts:
+            parts.append(f"output_layouts={self.output_layouts}")
         return ", ".join(parts)
 
 
@@ -487,8 +491,8 @@ class ReshapeOp(RoutingOp):
         self.shape_fn = shape_fn
 
     def forward(self, x: Tensor) -> Tensor:
-        if len(self.input_dims) == 1:
-            x = materialize_logical_layout(x, self.input_dims[0])
+        if self.num_inputs == 1:
+            x = materialize_logical_layout(x, self.input_layouts[0].dims)
 
         if self.shape_fn is None:
             return x.flatten()

--- a/paibox/paiir/lowering/converter.py
+++ b/paibox/paiir/lowering/converter.py
@@ -55,9 +55,8 @@ from .dims_prop import DimsProp
 from .fx_utils import (
     get_call_arg,
     get_fx_call_target_name,
-    get_input_dims,
-    get_input_shapes,
-    get_output_dims,
+    get_input_layouts,
+    get_output_layouts,
     get_output_shape,
 )
 from .shape_analysis import (
@@ -691,17 +690,15 @@ def _is_lowering_bypass_module(mod: nn.Module) -> bool:
     return isinstance(mod, LOWERING_BYPASS_MODULE_TYPES)
 
 
-def _fill_shape_dims(
+def _fill_layouts(
     ir_node: OpNode,
     fx_node: fx.Node,
     *,
     input_nodes_override: tuple[fx.Node, ...] | None = None,
 ) -> None:
-    """Copy shape and axis-ordering info from FX node meta into a PAIIR node."""
-    ir_node.input_shapes = get_input_shapes(fx_node, input_nodes_override)
-    ir_node.output_shape = get_output_shape(fx_node)
-    ir_node.input_dims = get_input_dims(fx_node, input_nodes_override)
-    ir_node.output_dims = get_output_dims(fx_node)
+    """Copy input/output layouts from FX node meta into a PAIIR node."""
+    ir_node.input_layouts = get_input_layouts(fx_node, input_nodes_override)
+    ir_node.output_layouts = get_output_layouts(fx_node)
 
 
 @dataclass
@@ -742,8 +739,8 @@ def _register_ir_node(
 ) -> None:
     """Register an IR node produced from an FX node.
 
-    By default, the IR node inherits shape/dims metadata directly from the FX
-    node via :func:`_fill_shape_dims`.
+    By default, the IR node inherits layout metadata directly from the FX
+    node via :func:`_fill_layouts`.
 
     ``fill_meta=False`` is kept as an explicit extension hook for future
     lowering paths where metadata should be populated later or from a source
@@ -751,7 +748,7 @@ def _register_ir_node(
     default behavior.
     """
     if fill_meta:
-        _fill_shape_dims(ir_node, fx_node, input_nodes_override=input_nodes_override)
+        _fill_layouts(ir_node, fx_node, input_nodes_override=input_nodes_override)
 
     if input_nodes_override is not None:
         # Persist the normalized data-input view for the later edge-wiring pass.

--- a/paibox/paiir/lowering/fx_utils.py
+++ b/paibox/paiir/lowering/fx_utils.py
@@ -5,15 +5,18 @@ from typing import Any
 import torch
 from torch import fx
 
+from ..ir.op_node import TensorLayout
 from .dims_prop import DimsProp, DimsType
 
 __all__ = [
     "get_call_arg",
     "get_fx_call_target_name",
-    "get_input_dims",
+    "get_input_layouts",
     "get_input_shapes",
-    "get_output_dims",
+    "get_input_dims",
+    "get_output_layouts",
     "get_output_shape",
+    "get_output_dims",
 ]
 
 
@@ -30,7 +33,7 @@ def get_fx_call_target_name(node: fx.Node) -> str:
     return str(node.target)
 
 
-def get_output_shape(node: fx.Node) -> torch.Size:
+def _get_output_shape(node: fx.Node) -> torch.Size:
     """Extract output shape from an FX node's tensor metadata."""
     meta = node.meta.get("tensor_meta")
     if meta is None:
@@ -40,26 +43,49 @@ def get_output_shape(node: fx.Node) -> torch.Size:
     return torch.Size()
 
 
-def get_input_shapes(
-    node: fx.Node, input_nodes: tuple[fx.Node, ...] | None = None
-) -> list[torch.Size]:
-    """Extract input shapes from predecessor tensor metadata."""
-    source_nodes = (
-        input_nodes if input_nodes is not None else tuple(node.all_input_nodes)
-    )
-    return [get_output_shape(inp) for inp in source_nodes]
+def _get_output_dims(node: fx.Node) -> DimsType:
+    """Get output dims from an FX node's propagated layout metadata."""
+    return node.meta.get(DimsProp.KEY, ())
+
+
+def get_output_shape(node: fx.Node) -> torch.Size:
+    return _get_output_shape(node)
 
 
 def get_output_dims(node: fx.Node) -> DimsType:
-    """Get output dims from an FX node's propagated layout metadata."""
-    return node.meta.get(DimsProp.KEY, ())
+    return _get_output_dims(node)
+
+
+def get_output_layouts(node: fx.Node) -> tuple[TensorLayout, ...]:
+    """Extract output layouts from an FX node.
+
+    Most supported nodes are single-output and return one layout entry.
+    Tuple-valued nodes such as ``torch.split`` are handled by dedicated lowering
+    paths and therefore typically do not call this helper.
+    """
+    return (TensorLayout(shape=_get_output_shape(node), dims=_get_output_dims(node)),)
+
+
+def get_input_layouts(
+    node: fx.Node, input_nodes: tuple[fx.Node, ...] | None = None
+) -> tuple[TensorLayout, ...]:
+    """Extract input layouts from predecessor tensor metadata."""
+    source_nodes = (
+        input_nodes if input_nodes is not None else tuple(node.all_input_nodes)
+    )
+    return tuple(
+        TensorLayout(shape=_get_output_shape(inp), dims=_get_output_dims(inp))
+        for inp in source_nodes
+    )
+
+
+def get_input_shapes(
+    node: fx.Node, input_nodes: tuple[fx.Node, ...] | None = None
+) -> list[torch.Size]:
+    return [layout.shape for layout in get_input_layouts(node, input_nodes)]
 
 
 def get_input_dims(
     node: fx.Node, input_nodes: tuple[fx.Node, ...] | None = None
 ) -> list[DimsType]:
-    """Get input dims from predecessor propagated layout metadata."""
-    source_nodes = (
-        input_nodes if input_nodes is not None else tuple(node.all_input_nodes)
-    )
-    return [get_output_dims(inp) for inp in source_nodes]
+    return [layout.dims for layout in get_input_layouts(node, input_nodes)]

--- a/paibox/paiir/lowering/split_lowering.py
+++ b/paibox/paiir/lowering/split_lowering.py
@@ -12,7 +12,8 @@ from typing import Any
 import torch
 from torch import fx
 
-from ..ir.op_node import SplitOp
+from ..ir.op_node import SplitOp, TensorLayout
+from ..ir.utils import infer_split_output_shapes
 from .dims_prop import DimsType
 from .fx_utils import (
     get_call_arg,
@@ -167,7 +168,16 @@ def build_split_ir_node(
     ir_node = SplitOp(split_info.sections, split_info.dim)
     # The SplitOp itself records only the split contract. Per-consumer branch
     # selection is attached later on outgoing edges via `src_port`.
-    ir_node.input_shapes = [get_output_shape(split_info.data_input)]
-    ir_node.input_dims = [get_output_dims(split_info.data_input)]
-    ir_node.output_dims = ir_node.input_dims[0] if ir_node.input_dims else ()
+    input_layout = TensorLayout(
+        shape=get_output_shape(split_info.data_input),
+        dims=get_output_dims(split_info.data_input),
+    )
+    ir_node.input_layouts = (input_layout,)
+    if input_layout.shape:
+        ir_node.output_layouts = tuple(
+            TensorLayout(shape=shape, dims=input_layout.dims)
+            for shape in infer_split_output_shapes(
+                input_layout.shape, split_info.sections, split_info.dim
+            )
+        )
     return ir_node, (split_info.data_input,)

--- a/paibox/paiir/pipeline/avgpool/fusion.py
+++ b/paibox/paiir/pipeline/avgpool/fusion.py
@@ -283,10 +283,8 @@ def _materialize_split_avgpool_pair(
 
     core1_act = ANNNodeV25(core1_lut)
     core1 = SequentialOp(sumpool, core1_act)
-    core1.input_shapes = pred.input_shapes
-    core1.output_shape = act_node.output_shape
-    core1.input_dims = pred.input_dims
-    core1.output_dims = act_node.output_dims
+    core1.input_layouts = pred.input_layouts
+    core1.output_layouts = act_node.output_layouts
 
     consumed.add(pred_name)
     consumed.add(act_name)

--- a/paibox/paiir/pipeline/fusion_utils.py
+++ b/paibox/paiir/pipeline/fusion_utils.py
@@ -15,10 +15,8 @@ def _materialize_shared_sequential(
 ) -> SequentialOp:
     """Build and register a shared-core ``SequentialOp`` from comp + act."""
     fused = SequentialOp(pred.comp, act_node.act)
-    fused.input_shapes = pred.input_shapes
-    fused.output_shape = act_node.output_shape
-    fused.input_dims = pred.input_dims
-    fused.output_dims = act_node.output_dims
+    fused.input_layouts = pred.input_layouts
+    fused.output_layouts = act_node.output_layouts
 
     consumed.add(act_name)
     consumed.add(pred_name)

--- a/paibox/paiir/pipeline/layout_chain_canonicalization.py
+++ b/paibox/paiir/pipeline/layout_chain_canonicalization.py
@@ -106,7 +106,9 @@ def _compose_shape_fns(chain: list[ReshapeOp]) -> Callable[[torch.Size], torch.S
     def _composed(input_shape: torch.Size) -> torch.Size:
         current = input_shape
         for op in chain:
-            current = reshape_output_shape(current, op.input_layouts[0].dims, op.shape_fn)
+            current = reshape_output_shape(
+                current, op.input_layouts[0].dims, op.shape_fn
+            )
         return current
 
     return _composed

--- a/paibox/paiir/pipeline/layout_chain_canonicalization.py
+++ b/paibox/paiir/pipeline/layout_chain_canonicalization.py
@@ -42,16 +42,20 @@ def _try_remove_identity_reshape(graph: PAIIRGraph, name: str) -> bool:
     if len(preds) != 1:
         return False
 
-    if len(node.input_shapes) != 1 or not node.input_shapes[0] or not node.output_shape:
+    if node.num_inputs != 1 or node.num_outputs != 1:
         return False
 
-    if node.input_shapes[0] != node.output_shape:
+    input_layout = node.input_layouts[0]
+    output_layout = node.output_layouts[0]
+    if not input_layout.shape or not output_layout.shape:
         return False
 
-    input_dims = node.input_dims[0] if len(node.input_dims) == 1 else ()
-    if not is_layout_invisible_dims(node.input_shapes[0], input_dims):
+    if input_layout.shape != output_layout.shape:
         return False
-    if not is_layout_invisible_dims(node.output_shape, node.output_dims):
+
+    if not is_layout_invisible_dims(input_layout.shape, input_layout.dims):
+        return False
+    if not is_layout_invisible_dims(output_layout.shape, output_layout.dims):
         return False
 
     graph.remove_node_and_reconnect(name)
@@ -75,24 +79,18 @@ def _try_collapse_adjacent_reshapes(graph: PAIIRGraph, first_name: str) -> bool:
     if len(graph.predecessors(second_name)) != 1:
         return False
 
-    if (
-        len(first.input_shapes) != 1
-        or not first.input_shapes[0]
-        or not second.output_shape
-    ):
+    if first.num_inputs != 1 or first.num_outputs != 1:
         return False
 
-    if len(second.input_shapes) != 1 or not second.input_shapes[0]:
+    if second.num_inputs != 1 or second.num_outputs != 1:
         return False
 
-    if len(first.input_dims) != 1 or len(second.input_dims) != 1:
+    if not first.input_layouts[0].shape or not second.output_layouts[0].shape:
         return False
 
     composed = ReshapeOp(shape_fn=_compose_shape_fns([first, second]))
-    composed.input_shapes = list(first.input_shapes)
-    composed.output_shape = second.output_shape
-    composed.input_dims = list(first.input_dims)
-    composed.output_dims = second.output_dims
+    composed.input_layouts = first.input_layouts
+    composed.output_layouts = second.output_layouts
 
     graph.add_node(composed)
     graph.add_edge(graph.predecessors(first_name)[0], composed.name, dst_port=0)
@@ -108,8 +106,7 @@ def _compose_shape_fns(chain: list[ReshapeOp]) -> Callable[[torch.Size], torch.S
     def _composed(input_shape: torch.Size) -> torch.Size:
         current = input_shape
         for op in chain:
-            dims = op.input_dims[0] if len(op.input_dims) == 1 else ()
-            current = reshape_output_shape(current, dims, op.shape_fn)
+            current = reshape_output_shape(current, op.input_layouts[0].dims, op.shape_fn)
         return current
 
     return _composed

--- a/paibox/paiir/pipeline/layout_cross_node_elision.py
+++ b/paibox/paiir/pipeline/layout_cross_node_elision.py
@@ -67,19 +67,19 @@ def _try_elide_comp_act_reshape_sandwich(graph: PAIIRGraph, act_name: str) -> bo
     if not _is_layout_invisible(pre) or not _is_layout_invisible(post):
         return False
 
-    if not comp.output_shape or pre.input_shapes != [comp.output_shape]:
+    if comp.num_outputs != 1 or not comp.output_layouts[0].shape:
         return False
-    if not pre.output_shape or act.input_shapes != [pre.output_shape]:
+    if pre.input_layouts != (comp.output_layouts[0],):
         return False
-    if not act.output_shape or post.input_shapes != [act.output_shape]:
+    if pre.num_outputs != 1 or pre.output_layouts != act.input_layouts:
         return False
-    if post.output_shape != comp.output_shape:
+    if act.num_outputs != 1 or act.output_layouts != post.input_layouts:
+        return False
+    if post.num_outputs != 1 or post.output_layouts[0] != comp.output_layouts[0]:
         return False
 
-    act.input_shapes = [comp.output_shape]
-    act.output_shape = comp.output_shape
-    act.input_dims = [comp.output_dims]
-    act.output_dims = comp.output_dims
+    act.input_layouts = (comp.output_layouts[0],)
+    act.output_layouts = (comp.output_layouts[0],)
 
     graph.replace_all_uses_with(post_name, act_name, delete_old=True)
     graph.remove_node(pre_name)
@@ -89,10 +89,14 @@ def _try_elide_comp_act_reshape_sandwich(graph: PAIIRGraph, act_name: str) -> bo
 
 
 def _is_layout_invisible(node: ReshapeOp) -> bool:
-    if len(node.input_shapes) != 1 or not node.input_shapes[0] or not node.output_shape:
+    if node.num_inputs != 1 or node.num_outputs != 1:
         return False
 
-    input_dims = node.input_dims[0] if len(node.input_dims) == 1 else ()
+    input_layout = node.input_layouts[0]
+    output_layout = node.output_layouts[0]
+    if not input_layout.shape or not output_layout.shape:
+        return False
+
     return is_layout_invisible_reshape(
-        node.input_shapes[0], node.output_shape, input_dims, node.output_dims
+        input_layout.shape, output_layout.shape, input_layout.dims, output_layout.dims
     )

--- a/paibox/paiir/pipeline/passes.py
+++ b/paibox/paiir/pipeline/passes.py
@@ -80,6 +80,20 @@ _DEPLOYABLE_GRAPH_NODE_TYPES = (
 )
 
 
+def _layout_shapes(node: OpNode) -> tuple[torch.Size, ...]:
+    return tuple(layout.shape for layout in node.input_layouts)
+
+
+def _layout_input_dims(node: OpNode) -> tuple[tuple[int, ...], ...]:
+    return tuple(layout.dims for layout in node.input_layouts)
+
+
+def _single_output_shape(node: OpNode) -> torch.Size:
+    if node.num_outputs != 1:
+        return torch.Size()
+    return node.output_layouts[0].shape
+
+
 def specialize_general_adds(graph: PAIIRGraph) -> PAIIRGraph:
     """Rewrite deployable expression-layer add nodes into deployable add IR.
 
@@ -98,10 +112,8 @@ def specialize_general_adds(graph: PAIIRGraph) -> PAIIRGraph:
         if isinstance(node, GeneralAddOp):
             specialized = _try_specialize_general_add(node)
             if specialized is not None:
-                specialized.input_shapes = list(node.input_shapes)
-                specialized.output_shape = node.output_shape
-                specialized.input_dims = list(node.input_dims)
-                specialized.output_dims = node.output_dims
+                specialized.input_layouts = node.input_layouts
+                specialized.output_layouts = node.output_layouts
                 specialized_graph.replace_node(name, specialized)
 
     return specialized_graph
@@ -118,8 +130,10 @@ def _try_specialize_general_add(node: GeneralAddOp) -> PotentialAddOp | None:
     if any(coeff not in (-1, 1) for coeff in coeffs):
         return None
 
-    if node.output_shape and node.input_shapes:
-        if any(shape != node.output_shape for shape in node.input_shapes):
+    output_shape = _single_output_shape(node)
+    input_shapes = _layout_shapes(node)
+    if output_shape and input_shapes:
+        if any(shape != output_shape for shape in input_shapes):
             return None
 
     return PotentialAddOp(op_signs=tuple(int(coeff) for coeff in coeffs))
@@ -254,13 +268,11 @@ def _try_fuse_accumulate(
     op_signs = add_node.signs
 
     fused = AccumulateOp(comps=comps, act=act_node.act, op_signs=op_signs)
-    fused.input_shapes = []
-    fused.input_dims = []
+    fused_input_layouts = []
     for p in comp_preds:
-        fused.input_shapes.extend(graph.nodes[p].input_shapes)  # type: ignore[union-attr]
-        fused.input_dims.extend(graph.nodes[p].input_dims)  # type: ignore[union-attr]
-    fused.output_shape = act_node.output_shape
-    fused.output_dims = act_node.output_dims
+        fused_input_layouts.extend(graph.nodes[p].input_layouts)  # type: ignore[union-attr]
+    fused.input_layouts = tuple(fused_input_layouts)
+    fused.output_layouts = act_node.output_layouts
 
     consumed.add(act_name)
     consumed.add(add_name)
@@ -334,10 +346,12 @@ def validate_graph(graph: PAIIRGraph) -> None:
         if not isinstance(node, OpNode):
             continue
         if isinstance(node, SplitOp):
-            if not node.input_shapes or any(not shape for shape in node.input_shapes):
+            if not node.input_layouts or any(
+                not layout.shape for layout in node.input_layouts
+            ):
                 missing_shape_nodes.append(name)
             continue
-        if not node.output_shape:
+        if not _single_output_shape(node):
             missing_shape_nodes.append(name)
 
     if missing_shape_nodes:
@@ -391,25 +405,37 @@ def validate_compiled_graph(graph: PAIIRGraph) -> None:
             continue
 
         if isinstance(node, SplitOp):
-            if not node.input_shapes or any(not shape for shape in node.input_shapes):
-                errors.append(f"SplitOp '{name}' is missing input_shapes")
-            if not node.input_dims or any(not dims for dims in node.input_dims):
-                errors.append(f"SplitOp '{name}' is missing input_dims")
-            if not node.output_dims:
-                errors.append(f"SplitOp '{name}' is missing output_dims")
+            if not node.input_layouts or any(
+                not layout.shape for layout in node.input_layouts
+            ):
+                errors.append(f"SplitOp '{name}' is missing input_layouts")
+            if not node.input_layouts or any(
+                not layout.dims for layout in node.input_layouts
+            ):
+                errors.append(f"SplitOp '{name}' is missing input layout dims")
+            if not node.output_layouts:
+                errors.append(f"SplitOp '{name}' is missing output_layouts")
             if node.output_domain is None:
                 errors.append(f"SplitOp '{name}' is missing output_domain")
             _validate_split_contract(errors, graph, name, node)
             continue
 
-        if not node.input_shapes or any(not shape for shape in node.input_shapes):
-            errors.append(f"OpNode '{name}' is missing input_shapes")
-        if not node.output_shape:
-            errors.append(f"OpNode '{name}' is missing output_shape")
-        if not node.input_dims or any(not dims for dims in node.input_dims):
-            errors.append(f"OpNode '{name}' is missing input_dims")
-        if not node.output_dims:
-            errors.append(f"OpNode '{name}' is missing output_dims")
+        if not node.input_layouts or any(
+            not layout.shape for layout in node.input_layouts
+        ):
+            errors.append(f"OpNode '{name}' is missing input_layouts")
+        if not node.output_layouts or any(
+            not layout.shape for layout in node.output_layouts
+        ):
+            errors.append(f"OpNode '{name}' is missing output_layouts")
+        if not node.input_layouts or any(
+            not layout.dims for layout in node.input_layouts
+        ):
+            errors.append(f"OpNode '{name}' is missing input layout dims")
+        if not node.output_layouts or any(
+            not layout.dims for layout in node.output_layouts
+        ):
+            errors.append(f"OpNode '{name}' is missing output layout dims")
         if node.output_domain is None:
             errors.append(f"OpNode '{name}' is missing output_domain")
 
@@ -447,7 +473,7 @@ def _get_node_output_shape(node: PAIIRNode) -> torch.Size:
     if isinstance(node, OutputNode):
         return node.shape
     if isinstance(node, OpNode):
-        return node.output_shape
+        return _single_output_shape(node)
     return torch.Size()
 
 
@@ -460,10 +486,10 @@ def _try_get_edge_output_shape(graph: PAIIRGraph, edge: Edge) -> torch.Size:
     """
     node = graph.nodes[edge.src]
     if isinstance(node, SplitOp):
-        if not node.input_shapes or not node.input_shapes[0]:
+        if node.num_inputs != 1 or not node.input_layouts[0].shape:
             return torch.Size()
 
-        input_shape = node.input_shapes[0]
+        input_shape = node.input_layouts[0].shape
         rank = len(input_shape)
         split_dim = node.dim if node.dim >= 0 else node.dim + rank
         if split_dim < 0 or split_dim >= rank:
@@ -478,10 +504,9 @@ def _try_get_edge_output_shape(graph: PAIIRGraph, edge: Edge) -> torch.Size:
 
         # Split branch shapes are derived on demand rather than persisted on
         # the node because the backend does not consume them directly.
-        output_shapes = infer_split_output_shapes(input_shape, node.sections, node.dim)
-        if edge.src_port < 0 or edge.src_port >= len(output_shapes):
+        if edge.src_port < 0 or edge.src_port >= node.num_outputs:
             return torch.Size()
-        return output_shapes[edge.src_port]
+        return node.output_layouts[edge.src_port].shape
 
     return _get_node_output_shape(node)
 
@@ -492,23 +517,25 @@ def _validate_concat_contract(
     incoming = graph.incoming_edges(name)
     preds = [edge.src for edge in incoming]
     pred_shapes = [_try_get_edge_output_shape(graph, edge) for edge in incoming]
+    input_shapes = _layout_shapes(node)
+    output_shape = _single_output_shape(node)
 
     if len(preds) < 1:
         errors.append(f"ConcatOp '{name}' must define at least one input path")
         return
 
-    if node.input_shapes and len(node.input_shapes) != len(preds):
+    if input_shapes and len(input_shapes) != len(preds):
         errors.append(
-            f"ConcatOp '{name}' has {len(node.input_shapes)} input_shapes but "
+            f"ConcatOp '{name}' has {len(input_shapes)} input layouts but "
             f"{len(preds)} predecessor(s)"
         )
         return
 
-    if node.input_shapes:
+    if input_shapes:
         mismatched = [
             (pred, pred_shape, expected_shape)
             for pred, pred_shape, expected_shape in zip(
-                preds, pred_shapes, node.input_shapes
+                preds, pred_shapes, input_shapes
             )
             if pred_shape and pred_shape != expected_shape
         ]
@@ -520,10 +547,10 @@ def _validate_concat_contract(
             errors.append(f"ConcatOp '{name}' predecessor shape mismatch: {details}")
             return
 
-        ranks = {len(shape) for shape in node.input_shapes if shape}
+        ranks = {len(shape) for shape in input_shapes if shape}
         if len(ranks) > 1:
             errors.append(
-                f"ConcatOp '{name}' requires same-rank operands, got {node.input_shapes}"
+                f"ConcatOp '{name}' requires same-rank operands, got {input_shapes}"
             )
             return
 
@@ -536,16 +563,16 @@ def _validate_concat_contract(
                 )
                 return
 
-            base_shape = list(node.input_shapes[0])
+            base_shape = list(input_shapes[0])
             concat_extent = 0
-            for shape in node.input_shapes:
+            for shape in input_shapes:
                 if any(
                     shape[axis] != base_shape[axis]
                     for axis in range(rank)
                     if axis != dim
                 ):
                     errors.append(
-                        f"ConcatOp '{name}' non-concat dims differ across inputs: {node.input_shapes}"
+                        f"ConcatOp '{name}' non-concat dims differ across inputs: {input_shapes}"
                     )
                     return
                 concat_extent += shape[dim]
@@ -554,10 +581,10 @@ def _validate_concat_contract(
                 concat_extent if axis == dim else base_shape[axis]
                 for axis in range(rank)
             )
-            if node.output_shape and expected_output != node.output_shape:
+            if output_shape and expected_output != output_shape:
                 errors.append(
                     f"ConcatOp '{name}' output_shape mismatch: "
-                    f"expected {expected_output}, got {node.output_shape}"
+                    f"expected {expected_output}, got {output_shape}"
                 )
 
 
@@ -573,18 +600,21 @@ def _validate_reshape_contract(
         return
 
     pred_shape = _try_get_edge_output_shape(graph, incoming[0])
-    if node.input_shapes and len(node.input_shapes) != 1:
+    input_shapes = _layout_shapes(node)
+    input_dims = _layout_input_dims(node)
+    output_shape = _single_output_shape(node)
+    if input_shapes and len(input_shapes) != 1:
         errors.append(
-            f"ReshapeOp '{name}' has {len(node.input_shapes)} input_shapes (expected 1)"
+            f"ReshapeOp '{name}' has {len(input_shapes)} input layouts (expected 1)"
         )
         return
 
-    if node.input_shapes and pred_shape:
-        expected_input_shape = node.input_shapes[0]
+    if input_shapes and pred_shape:
+        expected_input_shape = input_shapes[0]
         if pred_shape != expected_input_shape:
             logical_pred_shape = None
-            if len(node.input_dims) == 1:
-                logical_pred_shape = shape_after_dims(pred_shape, node.input_dims[0])
+            if len(input_dims) == 1:
+                logical_pred_shape = shape_after_dims(pred_shape, input_dims[0])
 
             if logical_pred_shape != expected_input_shape:
                 details = f"pred_output_shape={pred_shape}, input_shape={expected_input_shape}"
@@ -595,13 +625,13 @@ def _validate_reshape_contract(
                 )
                 return
 
-    if node.input_shapes and node.output_shape:
-        in_numel = math.prod(node.input_shapes[0])
-        out_numel = math.prod(node.output_shape)
+    if input_shapes and output_shape:
+        in_numel = math.prod(input_shapes[0])
+        out_numel = math.prod(output_shape)
         if in_numel != out_numel:
             errors.append(
                 f"ReshapeOp '{name}' changes element count: "
-                f"input_shape={node.input_shapes[0]}, output_shape={node.output_shape}"
+                f"input_shape={input_shapes[0]}, output_shape={output_shape}"
             )
 
 
@@ -617,30 +647,34 @@ def _validate_split_contract(
         return
 
     pred_shape = _try_get_edge_output_shape(graph, incoming[0])
-    if node.input_shapes and len(node.input_shapes) != 1:
+    input_shapes = _layout_shapes(node)
+    input_dims = _layout_input_dims(node)
+    if input_shapes and len(input_shapes) != 1:
         errors.append(
-            f"SplitOp '{name}' has {len(node.input_shapes)} input_shapes (expected 1)"
+            f"SplitOp '{name}' has {len(input_shapes)} input layouts (expected 1)"
         )
         return
 
-    if node.input_shapes and pred_shape and pred_shape != node.input_shapes[0]:
+    if input_shapes and pred_shape and pred_shape != input_shapes[0]:
         errors.append(
             f"SplitOp '{name}' predecessor shape mismatch: "
-            f"pred_output_shape={pred_shape}, input_shape={node.input_shapes[0]}"
+            f"pred_output_shape={pred_shape}, input_shape={input_shapes[0]}"
         )
         return
 
-    if len(node.input_dims) == 1 and node.output_dims != node.input_dims[0]:
+    if len(input_dims) == 1 and any(
+        layout.dims != input_dims[0] for layout in node.output_layouts
+    ):
         errors.append(
-            f"SplitOp '{name}' output_dims must match input_dims[0], got "
-            f"input_dims={node.input_dims[0]}, output_dims={node.output_dims}"
+            f"SplitOp '{name}' output layout dims must match input layout dims, got "
+            f"input_dims={input_dims[0]}, output_dims={[layout.dims for layout in node.output_layouts]}"
         )
         return
 
-    if not node.input_shapes or not node.input_shapes[0]:
+    if not input_shapes or not input_shapes[0]:
         return
 
-    input_shape = node.input_shapes[0]
+    input_shape = input_shapes[0]
     try:
         expected_outputs = infer_split_output_shapes(
             input_shape, node.sections, node.dim
@@ -648,6 +682,21 @@ def _validate_split_contract(
     except ValueError as e:
         errors.append(f"SplitOp '{name}' has invalid split spec: {e}")
         return
+
+    if node.output_layouts and len(node.output_layouts) != len(expected_outputs):
+        errors.append(
+            f"SplitOp '{name}' has {len(node.output_layouts)} output layouts but "
+            f"{len(expected_outputs)} split output(s) were inferred"
+        )
+        return
+
+    for idx, expected_shape in enumerate(expected_outputs):
+        if node.output_layouts and node.output_layouts[idx].shape != expected_shape:
+            errors.append(
+                f"SplitOp '{name}' output layout mismatch at result {idx}: "
+                f"expected {expected_shape}, got {node.output_layouts[idx].shape}"
+            )
+            return
 
     for edge in graph.outgoing_edges(name):
         if edge.src_port < 0 or edge.src_port >= len(expected_outputs):
@@ -659,7 +708,18 @@ def _validate_split_contract(
 
 
 def propagate_signal_domain(graph: PAIIRGraph) -> None:
-    """Infer and fill ``output_domain`` for every node in the graph."""
+    """Infer and fill node-level ``output_domain`` for every graph node.
+
+    ``output_domain`` is currently a single semantic value per node rather than
+    a per-output-port annotation. This is sufficient for the current IR because
+    routing-only nodes preserve the signal domain of their inputs:
+
+    - ``ReshapeOp`` inherits its sole predecessor domain
+    - ``SplitOp`` inherits its sole predecessor domain, and all split branches
+      therefore share that same domain
+    - ``ConcatOp`` requires all predecessors to agree on one domain, then
+      forwards that domain to its output
+    """
     errors: list[str] = []
 
     for name in graph.topo_sort():
@@ -849,15 +909,15 @@ def validate_deployable_graph(graph: PAIIRGraph) -> None:
                     f"AccumulateOp '{name}' signs must be +/-1 only, got {tuple(signs)}"
                 )
 
-            if node.input_shapes and len(node.input_shapes) != expected_paths:
+            if node.input_layouts and len(node.input_layouts) != expected_paths:
                 errors.append(
-                    f"AccumulateOp '{name}' has {len(node.input_shapes)} input_shapes but "
+                    f"AccumulateOp '{name}' has {len(node.input_layouts)} input layouts but "
                     f"{expected_paths} compute path(s)"
                 )
 
-            if node.input_dims and len(node.input_dims) != expected_paths:
+            if node.input_layouts and len(node.input_layouts) != expected_paths:
                 errors.append(
-                    f"AccumulateOp '{name}' has {len(node.input_dims)} input_dims but "
+                    f"AccumulateOp '{name}' has {len(node.input_layouts)} input layouts but "
                     f"{expected_paths} compute path(s)"
                 )
 
@@ -893,20 +953,20 @@ def _validate_potential_add_contract(
             f"{expected_paths} sign/path entries"
         )
 
-    if node.input_shapes and len(node.input_shapes) != expected_paths:
+    if node.input_layouts and len(node.input_layouts) != expected_paths:
         errors.append(
-            f"PotentialAddOp '{name}' has {len(node.input_shapes)} input_shapes but "
+            f"PotentialAddOp '{name}' has {len(node.input_layouts)} input layouts but "
             f"{expected_paths} sign/path entries"
         )
 
-    if node.output_shape and node.input_shapes:
-        mismatched = [
-            shape for shape in node.input_shapes if shape != node.output_shape
-        ]
+    input_shapes = _layout_shapes(node)
+    output_shape = _single_output_shape(node)
+    if output_shape and input_shapes:
+        mismatched = [shape for shape in input_shapes if shape != output_shape]
         if mismatched:
             errors.append(
                 f"PotentialAddOp '{name}' requires same-shape operands, got "
-                f"input_shapes={node.input_shapes}, output_shape={node.output_shape}"
+                f"input_shapes={input_shapes}, output_shape={output_shape}"
             )
 
 

--- a/tests/paiir/ir/test_graph.py
+++ b/tests/paiir/ir/test_graph.py
@@ -7,7 +7,14 @@ from paibox.paiir.ir.add_ops import PotentialAddOp
 from paibox.paiir.ir.core_neuron import IFNodeV25
 from paibox.paiir.ir.graph import Edge, PAIIRGraph
 from paibox.paiir.ir.ir_base import InputNode, OutputNode
-from paibox.paiir.ir.op_node import SequentialOp, StandaloneActOp, StandaloneCompOp
+from paibox.paiir.ir.op_node import (
+    RoutingOp,
+    SequentialOp,
+    SplitOp,
+    StandaloneActOp,
+    StandaloneCompOp,
+    TensorLayout,
+)
 
 
 class TestPAIIRGraph:
@@ -168,7 +175,7 @@ class TestPAIIRGraph:
 
     def test_verify_before_sim_reports_structural_lint_errors(self):
         graph, _, seq, _ = self._build_simple_graph()
-        seq.output_shape = torch.Size((1, 8, 8, 8))
+        seq.output_layouts = (TensorLayout(torch.Size((1, 8, 8, 8)), (0, 1, 2, 3)),)
         seq.core_params.tick_start = 1
         seq.core_params.tick_duration = 0
         seq.core_params.tick_initial = 0
@@ -208,9 +215,9 @@ class TestPAIIRGraph:
         graph = PAIIRGraph("summary_labels")
         inp = InputNode(shape=torch.Size((1, 4)))
         comp = StandaloneCompOp(nn.Linear(4, 8))
-        comp.output_shape = torch.Size((1, 8))
+        comp.output_layouts = (TensorLayout(torch.Size((1, 8)), (0, 1)),)
         act = StandaloneActOp(IFNodeV25())
-        act.output_shape = torch.Size((1, 8))
+        act.output_layouts = (TensorLayout(torch.Size((1, 8)), (0, 1)),)
         out = OutputNode(shape=torch.Size((1, 8)))
 
         for node in (inp, comp, act, out):
@@ -227,3 +234,72 @@ class TestPAIIRGraph:
         assert f"{comp.name} (Linear) (8,)" in captured
         assert f"{act.name} (IFNodeV25) (8,)" in captured
         assert f"{out.name} (OutputNode) (8,)" in captured
+
+    def test_boundary_layout_is_explicit_and_not_synthesized(self):
+        graph = PAIIRGraph("boundary_layout")
+        inp = InputNode(shape=torch.Size((1, 2, 3)), dims=(0, 2, 1))
+        out = OutputNode(shape=torch.Size((1, 2, 3)), dims=(0, 2, 1))
+        graph.add_node(inp)
+        graph.add_node(out)
+        graph.add_edge(inp.name, out.name)
+
+        assert graph.get_node_output_layout(inp.name) == inp.layout
+        assert graph.get_node_output_layout(out.name) == out.layout
+        assert graph.get_edge_output_layout(graph.edges[0]) == inp.layout
+
+    def test_summary_verbose_shows_multi_output_layouts_and_ports(self, capsys):
+        graph = PAIIRGraph("multi_output_summary")
+        inp = InputNode(shape=torch.Size((1, 4)), dims=(0, 1))
+        split = SplitOp(sections=2, dim=1)
+        split.input_layouts = (TensorLayout(torch.Size((1, 4)), (0, 1)),)
+        split.output_layouts = (
+            TensorLayout(torch.Size((1, 2)), (0, 1)),
+            TensorLayout(torch.Size((1, 2)), (0, 1)),
+        )
+        out_a = OutputNode(shape=torch.Size((1, 2)))
+        out_b = OutputNode(shape=torch.Size((1, 2)))
+
+        for node in (inp, split, out_a, out_b):
+            graph.add_node(node)
+        graph.add_edge(inp.name, split.name)
+        graph.add_edge(split.name, out_a.name, src_port=0)
+        graph.add_edge(split.name, out_b.name, src_port=1)
+
+        graph.summary(verbose=True)
+        summary = capsys.readouterr().out
+        assert "out[0] shape=(1, 2), dims=(0, 1)" in summary
+        assert "out[1] shape=(1, 2), dims=(0, 1)" in summary
+        assert "src_port=0 ->" in summary
+        assert "src_port=1 ->" in summary
+
+    def test_runtime_supports_generic_multi_output_routing_node(self):
+        class DuplicateOp(RoutingOp):
+            def __init__(self):
+                super().__init__()
+                self.input_layouts = (TensorLayout(torch.Size((1, 3)), (0, 1)),)
+                self.output_layouts = (
+                    TensorLayout(torch.Size((1, 3)), (0, 1)),
+                    TensorLayout(torch.Size((1, 3)), (0, 1)),
+                )
+
+            def forward(self, x: torch.Tensor):
+                return (x, x + 1)
+
+        graph = PAIIRGraph("generic_multi_output")
+        inp = InputNode(shape=torch.Size((1, 3)))
+        dup = DuplicateOp()
+        out_a = OutputNode(shape=torch.Size((1, 3)))
+        out_b = OutputNode(shape=torch.Size((1, 3)))
+
+        for node in (inp, dup, out_a, out_b):
+            graph.add_node(node)
+        graph.add_edge(inp.name, dup.name)
+        graph.add_edge(dup.name, out_a.name, src_port=0)
+        graph.add_edge(dup.name, out_b.name, src_port=1)
+
+        x = torch.tensor([[1.0, 2.0, 3.0]])
+        outputs = graph.step(x)
+        assert isinstance(outputs, tuple)
+        assert len(outputs) == 2
+        torch.testing.assert_close(outputs[0], x)
+        torch.testing.assert_close(outputs[1], x + 1)

--- a/tests/paiir/ir/test_op_node.py
+++ b/tests/paiir/ir/test_op_node.py
@@ -25,6 +25,7 @@ from paibox.paiir.ir.op_node import (
     SequentialOp,
     StandaloneActOp,
     StandaloneCompOp,
+    TensorLayout,
 )
 from paibox.paiir.pipeline.avgpool.compensation import (
     apply_avgpool_lut_compensation,
@@ -122,7 +123,7 @@ class TestWeights:
     def test_sequential_conv_returns_weight(self):
         conv = nn.Conv2d(3, 8, 3, padding=1)
         op = SequentialOp(comp=conv, act=ANNNodeV25(lut=LutReLU()))
-        op.output_shape = torch.Size((1, 8, 8, 8))
+        op.output_layouts = (TensorLayout(torch.Size((1, 8, 8, 8)), (0, 1, 2, 3)),)
         ws = op.weights
         assert ws is not None
         assert len(ws) == 1
@@ -132,14 +133,14 @@ class TestWeights:
     def test_sequential_pool_returns_none(self):
         """Weightless ops (pool etc.) return None, not identity matrices."""
         op = SequentialOp(comp=nn.MaxPool2d(2), act=IFNodeV25())
-        op.output_shape = torch.Size((1, 4, 4, 4))
+        op.output_layouts = (TensorLayout(torch.Size((1, 4, 4, 4)), (0, 1, 2, 3)),)
         assert op.weights is None
 
     def test_accumulate_returns_per_path_weights(self):
         conv1 = nn.Conv2d(3, 8, 3, padding=1)
         conv2 = nn.Conv2d(3, 8, 3, padding=1)
         op = AccumulateOp(comps=[conv1, conv2], act=IFNodeV25(), op_signs=(1, 1))
-        op.output_shape = torch.Size((1, 8, 8, 8))
+        op.output_layouts = (TensorLayout(torch.Size((1, 8, 8, 8)), (0, 1, 2, 3)),)
         ws = op.weights
         assert ws is not None
         assert len(ws) == 2
@@ -154,7 +155,7 @@ class TestWeights:
     def test_standalone_comp_linear_returns_weight(self):
         linear = nn.Linear(4, 8, bias=False)
         op = StandaloneCompOp(comp=linear)
-        op.output_shape = torch.Size((1, 8))
+        op.output_layouts = (TensorLayout(torch.Size((1, 8)), (0, 1)),)
         ws = op.weights
         assert ws is not None
         assert len(ws) == 1
@@ -164,7 +165,7 @@ class TestWeights:
     def test_standalone_comp_pool_returns_none(self):
         """Weightless ops (pool etc.) return None, not identity matrices."""
         op = StandaloneCompOp(comp=nn.AvgPool2d(2))
-        op.output_shape = torch.Size((1, 3, 4, 4))
+        op.output_layouts = (TensorLayout(torch.Size((1, 3, 4, 4)), (0, 1, 2, 3)),)
         assert op.weights is None
 
     def test_add_op_returns_none(self):
@@ -213,7 +214,7 @@ class TestWeights:
 
     def test_standalone_act_weight_format_uses_implicit_identity_range(self):
         op = StandaloneActOp(act=ANNNodeV25(lut=LutReLU()))
-        op.output_shape = torch.Size((1, 1024, 1024))
+        op.output_layouts = (TensorLayout(torch.Size((1, 1024, 1024)), (0, 1, 2)),)
 
         assert _infer_node_weight_format(op) == (
             DataSign.UNSIGNED,
@@ -222,7 +223,7 @@ class TestWeights:
 
     def test_add_weight_format_uses_implicit_identity_range(self):
         op = PotentialAddOp(op_signs=(1, -1))
-        op.output_shape = torch.Size((1, 1024, 1024))
+        op.output_layouts = (TensorLayout(torch.Size((1, 1024, 1024)), (0, 1, 2)),)
 
         assert _infer_node_weight_format(op) == (
             DataSign.UNSIGNED,

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -21,6 +21,7 @@ from paibox.paiir.ir.op_node import (
     ConcatOp,
     ReshapeOp,
     SequentialOp,
+    SplitOp,
     StandaloneActOp,
     StandaloneCompOp,
 )
@@ -32,7 +33,7 @@ from paibox.paiir.pipeline.avgpool import (
     calibrate_avgpool_threshold,
 )
 from paibox.paiir.pipeline.avgpool.metadata import AvgPoolDeployMetadata
-from paibox.paiir.pipeline.passes import GraphCleanupWarning
+from paibox.paiir.pipeline.passes import GraphCleanupWarning, validate_graph
 from tests.paiir.conftest import (
     ANNClassifier,
     SimpleCNN,
@@ -749,6 +750,37 @@ class TestFunctionalConv:
 
 
 class TestSplitCompilation:
+    def test_torch_to_paiir_split_concat_reshape_summary_smoke(self):
+        class Model(nn.Module):
+            def forward(self, x):
+                left, right = torch.split(x, [2, 3], dim=1)
+                y = torch.cat([right, left], dim=1)
+                return y.reshape(y.shape[0], -1)
+
+        sample = torch.randn(1, 5, 4, 4)
+        graph = torch_to_paiir(Model().eval(), sample)
+        validate_graph(graph)
+
+        split_nodes = [node for node in graph.nodes.values() if isinstance(node, SplitOp)]
+        concat_nodes = [node for node in graph.nodes.values() if isinstance(node, ConcatOp)]
+        reshape_nodes = [node for node in graph.nodes.values() if isinstance(node, ReshapeOp)]
+
+        assert len(split_nodes) == 1
+        assert len(concat_nodes) == 1
+        assert len(reshape_nodes) == 1
+
+        from io import StringIO
+        from contextlib import redirect_stdout
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            graph.summary(verbose=True)
+        summary = buf.getvalue()
+        assert "out[0] shape=(1, 2, 4, 4), dims=(0, 1, 2, 3)" in summary
+        assert "out[1] shape=(1, 3, 4, 4), dims=(0, 1, 2, 3)" in summary
+        assert "src_port=0 ->" in summary
+        assert "src_port=1 ->" in summary
+
     def test_compile_to_paiir_rejects_frontend_only_split_op(self):
         class Model(nn.Module):
             def __init__(self):

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -761,16 +761,22 @@ class TestSplitCompilation:
         graph = torch_to_paiir(Model().eval(), sample)
         validate_graph(graph)
 
-        split_nodes = [node for node in graph.nodes.values() if isinstance(node, SplitOp)]
-        concat_nodes = [node for node in graph.nodes.values() if isinstance(node, ConcatOp)]
-        reshape_nodes = [node for node in graph.nodes.values() if isinstance(node, ReshapeOp)]
+        split_nodes = [
+            node for node in graph.nodes.values() if isinstance(node, SplitOp)
+        ]
+        concat_nodes = [
+            node for node in graph.nodes.values() if isinstance(node, ConcatOp)
+        ]
+        reshape_nodes = [
+            node for node in graph.nodes.values() if isinstance(node, ReshapeOp)
+        ]
 
         assert len(split_nodes) == 1
         assert len(concat_nodes) == 1
         assert len(reshape_nodes) == 1
 
-        from io import StringIO
         from contextlib import redirect_stdout
+        from io import StringIO
 
         buf = StringIO()
         with redirect_stdout(buf):

--- a/tests/paiir/pipeline/test_graph_simulation.py
+++ b/tests/paiir/pipeline/test_graph_simulation.py
@@ -162,7 +162,7 @@ class TestTickActivityWindow:
             assert torch.all(outputs[step - 1] == 0), f"step {step} should be inactive"
 
         for step in active_steps:
-            assert outputs[step - 1].shape == seq_ops[0].output_shape
+            assert outputs[step - 1].shape == seq_ops[0].output_layouts[0].shape
 
 
 class TestTickInitial:

--- a/tests/paiir/pipeline/test_layout_chain_canonicalization.py
+++ b/tests/paiir/pipeline/test_layout_chain_canonicalization.py
@@ -71,7 +71,9 @@ class TestLayoutChainCanonicalization:
         reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
         assert len(reshape_nodes) == 1
         reshape = reshape_nodes[0]
-        assert reshape.input_layouts == (TensorLayout(torch.Size((1, 2, 3)), (0, 2, 1)),)
+        assert reshape.input_layouts == (
+            TensorLayout(torch.Size((1, 2, 3)), (0, 2, 1)),
+        )
         assert reshape.output_layouts == (TensorLayout(torch.Size((1, 6)), (0, 1)),)
 
     def test_removes_identity_shape_when_dims_only_swap_singleton_axes(self):
@@ -109,5 +111,7 @@ class TestLayoutChainCanonicalization:
         reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
         assert len(reshape_nodes) == 1
         reshape = reshape_nodes[0]
-        assert reshape.input_layouts == (TensorLayout(torch.Size((1, 2, 3)), (0, 2, 1)),)
+        assert reshape.input_layouts == (
+            TensorLayout(torch.Size((1, 2, 3)), (0, 2, 1)),
+        )
         assert reshape.output_layouts == (TensorLayout(torch.Size((1, 6)), (0, 1)),)

--- a/tests/paiir/pipeline/test_layout_chain_canonicalization.py
+++ b/tests/paiir/pipeline/test_layout_chain_canonicalization.py
@@ -2,7 +2,7 @@ import torch
 
 from paibox.paiir.ir.graph import PAIIRGraph
 from paibox.paiir.ir.ir_base import InputNode, OutputNode
-from paibox.paiir.ir.op_node import ReshapeOp
+from paibox.paiir.ir.op_node import ReshapeOp, TensorLayout
 from paibox.paiir.ir.reshape_semantics import is_layout_invisible_dims
 from paibox.paiir.pipeline.layout_chain_canonicalization import (
     canonicalize_layout_chains,
@@ -21,10 +21,8 @@ def _reshape(
     output_dims: tuple[int, ...],
 ) -> ReshapeOp:
     node = ReshapeOp(shape_fn=_fixed_shape(output_shape))
-    node.input_shapes = [torch.Size(input_shape)]
-    node.output_shape = torch.Size(output_shape)
-    node.input_dims = [input_dims]
-    node.output_dims = output_dims
+    node.input_layouts = (TensorLayout(torch.Size(input_shape), input_dims),)
+    node.output_layouts = (TensorLayout(torch.Size(output_shape), output_dims),)
     return node
 
 
@@ -73,9 +71,8 @@ class TestLayoutChainCanonicalization:
         reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
         assert len(reshape_nodes) == 1
         reshape = reshape_nodes[0]
-        assert reshape.input_shapes == [(1, 2, 3)]
-        assert reshape.output_shape == (1, 6)
-        assert reshape.input_dims == [(0, 2, 1)]
+        assert reshape.input_layouts == (TensorLayout(torch.Size((1, 2, 3)), (0, 2, 1)),)
+        assert reshape.output_layouts == (TensorLayout(torch.Size((1, 6)), (0, 1)),)
 
     def test_removes_identity_shape_when_dims_only_swap_singleton_axes(self):
         graph = PAIIRGraph("reshape_singleton_dims")
@@ -112,6 +109,5 @@ class TestLayoutChainCanonicalization:
         reshape_nodes = [n for n in graph.nodes.values() if isinstance(n, ReshapeOp)]
         assert len(reshape_nodes) == 1
         reshape = reshape_nodes[0]
-        assert reshape.input_shapes == [(1, 2, 3)]
-        assert reshape.output_shape == (1, 6)
-        assert reshape.input_dims == [(0, 2, 1)]
+        assert reshape.input_layouts == (TensorLayout(torch.Size((1, 2, 3)), (0, 2, 1)),)
+        assert reshape.output_layouts == (TensorLayout(torch.Size((1, 6)), (0, 1)),)

--- a/tests/paiir/pipeline/test_layout_cross_node_elision.py
+++ b/tests/paiir/pipeline/test_layout_cross_node_elision.py
@@ -10,6 +10,7 @@ from paibox.paiir.ir.op_node import (
     SequentialOp,
     StandaloneActOp,
     StandaloneCompOp,
+    TensorLayout,
 )
 from paibox.paiir.pipeline.layout_cross_node_elision import (
     elide_layout_invisible_reshapes,
@@ -25,10 +26,8 @@ def _reshape(
 ) -> ReshapeOp:
     target = torch.Size(output_shape)
     node = ReshapeOp(shape_fn=lambda _shape, bound=target: bound)
-    node.input_shapes = [torch.Size(input_shape)]
-    node.output_shape = target
-    node.input_dims = [input_dims]
-    node.output_dims = output_dims
+    node.input_layouts = (TensorLayout(torch.Size(input_shape), input_dims),)
+    node.output_layouts = (TensorLayout(target, output_dims),)
     return node
 
 
@@ -38,10 +37,8 @@ def _build_conv_reshape_act_reshape_graph(
     graph = PAIIRGraph("conv_reshape_act_reshape")
     inp = InputNode(shape=torch.Size((1, 3, 8, 8)))
     comp = StandaloneCompOp(nn.Conv2d(3, 4, 1))
-    comp.input_shapes = [inp.shape]
-    comp.output_shape = torch.Size((1, 4, 8, 8))
-    comp.input_dims = [(0, 1, 2, 3)]
-    comp.output_dims = (0, 1, 2, 3)
+    comp.input_layouts = (TensorLayout(inp.shape, (0, 1, 2, 3)),)
+    comp.output_layouts = (TensorLayout(torch.Size((1, 4, 8, 8)), (0, 1, 2, 3)),)
 
     pre = _reshape(
         (1, 4, 8, 8),
@@ -50,10 +47,8 @@ def _build_conv_reshape_act_reshape_graph(
         (0, 1, 2, 3, 4),
     )
     act = StandaloneActOp(ANNNodeV25(LutReLU()))
-    act.input_shapes = [pre.output_shape]
-    act.output_shape = pre.output_shape
-    act.input_dims = [pre.output_dims]
-    act.output_dims = pre.output_dims
+    act.input_layouts = pre.output_layouts
+    act.output_layouts = pre.output_layouts
     post = _reshape((1, 1, 4, 8, 8), (1, 4, 8, 8), (0, 1, 2, 3, 4), (0, 1, 2, 3))
     out = OutputNode(shape=torch.Size((1, 4, 8, 8)))
 

--- a/tests/paiir/pipeline/test_passes.py
+++ b/tests/paiir/pipeline/test_passes.py
@@ -31,6 +31,7 @@ from paibox.paiir.ir.op_node import (
     SplitOp,
     StandaloneActOp,
     StandaloneCompOp,
+    TensorLayout,
 )
 from paibox.paiir.ir.signal_domain import SignalDomain
 from paibox.paiir.lowering.converter import torch_to_paiir
@@ -67,6 +68,44 @@ from tests.paiir.conftest import (
     make_img_16ch_8x8,
     make_vec_8d,
 )
+
+
+def _layout(shape: tuple[int, ...] | torch.Size, dims: tuple[int, ...]) -> TensorLayout:
+    return TensorLayout(shape=torch.Size(shape), dims=dims)
+
+
+def _set_single_layouts(
+    node,
+    input_shape: tuple[int, ...] | torch.Size,
+    output_shape: tuple[int, ...] | torch.Size,
+    input_dims: tuple[int, ...] = (),
+    output_dims: tuple[int, ...] = (),
+) -> None:
+    node.input_layouts = (_layout(input_shape, input_dims),)
+    node.output_layouts = (_layout(output_shape, output_dims),)
+
+
+def _set_multi_input_single_output_layouts(
+    node,
+    input_shapes: list[tuple[int, ...] | torch.Size],
+    output_shape: tuple[int, ...] | torch.Size,
+    input_dims: list[tuple[int, ...]],
+    output_dims: tuple[int, ...],
+) -> None:
+    node.input_layouts = tuple(
+        _layout(shape, dims) for shape, dims in zip(input_shapes, input_dims)
+    )
+    node.output_layouts = (_layout(output_shape, output_dims),)
+
+
+def _set_split_layouts(
+    node: SplitOp,
+    input_shape: tuple[int, ...] | torch.Size,
+    output_shapes: list[tuple[int, ...] | torch.Size],
+    dims: tuple[int, ...],
+) -> None:
+    node.input_layouts = (_layout(input_shape, dims),)
+    node.output_layouts = tuple(_layout(shape, dims) for shape in output_shapes)
 
 
 class TestSNNConversion:
@@ -300,8 +339,8 @@ class TestShapeAndDims:
 
         seq_nodes = find_nodes(fused, SequentialOp)
         for node in seq_nodes:
-            assert node.output_shape != ()
-            assert all(s != () for s in node.input_shapes)
+            assert node.output_layouts[0].shape != ()
+            assert all(layout.shape != () for layout in node.input_layouts)
 
     def test_no_sample_input(self):
         """Converter works without sample input, shapes default to ()."""
@@ -312,7 +351,9 @@ class TestShapeAndDims:
         seq_nodes = find_nodes(fused, SequentialOp)
         assert len(seq_nodes) == 2
         for node in seq_nodes:
-            assert node.output_shape == torch.Size()
+            assert node.num_outputs == 1
+            assert node.output_layouts[0].shape == torch.Size()
+            assert node.output_layouts[0].dims == ()
 
     def test_dims_identity(self):
         """Identity dims for standard conv/linear (no transpose)."""
@@ -321,7 +362,7 @@ class TestShapeAndDims:
 
         seq_nodes = find_nodes(fused, SequentialOp)
         for node in seq_nodes:
-            assert node.output_dims == (0, 1, 2, 3)
+            assert node.output_layouts[0].dims == (0, 1, 2, 3)
 
     def test_flatten_dims(self):
         """flatten resets dims to identity."""
@@ -331,7 +372,7 @@ class TestShapeAndDims:
         seq_nodes = find_nodes(fused, SequentialOp)
         assert len(seq_nodes) == 2
         for node in seq_nodes:
-            assert node.output_dims in [(0, 1, 2, 3), (0, 1)]
+            assert node.output_layouts[0].dims in [(0, 1, 2, 3), (0, 1)]
 
 
 class TestAssignTickParams:
@@ -552,8 +593,7 @@ class TestUnrecoverableErrors:
     def test_no_input_node(self):
         graph = PAIIRGraph("no_input")
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [torch.Size((1, 8))]
-        op.output_shape = torch.Size((1, 4))
+        _set_single_layouts(op, (1, 8), (1, 4), (0, 1), (0, 1))
         out = OutputNode()
         graph.add_node(op)
         graph.add_node(out)
@@ -566,8 +606,7 @@ class TestUnrecoverableErrors:
         graph = PAIIRGraph("no_output")
         inp = InputNode(shape=torch.Size((1, 8)))
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [torch.Size((1, 8))]
-        op.output_shape = torch.Size((1, 4))
+        _set_single_layouts(op, (1, 8), (1, 4), (0, 1), (0, 1))
         graph.add_node(inp)
         graph.add_node(op)
         graph.add_edge(inp.name, op.name)
@@ -580,8 +619,7 @@ class TestUnrecoverableErrors:
         graph = PAIIRGraph("bad_input")
         inp = InputNode(shape=torch.Size((1, 8)))
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [torch.Size((1, 8))]
-        op.output_shape = torch.Size((1, 4))
+        _set_single_layouts(op, (1, 8), (1, 4), (0, 1), (0, 1))
         out = OutputNode()
         graph.add_node(inp)
         graph.add_node(op)
@@ -599,8 +637,7 @@ class TestUnrecoverableErrors:
         graph = PAIIRGraph("bad_output")
         inp = InputNode(shape=torch.Size((1, 8)))
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [torch.Size((1, 8))]
-        op.output_shape = torch.Size((1, 4))
+        _set_single_layouts(op, (1, 8), (1, 4), (0, 1), (0, 1))
         out = OutputNode()
         graph.add_node(inp)
         graph.add_node(op)
@@ -618,8 +655,7 @@ class TestUnrecoverableErrors:
         graph = PAIIRGraph("multiple_errors")
         # No InputNode, no OutputNode
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [torch.Size((1, 8))]
-        op.output_shape = torch.Size((1, 4))
+        _set_single_layouts(op, (1, 8), (1, 4), (0, 1), (0, 1))
         graph.add_node(op)
 
         with pytest.raises(GraphValidationError) as exc_info:
@@ -664,11 +700,9 @@ class TestAutoCleanup:
         graph = PAIIRGraph("orphan_op")
         inp = InputNode(shape=torch.Size((1, 8)))
         op1 = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op1.input_shapes = [torch.Size((1, 8))]
-        op1.output_shape = torch.Size((1, 4))
+        _set_single_layouts(op1, (1, 8), (1, 4), (0, 1), (0, 1))
         op2 = SequentialOp(nn.Linear(8, 4), IFNodeV25())  # orphan
-        op2.input_shapes = [torch.Size((1, 8))]
-        op2.output_shape = torch.Size((1, 4))
+        _set_single_layouts(op2, (1, 8), (1, 4), (0, 1), (0, 1))
         out = OutputNode()
         graph.add_node(inp)
         graph.add_node(op1)
@@ -690,11 +724,9 @@ class TestAutoCleanup:
         graph = PAIIRGraph("dead_end")
         inp = InputNode(shape=torch.Size((1, 8)))
         op1 = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op1.input_shapes = [torch.Size((1, 8))]
-        op1.output_shape = torch.Size((1, 4))
+        _set_single_layouts(op1, (1, 8), (1, 4), (0, 1), (0, 1))
         op2 = SequentialOp(nn.Linear(4, 2), IFNodeV25())  # dead end
-        op2.input_shapes = [torch.Size((1, 4))]
-        op2.output_shape = torch.Size((1, 2))
+        _set_single_layouts(op2, (1, 4), (1, 2), (0, 1), (0, 1))
         out = OutputNode()
         graph.add_node(inp)
         graph.add_node(op1)
@@ -717,8 +749,7 @@ class TestAutoCleanup:
         inp1 = InputNode(shape=torch.Size((1, 8)))
         inp2 = InputNode(shape=torch.Size((1, 8)))  # disconnected
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [torch.Size((1, 8))]
-        op.output_shape = torch.Size((1, 4))
+        _set_single_layouts(op, (1, 8), (1, 4), (0, 1), (0, 1))
         out = OutputNode()
         graph.add_node(inp1)
         graph.add_node(inp2)
@@ -738,8 +769,7 @@ class TestAutoCleanup:
         graph = PAIIRGraph("disconnected_output")
         inp = InputNode(shape=torch.Size((1, 8)))
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [torch.Size((1, 8))]
-        op.output_shape = torch.Size((1, 4))
+        _set_single_layouts(op, (1, 8), (1, 4), (0, 1), (0, 1))
         out1 = OutputNode()
         out2 = OutputNode()  # disconnected
         graph.add_node(inp)
@@ -760,8 +790,7 @@ class TestAutoCleanup:
         graph = PAIIRGraph("all_disconnected")
         inp = InputNode(shape=torch.Size((1, 8)))  # disconnected
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [torch.Size((1, 8))]
-        op.output_shape = torch.Size((1, 4))
+        _set_single_layouts(op, (1, 8), (1, 4), (0, 1), (0, 1))
         out = OutputNode()
         graph.add_node(inp)
         graph.add_node(op)
@@ -783,8 +812,7 @@ class TestSNNModeLUTConsistency:
         graph = PAIIRGraph("test")
         inp = InputNode(shape=torch.Size((1, 8)))
         op = SequentialOp(nn.Linear(8, 4), act)
-        op.input_shapes = [torch.Size((1, 8))]
-        op.output_shape = torch.Size((1, 4))
+        _set_single_layouts(op, (1, 8), (1, 4), (0, 1), (0, 1))
         out = OutputNode()
         graph.add_node(inp)
         graph.add_node(op)
@@ -835,10 +863,7 @@ class TestValidateCompiledGraph:
         graph = PAIIRGraph("compiled")
         inp = InputNode(shape=torch.Size((1, 8)))
         op = SequentialOp(nn.Linear(8, 4), IFNodeV25())
-        op.input_shapes = [torch.Size((1, 8))]
-        op.output_shape = torch.Size((1, 4))
-        op.input_dims = [(0, 1)]
-        op.output_dims = (0, 1)
+        _set_single_layouts(op, (1, 8), (1, 4), (0, 1), (0, 1))
         op.core_params.set_input_format((DataSign.SIGNED, DataWidth.WIDTH_8BIT))
         op.core_params.set_output_format((DataSign.UNSIGNED, DataWidth.WIDTH_1BIT))
         op.core_params.set_weight_format((DataSign.SIGNED, DataWidth.WIDTH_8BIT))
@@ -874,14 +899,8 @@ class TestValidateCompiledGraph:
         branch = SequentialOp(nn.Linear(8, 4), IFNodeV25())
         dead_end = SequentialOp(nn.Linear(4, 2), IFNodeV25())
 
-        branch.input_shapes = [torch.Size((1, 8))]
-        branch.output_shape = torch.Size((1, 4))
-        branch.input_dims = [(0, 1)]
-        branch.output_dims = (0, 1)
-        dead_end.input_shapes = [torch.Size((1, 4))]
-        dead_end.output_shape = torch.Size((1, 2))
-        dead_end.input_dims = [(0, 1)]
-        dead_end.output_dims = (0, 1)
+        _set_single_layouts(branch, (1, 8), (1, 4), (0, 1), (0, 1))
+        _set_single_layouts(dead_end, (1, 4), (1, 2), (0, 1), (0, 1))
 
         for node in (branch, dead_end):
             node.core_params.set_input_format((DataSign.SIGNED, DataWidth.WIDTH_8BIT))
@@ -917,10 +936,13 @@ class TestValidateCompiledGraph:
         cat.output_domain = SignalDomain.VALUE
         out.output_domain = SignalDomain.VALUE
 
-        cat.input_shapes = [torch.Size((1, 32)), torch.Size((1, 8))]
-        cat.output_shape = torch.Size((1, 40))
-        cat.input_dims = [(0, 1), (0, 1)]
-        cat.output_dims = (0, 1)
+        _set_multi_input_single_output_layouts(
+            cat,
+            [(1, 32), (1, 8)],
+            (1, 40),
+            [(0, 1), (0, 1)],
+            (0, 1),
+        )
 
         graph.add_node(inp_a)
         graph.add_node(inp_b)
@@ -945,9 +967,7 @@ class TestValidateCompiledGraph:
         split.output_domain = SignalDomain.VALUE
         out.output_domain = SignalDomain.VALUE
 
-        split.input_shapes = [torch.Size((1, 5))]
-        split.input_dims = [(0, 1)]
-        split.output_dims = (0, 1)
+        split.input_layouts = (_layout((1, 5), (0, 1)),)
 
         graph.add_node(inp)
         graph.add_node(split)
@@ -969,14 +989,8 @@ class TestSplitPassBehavior:
         act = StandaloneActOp(IFNodeV25())
         out = OutputNode(shape=torch.Size((1, 2)))
 
-        split.input_shapes = [torch.Size((1, 4))]
-        split.input_dims = [(0, 1)]
-        split.output_dims = (0, 1)
-
-        act.input_shapes = [torch.Size((1, 2))]
-        act.output_shape = torch.Size((1, 2))
-        act.input_dims = [(0, 1)]
-        act.output_dims = (0, 1)
+        _set_split_layouts(split, (1, 4), [(1, 2), (1, 2)], (0, 1))
+        _set_single_layouts(act, (1, 2), (1, 2), (0, 1), (0, 1))
 
         graph.add_node(inp)
         graph.add_node(split)
@@ -1124,10 +1138,7 @@ class TestValidateDeployableGraph:
         inp_b.output_domain = SignalDomain.VALUE
         acc.output_domain = SignalDomain.VALUE
         out.output_domain = SignalDomain.VALUE
-        acc.input_shapes = [torch.Size((1, 4))]
-        acc.output_shape = torch.Size((1, 4))
-        acc.input_dims = [(0, 1)]
-        acc.output_dims = (0, 1)
+        _set_single_layouts(acc, (1, 4), (1, 4), (0, 1), (0, 1))
 
         graph.add_node(inp_a)
         graph.add_node(inp_b)
@@ -1273,10 +1284,13 @@ class TestSignalDomain:
         inp_b.output_domain = SignalDomain.VALUE
         acc.output_domain = SignalDomain.VALUE
         out.output_domain = SignalDomain.VALUE
-        acc.input_shapes = [torch.Size((1, 4)), torch.Size((1, 4))]
-        acc.output_shape = torch.Size((1, 4))
-        acc.input_dims = [(0, 1), (0, 1)]
-        acc.output_dims = (0, 1)
+        _set_multi_input_single_output_layouts(
+            acc,
+            [(1, 4), (1, 4)],
+            (1, 4),
+            [(0, 1), (0, 1)],
+            (0, 1),
+        )
         acc.signs = (1, 0)
 
         graph.add_node(inp_a)


### PR DESCRIPTION
## Summary
### What changed
- Replaced node-level shape/dims storage on `OpNode` with unified `TensorLayout` metadata:
  - `input_layouts: tuple[TensorLayout, ...]`
  - `output_layouts: tuple[TensorLayout, ...]`
- Updated lowering, graph helpers, compile passes, and PAIIR-side tests to consume layout tuples instead of separate shape/dims fields.
- Preserved `Edge.src_port` and `Edge.dst_port` semantics:
  - `src_port` continues to identify source output index
  - `dst_port` continues to identify destination input slot
- Improved graph summary output:
  - `summary(verbose=True)` now prints per-input/per-output layouts
  - includes explicit `src_port` / `dst_port` edge annotations
- Made `InputNode` / `OutputNode` carry explicit boundary `TensorLayout` internally while preserving `.shape` access.
- Generalized graph runtime tuple-output handling from `SplitOp`-only logic to any `OpNode` with `num_outputs > 1`.