### PR TITLE
Feat(paiir): reduce transparent transform chains

### DIFF
--- a/paibox/paiir/ir/op_node.py
+++ b/paibox/paiir/ir/op_node.py
@@ -359,7 +359,8 @@ class SequentialOp(OfflineCoreOp):
         self.avgpool_deploy_metadata = None
 
     def forward(self, x: Tensor) -> Tensor:
-        return self.act(_prepare_act_input(self.act, _run_comp(self.comp, x)))
+        x = _run_comp(self.comp, x)
+        return self.act(_prepare_act_input(self.act, x))
 
     @property
     def weights(self) -> list[Tensor] | None:

--- a/paibox/paiir/pipeline/avgpool/fusion.py
+++ b/paibox/paiir/pipeline/avgpool/fusion.py
@@ -284,7 +284,7 @@ def _materialize_split_avgpool_pair(
     core1_act = ANNNodeV25(core1_lut)
     core1 = SequentialOp(sumpool, core1_act)
     core1.input_layouts = pred.input_layouts
-    core1.output_layouts = act_node.output_layouts
+    core1.output_layouts = act_node.input_layouts
 
     consumed.add(pred_name)
     consumed.add(act_name)

--- a/paibox/paiir/pipeline/compile.py
+++ b/paibox/paiir/pipeline/compile.py
@@ -19,32 +19,6 @@ conversion pipeline:
 
 Use :func:`compile_to_paiir` for a one-step compilation, or call the
 individual passes directly for fine-grained control.
-
-Example::
-
-    from paibox.paiir import compile_to_paiir
-
-    # Simple one-step compilation
-    graph = compile_to_paiir(model, torch.randn(1, 3, 32, 32))
-
-    # With custom timing parameters
-    graph = compile_to_paiir(
-        model,
-        torch.randn(1, 3, 32, 32),
-        tick_duration=100,
-        auto_reset=True,
-    )
-
-    # With per-node timing overrides
-    graph = compile_to_paiir(
-        model,
-        torch.randn(1, 3, 32, 32),
-        tick_duration=100,
-        tick_overrides={
-            "seq_op_0": {"tick_start": 5},
-            "seq_op_1": {"tick_duration": 200},
-        },
-    )
 """
 
 from dataclasses import dataclass
@@ -77,21 +51,7 @@ __all__ = ["compile_to_paiir", "CompileConfig"]
 
 @dataclass
 class CompileConfig:
-    """Configuration for :func:`compile_to_paiir`.
-
-    Args:
-        tick_duration: Global default for how many time steps each core works.
-            0 = always working (default).
-        auto_reset: Global default for automatic neuron state reset.
-        input_formats: Per-InputNode data format override for
-            :func:`propagate_data_format`.
-        enable_avgpool_calibration: Experimental. If True, refine shared-core
-            AvgPool+LIF thresholds via offline integer search after topology
-            selection. Off by default.
-        enable_split_avgpool_lif: Experimental. If True, allow the compiler to choose
-            split-core AvgPool+LIF when Core 1 can transmit the exact sum-domain
-            code through the current LUT VALUE path. Off by default.
-    """
+    """Configuration for :func:`compile_to_paiir`."""
 
     tick_duration: int = 0
     auto_reset: bool = True
@@ -126,80 +86,15 @@ def compile_to_paiir(
        apply AvgPool deployment params
     5. analysis phase -- validate graph, infer signal domains, infer data formats
     6. standalone AvgPool auto-rewrite that depends on those analyses
-    7. re-run the analysis phase if the rewrite changed the graph
+    7. re-run the analysis phase if a rewrite changed the graph
     8. :func:`assign_tick_params` -- assign timing parameters
     9. :func:`calibrate_avgpool_thresholds` -- (experimental) refine shared-core
        AvgPool+LIF thresholds via offline integer search
     10. :func:`validate_compiled_graph` -- final post-pass graph validation
-       after connectivity cleanup, signal-domain propagation, data-format
-       propagation, and tick assignment
+        after connectivity cleanup, signal-domain propagation, data-format
+        propagation, and tick assignment
     11. :func:`validate_deployable_graph` -- ensure no frontend-only IR remains
-
-    For fine-grained control, call the individual passes directly instead.
-
-    Precedence: explicit keyword arguments > ``config`` fields > built-in
-    defaults.
-
-    Args:
-        model: The PyTorch model to compile.
-        *sample_inputs: Example input tensor(s) for shape and dims inference.
-            Omit entirely to skip shape propagation.
-        tick_duration: Global default for how many time steps each core works.
-            0 means always working. Default: 0.
-        auto_reset: Automatic neuron state reset when tick_duration > 0.
-            Default: True.
-        tick_overrides: Per-node timing overrides, keyed by node name.
-            Each value is a dict with optional keys ``tick_start``,
-            ``tick_duration``, and ``auto_reset``.
-        input_formats: Per-InputNode data format override, keyed by node name.
-            Format: ``(DataSign, DataWidth)`` tuples.
-        compile_config: Optional :class:`CompileConfig` providing defaults.
-            Explicit keyword arguments always take precedence.
-        concrete_args: Concrete arguments forwarded to ``fx.Tracer.trace``.
-        strict: Raise on unsupported ops (True) or warn and bypass (False).
-            Default: True.
-        enable_avgpool_calibration: Experimental. If True, refine shared-core
-            AvgPool+LIF thresholds via offline integer search after topology
-            selection. Off by default. Explicit kwarg overrides
-            ``CompileConfig.enable_avgpool_calibration``.
-        enable_split_avgpool_lif: Experimental. If True, allow conditional
-            split-core AvgPool+LIF deployment when exact sum-domain LUT coding
-            is possible. Explicit kwarg overrides
-            ``CompileConfig.enable_split_avgpool_lif``.
-    Returns:
-        A compiled :class:`PAIIRGraph` with fused nodes and all compile-time
-        annotations filled.
-
-    Raises:
-        UnsupportedOpError: If ``strict=True`` and an unsupported operator is encountered.
-        GraphValidationError: If the graph fails structural validation.
-        ValueError: If timing parameters are invalid.
-
-    Example::
-
-        # Simple compilation
-        graph = compile_to_paiir(model, torch.randn(1, 3, 32, 32))
-
-        # Custom timing
-        graph = compile_to_paiir(
-            model,
-            torch.randn(1, 3, 32, 32),
-            tick_duration=100,
-            auto_reset=True,
-        )
-
-        # With calibration (experimental)
-        graph = compile_to_paiir(
-            model,
-            torch.randn(1, 3, 32, 32),
-            enable_avgpool_calibration=True,
-        )
-
-        # Using CompileConfig with per-call overrides
-        cfg = CompileConfig(tick_duration=100, auto_reset=True)
-        graph = compile_to_paiir(model, x, compile_config=cfg, strict=False)
     """
-    # Resolve: explicit kwarg > config > built-in default
     cfg = compile_config or CompileConfig()
     _tick_duration = tick_duration if tick_duration is not None else cfg.tick_duration
     _auto_reset = auto_reset if auto_reset is not None else cfg.auto_reset
@@ -215,45 +110,25 @@ def compile_to_paiir(
         else cfg.enable_split_avgpool_lif
     )
 
-    # Step 1: FX trace and 1:1 node mapping
     graph = torch_to_paiir(
         model, *sample_inputs, concrete_args=concrete_args, strict=strict
     )
 
-    # Step 2: Normalize pre-fusion transform topology to a fixed point.
     graph = _run_pre_fusion_rewrite_phase(graph)
-
-    # Step 3: Narrow expression-layer add nodes into deployable add IR where possible.
     graph = specialize_general_adds(graph)
-
-    # Step 4: Choose topology, fuse atomic nodes, and prepare AvgPool deployment
     graph = fuse_to_offline_cores(
         graph, _enable_split_avgpool_lif, _enable_avgpool_calibration
     )
-
-    # Step 5: Run post-fusion rewrites that depend on graph analyses. This
-    # phase owns the "analyze -> rewrite -> re-analyze" control flow so future
-    # topology rewrites can be added without growing ad-hoc replay logic in the
-    # main compile function.
     graph = _run_post_fusion_rewrite_phase(
         graph, _input_formats, _post_fusion_rewrite_passes()
     )
 
-    # Step 6: Assign timing parameters
     assign_tick_params(graph, _tick_duration, _auto_reset, tick_overrides)
 
-    # Step 7: Calibrate AvgPool+LIF thresholds (experimental, off by default)
     if _enable_avgpool_calibration:
         calibrate_avgpool_thresholds(graph)
 
-    # Step 8: Final validation after all compile-time annotations are filled.
-    # Unlike validate_graph(), this stage assumes the graph is in its final
-    # compiled form and checks shape/dims completeness, propagated signal
-    # domains, propagated data formats, tick parameters, and connectivity.
     validate_compiled_graph(graph)
-
-    # Step 9: The backend only accepts deployable IR nodes. Expression-layer
-    # nodes such as GeneralAddOp must have been specialized away by now.
     validate_deployable_graph(graph)
 
     graph.eval()
@@ -263,14 +138,7 @@ def compile_to_paiir(
 def _run_mid_compile_analyses(
     graph: PAIIRGraph, input_formats: dict[str, DataFormat] | None
 ) -> PAIIRGraph:
-    """Run the standard analysis phase for a topology-stable graph.
-
-    This helper gives compile-time rewrites one explicit place to "rewind" to
-    when they invalidate previously-computed graph annotations. Any pass that
-    rewrites topology after fusion but before scheduling can re-enter this
-    phase instead of manually remembering which analyses must be replayed.
-    """
-
+    """Run the standard analysis phase for a topology-stable graph."""
     validate_graph(graph)
     propagate_signal_domain(graph)
     propagate_data_format(graph, input_formats)
@@ -295,12 +163,7 @@ def _run_pre_fusion_rewrite_phase(graph: PAIIRGraph, max_rounds: int = 4) -> PAI
 
 
 def _post_fusion_rewrite_passes() -> tuple[RewritePass, ...]:
-    """Return the ordered post-fusion rewrite passes.
-
-    Keeping pass declaration separate from phase execution lets us add future
-    rewrites by appending one new spec instead of editing the replay logic.
-    """
-
+    """Return the ordered post-fusion rewrite passes."""
     return (RewritePass("rewrite_standalone_avgpools", rewrite_standalone_avgpools),)
 
 

--- a/paibox/paiir/pipeline/layout_chain_canonicalization.py
+++ b/paibox/paiir/pipeline/layout_chain_canonicalization.py
@@ -1,15 +1,22 @@
 """Canonicalize consecutive transform chains before fusion."""
 
 from ..ir.graph import PAIIRGraph
-from ..ir.op_node import TransformOp
+from ..ir.op_node import TransformOp, TransformStage
 from .graph_utils import is_order_preserving_transform_node, is_transform_node
 
 __all__ = ["canonicalize_layout_chains"]
 
 
 def canonicalize_layout_chains(graph: PAIIRGraph) -> PAIIRGraph:
-    """Collapse local transform chains until no further rewrite applies."""
+    """Reduce continuous transform segments until no further rewrite applies.
+
+    The pass operates on maximal linear transform slices. When a transform
+    chain is interrupted by an observed intermediate output, the chain is cut
+    at that observation point and each safe slice is canonicalized
+    independently.
+    """
     changed = True
+    changed_any = False
     while changed:
         changed = False
         for name in graph.topo_sort():
@@ -17,75 +24,182 @@ def canonicalize_layout_chains(graph: PAIIRGraph) -> PAIIRGraph:
             if not is_transform_node(node):
                 continue
 
-            if _try_remove_identity_transform(graph, name):
+            if _try_reduce_transform_segment(graph, name):
                 changed = True
+                changed_any = True
                 break
 
-            if _try_collapse_adjacent_transforms(graph, name):
-                changed = True
-                break
-
-    return graph
+    return graph.clone_shallow() if changed_any else graph
 
 
-def _try_remove_identity_transform(graph: PAIIRGraph, name: str) -> bool:
-    """Delete a transform when it preserves both shape and element ordering."""
-    node = graph.nodes.get(name)
-    if not is_transform_node(node):
+def _try_reduce_transform_segment(graph: PAIIRGraph, head_name: str) -> bool:
+    segment = _collect_transform_segment(graph, head_name)
+    if segment is None:
+        return False
+
+    if _is_identity_transform(segment[0]):
+        _remove_transform_segment(graph, [segment[0]])
+        return True
+
+    if _is_identity_segment(segment):
+        _remove_transform_segment(graph, segment)
+        return True
+
+    if len(segment) == 1:
+        return False
+
+    _replace_transform_segment(
+        graph, segment, TransformOp(_compose_transform_stages(segment))
+    )
+    return True
+
+
+def _collect_transform_segment(
+    graph: PAIIRGraph, head_name: str
+) -> list[TransformOp] | None:
+    """Return one maximal reducible transform slice starting at *head_name*."""
+    head = graph.nodes.get(head_name)
+    if not is_transform_node(head):
+        return None
+
+    if not _is_transform_segment_head(graph, head_name, head):
+        return None
+    if not _has_concrete_layouts(head):
+        return None
+
+    segment: list[TransformOp] = [head]
+    current_name = head_name
+
+    while True:
+        succs = graph.successors(current_name)
+        if len(succs) != 1:
+            return segment
+
+        next_name = succs[0]
+        next_node = graph.nodes.get(next_name)
+        if not is_transform_node(next_node):
+            return segment
+        if len(graph.predecessors(next_name)) != 1:
+            return segment
+        if not _is_single_input_output_transform(next_node):
+            return segment
+        if not _has_concrete_layouts(next_node):
+            return segment
+
+        segment.append(next_node)
+        current_name = next_name
+
+
+def _is_transform_segment_head(graph: PAIIRGraph, name: str, node: TransformOp) -> bool:
+    """Return whether *name* starts a reducible transform slice."""
+    if not _is_single_input_output_transform(node):
         return False
 
     preds = graph.predecessors(name)
     if len(preds) != 1:
         return False
 
-    input_layout = node.input_layouts[0]
-    output_layout = node.output_layouts[0]
-    if not input_layout.shape or not output_layout.shape:
+    pred_name = preds[0]
+    pred = graph.nodes.get(pred_name)
+    if not is_transform_node(pred):
+        return True
+
+    return len(graph.successors(pred_name)) != 1
+
+
+def _is_single_input_output_transform(node: TransformOp) -> bool:
+    return node.num_inputs == 1 and node.num_outputs == 1
+
+
+def _has_concrete_layouts(node: TransformOp) -> bool:
+    return bool(node.input_layouts and node.input_layouts[0].shape) and bool(
+        node.output_layouts and node.output_layouts[0].shape
+    )
+
+
+def _is_identity_segment(segment: list[TransformOp]) -> bool:
+    head_input_layout = segment[0].input_layouts[0]
+    tail_output_layout = segment[-1].output_layouts[0]
+    if head_input_layout.shape != tail_output_layout.shape:
         return False
 
+    combined = TransformOp(_compose_transform_stages(segment))
+    combined.input_layouts = (head_input_layout,)
+    combined.output_layouts = (tail_output_layout,)
+    return is_order_preserving_transform_node(combined)
+
+
+def _is_identity_transform(node: TransformOp) -> bool:
+    if not _has_concrete_layouts(node):
+        return False
+
+    input_layout = node.input_layouts[0]
+    output_layout = node.output_layouts[0]
     if input_layout.shape != output_layout.shape:
         return False
 
-    if not is_order_preserving_transform_node(node):
-        return False
-
-    graph.remove_node_and_reconnect(name)
-    return True
+    return is_order_preserving_transform_node(node)
 
 
-def _try_collapse_adjacent_transforms(graph: PAIIRGraph, first_name: str) -> bool:
-    first = graph.nodes.get(first_name)
-    if not is_transform_node(first):
-        return False
+def _remove_transform_segment(graph: PAIIRGraph, segment: list[TransformOp]) -> None:
+    """Delete one identity transform slice and reconnect its surrounding edges."""
+    head_name = segment[0].name
+    tail_name = segment[-1].name
+    incoming = graph.incoming_edges(head_name)
+    if len(incoming) != 1:
+        raise ValueError("transform segment head must have exactly one incoming edge")
 
-    succs = graph.successors(first_name)
-    if len(succs) != 1:
-        return False
+    source_edge = incoming[0]
+    outgoing = graph.outgoing_edges(tail_name)
 
-    second_name = succs[0]
-    second = graph.nodes.get(second_name)
-    if not is_transform_node(second):
-        return False
+    for node in segment:
+        graph.remove_node(node.name)
 
-    if len(graph.predecessors(second_name)) != 1:
-        return False
+    for edge in outgoing:
+        candidate = (source_edge.src, edge.dst, source_edge.src_port, edge.dst_port)
+        if any(
+            existing.src == candidate[0]
+            and existing.dst == candidate[1]
+            and existing.src_port == candidate[2]
+            and existing.dst_port == candidate[3]
+            for existing in graph.edges
+        ):
+            continue
+        graph.add_edge(
+            source_edge.src,
+            edge.dst,
+            src_port=source_edge.src_port,
+            dst_port=edge.dst_port,
+        )
 
-    if first.num_inputs != 1 or first.num_outputs != 1:
-        return False
 
-    if second.num_inputs != 1 or second.num_outputs != 1:
-        return False
+def _replace_transform_segment(
+    graph: PAIIRGraph,
+    segment: list[TransformOp],
+    replacement: TransformOp,
+) -> None:
+    """Replace one transform slice with a single composed ``TransformOp``."""
+    head_name = segment[0].name
+    tail_name = segment[-1].name
+    incoming = graph.incoming_edges(head_name)
+    if len(incoming) != 1:
+        raise ValueError("transform segment head must have exactly one incoming edge")
 
-    if not first.input_layouts[0].shape or not second.output_layouts[0].shape:
-        return False
+    replacement.input_layouts = segment[0].input_layouts
+    replacement.output_layouts = segment[-1].output_layouts
+    graph.add_node(replacement)
+    graph.add_edge(
+        incoming[0].src,
+        replacement.name,
+        src_port=incoming[0].src_port,
+        dst_port=0,
+    )
+    graph.replace_all_uses_with(tail_name, replacement.name, delete_old=False)
 
-    composed = TransformOp(first.stages + second.stages)
-    composed.input_layouts = first.input_layouts
-    composed.output_layouts = second.output_layouts
+    for node in segment:
+        graph.remove_node(node.name)
 
-    graph.add_node(composed)
-    graph.add_edge(graph.predecessors(first_name)[0], composed.name, dst_port=0)
-    graph.replace_all_uses_with(second_name, composed.name, delete_old=True)
 
-    graph.remove_node(first_name)
-    return True
+def _compose_transform_stages(segment: list[TransformOp]) -> tuple[TransformStage, ...]:
+    """Concatenate the stages of one transform slice in graph order."""
+    return tuple(stage for node in segment for stage in node.stages)

--- a/paibox/paiir/pipeline/passes.py
+++ b/paibox/paiir/pipeline/passes.py
@@ -1242,7 +1242,9 @@ def _infer_node_weight_format(node: OfflineCoreOp) -> DataFormat:
     return infer_weight_format(w_min, w_max)
 
 
-def _derive_input_add_potential_mode(node: OfflineCoreOp, input_format: DataFormat) -> None:
+def _derive_input_add_potential_mode(
+    node: OfflineCoreOp, input_format: DataFormat
+) -> None:
     """Derive hardware add-potential mode from the resolved input format.
 
     Standalone activation cores synthesize an implicit identity connectivity

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -60,6 +60,22 @@ class ConcatModel(nn.Module):
         self.conv1 = nn.Conv2d(3, 4, 1)
         self.conv2 = nn.Conv2d(3, 4, 1)
         self.conv3 = nn.Conv2d(8, 2, 1)
+        self.relu1 = nn.ReLU()
+        self.relu2 = nn.ReLU()
+        self.relu3 = nn.ReLU()
+
+    def forward(self, x):
+        left = self.relu1(self.conv1(x))
+        right = self.relu2(self.conv2(x))
+        return self.relu3(self.conv3(torch.cat([left, right], dim=1)))
+
+
+class PotentialConcatIntoWeightedConsumer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 4, 1)
+        self.conv2 = nn.Conv2d(3, 4, 1)
+        self.conv3 = nn.Conv2d(8, 2, 1)
         self.relu = nn.ReLU()
 
     def forward(self, x):
@@ -258,6 +274,14 @@ class TestUnsupported32BitConsumers:
             GraphValidationError, match="StandaloneCompOp.*WIDTH_32BIT|WIDTH_32BIT"
         ):
             compile_to_paiir(PotentialIntoStandalonePool().eval(), make_img_3ch_8x8())
+
+    def test_compile_rejects_potential_concat_into_weighted_consumer(self):
+        with pytest.raises(
+            GraphValidationError, match="SequentialOp.*WIDTH_32BIT|WIDTH_32BIT"
+        ):
+            compile_to_paiir(
+                PotentialConcatIntoWeightedConsumer().eval(), make_img_3ch_8x8()
+            )
 
 
 class TestCompileBasic:

--- a/tests/paiir/pipeline/test_layout_chain_canonicalization.py
+++ b/tests/paiir/pipeline/test_layout_chain_canonicalization.py
@@ -32,7 +32,7 @@ class TestLayoutChainCanonicalization:
         assert is_layout_invisible_dims(torch.Size((1, 1, 64, 40, 40)), (1, 0, 2, 3, 4))
         assert not is_layout_invisible_dims(torch.Size((2, 3, 4)), (1, 0, 2))
 
-    def test_collapses_three_identity_reshape_nodes(self):
+    def test_collapses_three_identity_transform_nodes(self):
         graph = PAIIRGraph("reshape_chain")
         inp = InputNode(shape=torch.Size((1, 3, 4)))
         r1 = _transform((1, 3, 4), (1, 1, 3, 4), (0, 1, 2), (0, 1, 2, 3))
@@ -49,11 +49,11 @@ class TestLayoutChainCanonicalization:
 
         canonicalize_layout_chains(graph)
 
-        reshape_nodes = find_transform_nodes(graph)
-        assert reshape_nodes == []
+        transform_nodes = find_transform_nodes(graph)
+        assert transform_nodes == []
         assert graph.predecessors(out.name) == [inp.name]
 
-    def test_collapses_reshape_pair_with_leading_layout_metadata(self):
+    def test_collapses_transform_pair_with_leading_layout_metadata(self):
         graph = PAIIRGraph("reshape_pair")
         inp = InputNode(shape=torch.Size((1, 2, 3)))
         r1 = _transform((1, 2, 3), (1, 3, 2), (0, 2, 1), (0, 1, 2))
@@ -68,35 +68,68 @@ class TestLayoutChainCanonicalization:
 
         canonicalize_layout_chains(graph)
 
-        reshape_nodes = find_transform_nodes(graph)
-        assert len(reshape_nodes) == 1
-        reshape = reshape_nodes[0]
-        assert _stage_types(reshape) == (
+        transform_nodes = find_transform_nodes(graph)
+        assert len(transform_nodes) == 1
+        transform = transform_nodes[0]
+        assert _stage_types(transform) == (
             LayoutStage,
             ShapeStage,
             LayoutStage,
             ShapeStage,
         )
-        assert reshape.input_layouts == (
+        assert transform.input_layouts == (
             TensorLayout(torch.Size((1, 2, 3)), (0, 2, 1)),
         )
-        assert reshape.output_layouts == (TensorLayout(torch.Size((1, 6)), (0, 1)),)
+        assert transform.output_layouts == (TensorLayout(torch.Size((1, 6)), (0, 1)),)
+
+    def test_collapses_entire_nonidentity_transform_chain_in_one_pass(self):
+        graph = PAIIRGraph("transform_chain_nonidentity")
+        inp = InputNode(shape=torch.Size((1, 2, 3)))
+        r1 = _transform((1, 2, 3), (1, 3, 2), (0, 2, 1), (0, 1, 2))
+        r2 = _transform((1, 3, 2), (1, 1, 3, 2), (0, 1, 2), (0, 1, 2, 3))
+        r3 = _transform((1, 1, 3, 2), (1, 6), (0, 1, 2, 3), (0, 1))
+        out = OutputNode(shape=torch.Size((1, 6)))
+
+        for node in (inp, r1, r2, r3, out):
+            graph.add_node(node)
+        graph.add_edge(inp.name, r1.name)
+        graph.add_edge(r1.name, r2.name)
+        graph.add_edge(r2.name, r3.name)
+        graph.add_edge(r3.name, out.name)
+
+        canonicalize_layout_chains(graph)
+
+        transform_nodes = find_transform_nodes(graph)
+        assert len(transform_nodes) == 1
+        transform = transform_nodes[0]
+        assert _stage_types(transform) == (
+            LayoutStage,
+            ShapeStage,
+            LayoutStage,
+            ShapeStage,
+            LayoutStage,
+            ShapeStage,
+        )
+        assert transform.input_layouts == (
+            TensorLayout(torch.Size((1, 2, 3)), (0, 2, 1)),
+        )
+        assert transform.output_layouts == (TensorLayout(torch.Size((1, 6)), (0, 1)),)
 
     def test_removes_identity_shape_when_dims_only_swap_singleton_axes(self):
         graph = PAIIRGraph("reshape_singleton_dims")
         inp = InputNode(shape=torch.Size((1, 3, 4)))
-        reshape = _transform((1, 3, 4), (1, 3, 4), (1, 0, 2), (1, 0, 2))
+        transform = _transform((1, 3, 4), (1, 3, 4), (1, 0, 2), (1, 0, 2))
         out = OutputNode(shape=torch.Size((1, 3, 4)))
 
-        for node in (inp, reshape, out):
+        for node in (inp, transform, out):
             graph.add_node(node)
-        graph.add_edge(inp.name, reshape.name)
-        graph.add_edge(reshape.name, out.name)
+        graph.add_edge(inp.name, transform.name)
+        graph.add_edge(transform.name, out.name)
 
         canonicalize_layout_chains(graph)
 
-        reshape_nodes = find_transform_nodes(graph)
-        assert reshape_nodes == []
+        transform_nodes = find_transform_nodes(graph)
+        assert transform_nodes == []
         assert graph.predecessors(out.name) == [inp.name]
 
     def test_keeps_pair_when_second_requires_nonidentity_input_dims(self):
@@ -114,16 +147,116 @@ class TestLayoutChainCanonicalization:
 
         canonicalize_layout_chains(graph)
 
-        reshape_nodes = find_transform_nodes(graph)
-        assert len(reshape_nodes) == 1
-        reshape = reshape_nodes[0]
-        assert _stage_types(reshape) == (
+        transform_nodes = find_transform_nodes(graph)
+        assert len(transform_nodes) == 1
+        transform = transform_nodes[0]
+        assert _stage_types(transform) == (
             LayoutStage,
             ShapeStage,
             LayoutStage,
             ShapeStage,
         )
-        assert reshape.input_layouts == (
+        assert transform.input_layouts == (
             TensorLayout(torch.Size((1, 2, 3)), (0, 2, 1)),
         )
-        assert reshape.output_layouts == (TensorLayout(torch.Size((1, 6)), (0, 1)),)
+        assert transform.output_layouts == (TensorLayout(torch.Size((1, 6)), (0, 1)),)
+
+    def test_keeps_identity_endpoints_chain_when_middle_layout_semantics_change(self):
+        graph = PAIIRGraph("transform_identity_false_positive")
+        inp = InputNode(shape=torch.Size((1, 2, 3)))
+        t1 = _transform((1, 2, 3), (1, 3, 2), (0, 1, 2), (0, 1, 2))
+        t2 = _transform((1, 3, 2), (1, 2, 3), (0, 2, 1), (0, 1, 2))
+        out = OutputNode(shape=torch.Size((1, 2, 3)))
+
+        for node in (inp, t1, t2, out):
+            graph.add_node(node)
+        graph.add_edge(inp.name, t1.name)
+        graph.add_edge(t1.name, t2.name)
+        graph.add_edge(t2.name, out.name)
+
+        x = torch.arange(6, dtype=torch.int32).reshape(1, 2, 3)
+        expected_before = graph.forward(x)
+
+        canonicalize_layout_chains(graph)
+
+        transform_nodes = find_transform_nodes(graph)
+        assert transform_nodes
+        graph.reset()
+        actual_after = graph.forward(x)
+
+        assert torch.is_tensor(actual_after)
+        assert torch.is_tensor(expected_before)
+        assert torch.equal(actual_after, expected_before)
+
+    def test_collapses_suffix_slice_when_upstream_transform_is_shared(self):
+        graph = PAIIRGraph("transform_shared_prefix")
+        inp = InputNode(shape=torch.Size((1, 2, 3)))
+        shared = _transform((1, 2, 3), (1, 3, 2), (0, 1, 2), (0, 1, 2))
+        r1 = _transform((1, 3, 2), (1, 1, 3, 2), (0, 1, 2), (0, 1, 2, 3))
+        r2 = _transform((1, 1, 3, 2), (1, 6), (0, 1, 2, 3), (0, 1))
+        out_main = OutputNode(shape=torch.Size((1, 6)))
+        out_side = OutputNode(shape=torch.Size((1, 3, 2)))
+
+        for node in (inp, shared, r1, r2, out_main, out_side):
+            graph.add_node(node)
+        graph.add_edge(inp.name, shared.name)
+        graph.add_edge(shared.name, r1.name)
+        graph.add_edge(r1.name, r2.name)
+        graph.add_edge(r2.name, out_main.name)
+        graph.add_edge(shared.name, out_side.name)
+
+        canonicalize_layout_chains(graph)
+
+        transform_nodes = find_transform_nodes(graph)
+        assert len(transform_nodes) == 2
+        assert graph.predecessors(out_side.name) == [shared.name]
+        main_pred = graph.predecessors(out_main.name)[0]
+        assert main_pred != shared.name
+
+    def test_collapses_prefix_slice_when_tail_transform_has_multiple_successors(self):
+        graph = PAIIRGraph("transform_shared_tail")
+        inp = InputNode(shape=torch.Size((1, 2, 3)))
+        r1 = _transform((1, 2, 3), (1, 3, 2), (0, 2, 1), (0, 1, 2))
+        r2 = _transform((1, 3, 2), (1, 6), (0, 1, 2), (0, 1))
+        out_a = OutputNode(shape=torch.Size((1, 6)))
+        out_b = OutputNode(shape=torch.Size((1, 6)))
+
+        for node in (inp, r1, r2, out_a, out_b):
+            graph.add_node(node)
+        graph.add_edge(inp.name, r1.name)
+        graph.add_edge(r1.name, r2.name)
+        graph.add_edge(r2.name, out_a.name)
+        graph.add_edge(r2.name, out_b.name)
+
+        canonicalize_layout_chains(graph)
+
+        transform_nodes = find_transform_nodes(graph)
+        assert len(transform_nodes) == 1
+        transform = transform_nodes[0]
+        assert graph.predecessors(out_a.name) == [transform.name]
+        assert graph.predecessors(out_b.name) == [transform.name]
+
+    def test_does_not_cross_middle_observer_when_collapsing_chain(self):
+        graph = PAIIRGraph("transform_middle_observer")
+        inp = InputNode(shape=torch.Size((1, 2, 3)))
+        r1 = _transform((1, 2, 3), (1, 3, 2), (0, 2, 1), (0, 1, 2))
+        r2 = _transform((1, 3, 2), (1, 1, 3, 2), (0, 1, 2), (0, 1, 2, 3))
+        r3 = _transform((1, 1, 3, 2), (1, 6), (0, 1, 2, 3), (0, 1))
+        out_main = OutputNode(shape=torch.Size((1, 6)))
+        out_obs = OutputNode(shape=torch.Size((1, 1, 3, 2)))
+
+        for node in (inp, r1, r2, r3, out_main, out_obs):
+            graph.add_node(node)
+        graph.add_edge(inp.name, r1.name)
+        graph.add_edge(r1.name, r2.name)
+        graph.add_edge(r2.name, r3.name)
+        graph.add_edge(r3.name, out_main.name)
+        graph.add_edge(r2.name, out_obs.name)
+
+        canonicalize_layout_chains(graph)
+
+        transform_nodes = find_transform_nodes(graph)
+        assert len(transform_nodes) == 2
+        obs_pred = graph.predecessors(out_obs.name)[0]
+        main_pred = graph.predecessors(out_main.name)[0]
+        assert obs_pred != main_pred

--- a/tests/paiir/pipeline/test_pre_act_transform_commutation.py
+++ b/tests/paiir/pipeline/test_pre_act_transform_commutation.py
@@ -1,0 +1,185 @@
+from collections.abc import Callable
+from typing import TypeVar
+
+import torch
+from paicorelib import LeakMultiInputMode
+from spikingjelly.activation_based import neuron as sj
+from torch import nn
+
+from paibox.paiir import ANNNodeV25, IFNodeV25, LIFNodeV25, LutSigmoid, compile_to_paiir
+from paibox.paiir.ir.graph import PAIIRGraph
+from paibox.paiir.ir.op_node import SequentialOp, StandaloneActOp, TransformOp
+from paibox.paiir.nn import SumPool2d
+from tests.paiir.conftest import find_transform_nodes
+
+_T = TypeVar("_T")
+
+
+def _single_node(
+    graph: PAIIRGraph, typ: type[_T], predicate: Callable[[_T], bool] | None = None
+) -> _T:
+    matches = [node for node in graph.nodes.values() if isinstance(node, typ)]
+    if predicate is not None:
+        matches = [node for node in matches if predicate(node)]
+    assert len(matches) == 1
+    return matches[0]
+
+
+class LinearTransformReLU(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(8, 8, bias=False)
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        x = self.linear(x)
+        x = x.reshape(x.shape[0], 2, 4)
+        return self.relu(x)
+
+
+class LinearTransformReLUTransformBack(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(8, 8, bias=False)
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        x = self.linear(x)
+        x = x.reshape(x.shape[0], 2, 4)
+        x = self.relu(x)
+        return x.reshape(x.shape[0], 8)
+
+
+class MaxPoolTransformIF(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(1, 2, 1, bias=False)
+        self.if1 = sj.IFNode(v_threshold=1.0)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.if2 = sj.IFNode(v_threshold=1.0)
+
+    def forward(self, x):
+        x = self.if1(self.conv(x))
+        x = self.pool(x)
+        x = x.reshape(x.shape[0], 1, x.shape[1], x.shape[2], x.shape[3])
+        return self.if2(x)
+
+
+class AvgPoolTransformANN(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(1, 1, 1, bias=False)
+        self.relu = nn.ReLU()
+        self.pool = nn.AvgPool2d(2, 2)
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x):
+        x = self.relu(self.conv(x))
+        x = self.pool(x)
+        x = x.reshape(x.shape[0], 1, 1, x.shape[2], x.shape[3])
+        return self.sigmoid(x)
+
+
+class AvgPoolTransformIF(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(1, 1, 1, bias=False)
+        self.if1 = sj.IFNode(v_threshold=1.0)
+        self.pool = nn.AvgPool2d(2, 2)
+        self.if2 = sj.IFNode(v_threshold=1.0)
+
+    def forward(self, x):
+        x = self.if1(self.conv(x))
+        x = self.pool(x)
+        x = x.reshape(x.shape[0], 1, 1, x.shape[2], x.shape[3])
+        return self.if2(x)
+
+
+class AvgPoolTransformLIF(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(1, 1, 1, bias=False)
+        self.if1 = sj.IFNode(v_threshold=1.0)
+        self.pool = nn.AvgPool2d(2, 2)
+        self.lif2 = sj.LIFNode(tau=4.0, v_threshold=1.0)
+
+    def forward(self, x):
+        x = self.if1(self.conv(x))
+        x = self.pool(x)
+        x = x.reshape(x.shape[0], 1, 1, x.shape[2], x.shape[3])
+        return self.lif2(x)
+
+
+def test_compile_linear_transform_relu_keeps_visible_post_transform() -> None:
+    graph = compile_to_paiir(LinearTransformReLU(), torch.randn(1, 8))
+
+    seq = _single_node(
+        graph, SequentialOp, lambda node: isinstance(node.comp, nn.Linear)
+    )
+    transform = _single_node(graph, TransformOp)
+    assert seq.output_layouts[0].shape == torch.Size((1, 8))
+    assert transform.input_layouts == seq.output_layouts
+    assert transform.output_layouts[0].shape == torch.Size((1, 2, 4))
+
+
+def test_compile_fixed_point_removes_identity_post_transform_after_commutation() -> (
+    None
+):
+    graph = compile_to_paiir(LinearTransformReLUTransformBack(), torch.randn(1, 8))
+
+    seq = _single_node(
+        graph, SequentialOp, lambda node: isinstance(node.comp, nn.Linear)
+    )
+    assert seq.output_layouts[0].shape == torch.Size((1, 8))
+    assert not find_transform_nodes(graph)
+
+
+def test_compile_maxpool_transform_if_fuses_and_keeps_post_transform() -> None:
+    graph = compile_to_paiir(MaxPoolTransformIF(), torch.randn(1, 1, 4, 4))
+
+    seq = _single_node(
+        graph, SequentialOp, lambda node: isinstance(node.comp, nn.MaxPool2d)
+    )
+    transform = _single_node(graph, TransformOp)
+    assert isinstance(seq.act, IFNodeV25)
+    assert transform.input_layouts == seq.output_layouts
+
+
+def test_compile_avgpool_transform_ann_uses_shared_core_policy() -> None:
+    graph = compile_to_paiir(AvgPoolTransformANN(), torch.randn(1, 1, 4, 4))
+
+    avg_seq = _single_node(
+        graph, SequentialOp, lambda node: isinstance(node.comp, nn.AvgPool2d)
+    )
+    transform = _single_node(graph, TransformOp)
+    assert isinstance(avg_seq.act, ANNNodeV25)
+    assert isinstance(avg_seq.act.lut, LutSigmoid)
+    assert transform.input_layouts == avg_seq.output_layouts
+
+
+def test_compile_avgpool_transform_if_uses_split_core_policy() -> None:
+    graph = compile_to_paiir(AvgPoolTransformIF(), torch.randn(1, 1, 4, 4))
+
+    core1 = _single_node(
+        graph, SequentialOp, lambda node: isinstance(node.comp, SumPool2d)
+    )
+    act = _single_node(
+        graph, StandaloneActOp, lambda node: isinstance(node.act, IFNodeV25)
+    )
+    transform = _single_node(graph, TransformOp)
+    assert isinstance(core1.act, ANNNodeV25)
+    assert act.output_layouts == core1.output_layouts
+    assert transform.input_layouts == act.output_layouts
+
+
+def test_compile_avgpool_transform_lif_uses_shared_core_policy() -> None:
+    graph = compile_to_paiir(AvgPoolTransformLIF(), torch.randn(1, 1, 4, 4))
+
+    avg_seq = _single_node(
+        graph, SequentialOp, lambda node: isinstance(node.comp, nn.AvgPool2d)
+    )
+    transform = _single_node(graph, TransformOp)
+    assert isinstance(avg_seq.act, LIFNodeV25)
+    assert avg_seq.avgpool_deploy_metadata is not None
+    assert avg_seq.act.leak_multi_input == LeakMultiInputMode.ENABLE
+    assert transform.input_layouts == avg_seq.output_layouts

--- a/tests/paiir/pipeline/test_standalone_avgpool_rewrite.py
+++ b/tests/paiir/pipeline/test_standalone_avgpool_rewrite.py
@@ -1,9 +1,11 @@
+import pytest
 import torch
 from paicorelib import DataSign, DataWidth, ThresholdNegMode
 from spikingjelly.activation_based import neuron as sj
 from torch import nn
 
 from paibox.paiir import ANNNodeV25, IFNodeV25, LutLinear
+from paibox.paiir.exceptions import GraphValidationError
 from paibox.paiir.ir.op_node import SequentialOp, StandaloneCompOp
 from paibox.paiir.lowering.converter import register_neuron
 from paibox.paiir.nn import SumPool2d
@@ -118,15 +120,15 @@ def test_direct_input_avgpool_stays_standalone_when_source_mode_is_unknown() -> 
     assert isinstance(pool.comp, nn.AvgPool2d)
 
 
-def test_potential_predecessor_avgpool_stays_standalone() -> None:
+def test_potential_predecessor_avgpool_is_rejected_by_32bit_contract() -> None:
     model = PotentialStandaloneAvgPool().eval()
     with torch.no_grad():
         model.conv.weight.fill_(1)
 
-    graph = compile_to_paiir(model, torch.zeros(1, 1, 6, 6))
-
-    pool = _find_standalone_avgpool(graph)
-    assert isinstance(pool.comp, nn.AvgPool2d)
+    with pytest.raises(
+        GraphValidationError, match="StandaloneCompOp.*WIDTH_32BIT|WIDTH_32BIT"
+    ):
+        compile_to_paiir(model, torch.zeros(1, 1, 6, 6))
 
 
 def test_binary_majority_specializes_spike_predecessor_avgpool2d() -> None:


### PR DESCRIPTION
## Summary

- reduce transparent `TransformOp` chains as maximal safe segments instead of only collapsing adjacent pairs
- preserve split-core AvgPool pre-activation layout semantics when a visible post-activation transform remains after fusion
- add focused compile-level coverage for pre-activation transform commutation and expand transform-chain canonicalization cases
- align pipeline tests with the stricter `WIDTH_32BIT` consumer contract for concat and standalone AvgPool paths
- fold the small `SequentialOp.forward()` readability refactor into the main feature change