### PR TITLE
Bugfix(paiir): reset dims for function-form reshape ops

### DIFF
--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -68,6 +68,7 @@ class Group:
     def __hash__(self):
         return hash(id(self))
 
+
 SOURCE_ELEM = TypeVar("SOURCE_ELEM", bound=SourceElem)
 SOURCE_NODE = TypeVar("SOURCE_NODE", bound=SourceNode)
 

--- a/paibox/paiir/ir/reshape_semantics.py
+++ b/paibox/paiir/ir/reshape_semantics.py
@@ -46,6 +46,8 @@ def is_squeeze_target(target: Any) -> bool:
 def is_dims_reset_target(target: Any) -> bool:
     return (
         target in RESHAPE_METHOD_NAMES
+        or target in FLATTEN_FUNCTION_TARGETS
+        or target in RESHAPE_FUNCTION_TARGETS
         or is_unsqueeze_target(target)
         or is_squeeze_target(target)
     )

--- a/tests/paiir/lowering/test_dims_prop.py
+++ b/tests/paiir/lowering/test_dims_prop.py
@@ -159,6 +159,15 @@ class TestDimsProp:
         gm = _propagate(M(), torch.randn(2, 3, 4))
         assert _output_dims(gm) == (0, 1)
 
+    def test_function_flatten_resets_to_identity(self):
+        class M(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return torch.flatten(x, 1)
+
+        gm = _propagate(M(), torch.randn(2, 3, 4))
+        assert _output_dims(gm) == (0, 1)
+        assert _node_dims(gm, "flatten") == (0, 1)
+
     def test_view_resets_to_identity(self):
         class M(nn.Module):
             def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -174,6 +183,15 @@ class TestDimsProp:
 
         gm = _propagate(M(), torch.randn(2, 3, 4))
         assert _output_dims(gm) == (0, 1)
+
+    def test_function_reshape_resets_to_identity(self):
+        class M(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return torch.reshape(x, (6, 4))
+
+        gm = _propagate(M(), torch.randn(2, 3, 4))
+        assert _output_dims(gm) == (0, 1)
+        assert _node_dims(gm, "reshape") == (0, 1)
 
     def test_view_as_resets_to_identity(self):
         class M(nn.Module):
@@ -288,6 +306,29 @@ class TestDimsProp:
 
         gm = _propagate(M(), torch.randn(2, 3, 4))
         assert _output_dims(gm) == (0, 1)
+
+    def test_transpose_then_function_flatten(self):
+        """Function-form flatten must also reset non-identity dims."""
+
+        class M(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return torch.flatten(x.transpose(1, 2), 1)
+
+        gm = _propagate(M(), torch.randn(2, 3, 4))
+        assert _output_dims(gm) == (0, 1)
+        assert _node_dims(gm, "flatten") == (0, 1)
+
+    def test_permute_then_function_reshape(self):
+        """Function-form reshape must reset non-identity dims."""
+
+        class M(nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                y = x.permute(0, 2, 3, 1)
+                return torch.reshape(y, (y.size(0), -1))
+
+        gm = _propagate(M(), torch.randn(1, 2, 3, 4))
+        assert _output_dims(gm) == (0, 1)
+        assert _node_dims(gm, "reshape") == (0, 1)
 
     def test_conv_transpose_permute(self):
         """Conv (identity) -> transpose -> permute chain."""

--- a/tests/paiir/lowering/test_shape_analysis.py
+++ b/tests/paiir/lowering/test_shape_analysis.py
@@ -32,6 +32,29 @@ class TestShapeAnalysis:
         assert sink.output_shape == (1, 60)
         assert analysis.aux_nodes == set()
 
+    def test_function_flatten_is_recorded_as_reshape_sink(self):
+        class M(nn.Module):
+            def forward(self, x):
+                return torch.flatten(x, 1)
+
+        gm = _trace_for_shape_analysis(M(), torch.randn(1, 3, 4, 5))
+        analysis = analyze_shape_helpers(gm)
+
+        flatten_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function" and node.target is torch.flatten
+        )
+        sink = analysis.sink_for(flatten_node)
+        assert sink is not None
+
+        assert sink.kind == "flatten"
+        assert sink.data_input.op == "placeholder"
+        assert sink.start_dim == 1
+        assert sink.end_dim == -1
+        assert sink.shape_seed_nodes == ()
+        assert sink.output_shape == (1, 60)
+
     def test_function_unsqueeze_is_recorded_as_reshape_sink(self):
         class M(nn.Module):
             def forward(self, x):
@@ -94,6 +117,27 @@ class TestShapeAnalysis:
         assert sink.data_input.op == "placeholder"
         assert sink.shape_seed_nodes == ()
         assert sink.output_shape == (1, 2, 3)
+
+    def test_function_reshape_is_recorded_as_reshape_sink(self):
+        class M(nn.Module):
+            def forward(self, x):
+                return torch.reshape(x, (1, 6))
+
+        gm = _trace_for_shape_analysis(M(), torch.randn(1, 2, 3))
+        analysis = analyze_shape_helpers(gm)
+
+        reshape_node = next(
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function" and node.target is torch.reshape
+        )
+        sink = analysis.sink_for(reshape_node)
+        assert sink is not None
+
+        assert sink.kind == "reshape"
+        assert sink.data_input.op == "placeholder"
+        assert sink.shape_seed_nodes == ()
+        assert sink.output_shape == (1, 6)
 
     def test_tuple_repeat_all_ones_is_recorded_as_reshape_sink(self):
         class M(nn.Module):

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -206,9 +206,7 @@ class TestCompileBasic:
                 x = x.transpose(1, 2)
                 return self.linear(torch.flatten(x, 1))
 
-        graph = compile_to_paiir(
-            TransposeFunctionFlattenLinear(), torch.randn(1, 2, 3)
-        )
+        graph = compile_to_paiir(TransposeFunctionFlattenLinear(), torch.randn(1, 2, 3))
 
         reshape_nodes = find_nodes(graph, ReshapeOp)
         linear_nodes = [

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -173,6 +173,55 @@ class TestCompileBasic:
         assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
         assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[0].name]
 
+    def test_function_flatten_before_linear_compiles(self):
+        class FunctionFlattenLinear(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(6, 4, bias=False)
+
+            def forward(self, x):
+                return self.linear(torch.flatten(x, 1))
+
+        graph = compile_to_paiir(FunctionFlattenLinear(), torch.randn(1, 2, 3))
+
+        reshape_nodes = find_nodes(graph, ReshapeOp)
+        linear_nodes = [
+            node
+            for node in find_nodes(graph, StandaloneCompOp)
+            if isinstance(node.comp, nn.Linear)
+        ]
+
+        assert len(reshape_nodes) == 1
+        assert len(linear_nodes) == 1
+        assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
+        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[0].name]
+
+    def test_transpose_then_function_flatten_before_linear_compiles(self):
+        class TransposeFunctionFlattenLinear(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(6, 4, bias=False)
+
+            def forward(self, x):
+                x = x.transpose(1, 2)
+                return self.linear(torch.flatten(x, 1))
+
+        graph = compile_to_paiir(
+            TransposeFunctionFlattenLinear(), torch.randn(1, 2, 3)
+        )
+
+        reshape_nodes = find_nodes(graph, ReshapeOp)
+        linear_nodes = [
+            node
+            for node in find_nodes(graph, StandaloneCompOp)
+            if isinstance(node.comp, nn.Linear)
+        ]
+
+        assert len(reshape_nodes) == 1
+        assert len(linear_nodes) == 1
+        assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
+        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[0].name]
+
     def test_permute_then_reshape_before_linear_compiles(self):
         class PermuteReshapeLinear(nn.Module):
             def __init__(self):
@@ -185,6 +234,57 @@ class TestCompileBasic:
                 return self.linear(x)
 
         graph = compile_to_paiir(PermuteReshapeLinear(), torch.randn(1, 2, 3, 4))
+
+        reshape_nodes = find_nodes(graph, ReshapeOp)
+        linear_nodes = [
+            node
+            for node in find_nodes(graph, StandaloneCompOp)
+            if isinstance(node.comp, nn.Linear)
+        ]
+
+        assert len(reshape_nodes) == 1
+        assert len(linear_nodes) == 1
+        assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
+        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[0].name]
+
+    def test_function_reshape_before_linear_compiles(self):
+        class FunctionReshapeLinear(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(24, 5, bias=False)
+
+            def forward(self, x):
+                x = torch.reshape(x, (x.size(0), -1))
+                return self.linear(x)
+
+        graph = compile_to_paiir(FunctionReshapeLinear(), torch.randn(1, 2, 3, 4))
+
+        reshape_nodes = find_nodes(graph, ReshapeOp)
+        linear_nodes = [
+            node
+            for node in find_nodes(graph, StandaloneCompOp)
+            if isinstance(node.comp, nn.Linear)
+        ]
+
+        assert len(reshape_nodes) == 1
+        assert len(linear_nodes) == 1
+        assert graph.predecessors(reshape_nodes[0].name) == ["InputNode_0"]
+        assert graph.predecessors(linear_nodes[0].name) == [reshape_nodes[0].name]
+
+    def test_permute_then_function_reshape_before_linear_compiles(self):
+        class PermuteFunctionReshapeLinear(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(24, 5, bias=False)
+
+            def forward(self, x):
+                x = x.permute(0, 2, 3, 1)
+                x = torch.reshape(x, (x.size(0), -1))
+                return self.linear(x)
+
+        graph = compile_to_paiir(
+            PermuteFunctionReshapeLinear(), torch.randn(1, 2, 3, 4)
+        )
 
         reshape_nodes = find_nodes(graph, ReshapeOp)
         linear_nodes = [


### PR DESCRIPTION
## Summary
- Align `DimsProp` with shared reshape semantics so function-form `torch.flatten` and `torch.reshape` reset dims the same way as method and module forms.
- Add regression coverage for both identity and non-identity layout transitions, including `transpose -> torch.flatten()` and `permute -> torch.reshape()`.
- Prevent `TensorLayout` rank mismatches during lowering and compile flows, including failures like `shape rank 2 != dims rank 4`.