### PR TITLE
Refactor(paiir): unify signal semantics propagation

### DIFF
--- a/paibox/paiir/ir/__init__.py
+++ b/paibox/paiir/ir/__init__.py
@@ -14,7 +14,7 @@ from .calc_params import LutData, NeuronParams, OfflineCoreParams, OnlineCorePar
 from .core_neuron import ANNNodeV25, CoreNeuronV25, IFNodeV25, LIFNodeV25
 from .graph import Edge, PAIIRGraph
 from .ir_base import InputNode, OutputNode, PAIIRNode, TensorLayout
-from .signal_domain import SignalDomain
+from .signal_domain import SignalDomain, SignalSemantics
 from .add_ops import (
     AddOperandKind,
     AddOperandSpec,
@@ -85,6 +85,7 @@ __all__ = [
     "SequentialOp",
     "ShapeStage",
     "SignalDomain",
+    "SignalSemantics",
     "SplitOp",
     "StandaloneActOp",
     "StandaloneCompOp",

--- a/paibox/paiir/ir/ir_base.py
+++ b/paibox/paiir/ir/ir_base.py
@@ -49,13 +49,9 @@ class PAIIRNode:
         if hasattr(self, "shape") and self.shape:
             parts.append(f"shape={self.shape}")
         if self.signal_semantics.output_domain is not None:
-            parts.append(
-                f"output_domain={self.signal_semantics.output_domain.name}"
-            )
+            parts.append(f"output_domain={self.signal_semantics.output_domain.name}")
         if self.signal_semantics.known_code_range is not None:
-            parts.append(
-                f"known_code_range={self.signal_semantics.known_code_range}"
-            )
+            parts.append(f"known_code_range={self.signal_semantics.known_code_range}")
         return f"{self.__class__.__name__}({', '.join(parts)})"
 
 

--- a/paibox/paiir/ir/ir_base.py
+++ b/paibox/paiir/ir/ir_base.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 import torch
 
 from ._namespace import IRNamespace
-from .signal_domain import SignalDomain
+from .signal_domain import SignalSemantics
 
 __all__ = ["TensorLayout", "PAIIRNode", "InputNode", "OutputNode"]
 
@@ -35,27 +35,27 @@ class PAIIRNode:
     Each node is automatically assigned a unique name for identification
     within the computation graph.
 
-    ``output_domain`` is a node-level semantic annotation describing the signal
-    domain of the node's output:
-
-    - :class:`~paibox.paiir.ir.signal_domain.SignalDomain.VALUE`
-    - :class:`~paibox.paiir.ir.signal_domain.SignalDomain.POTENTIAL`
-
-    The current IR treats this as one value per node, not one value per output
-    port. This remains valid for today's multi-output ``SplitOp`` because all
-    split branches inherit the same output domain from the split input.
+    ``signal_semantics`` stores node-level compile-time signal semantics such
+    as the coarse VALUE/POTENTIAL domain and an optional exact VALUE code
+    range.
     """
 
     def __init__(self) -> None:
         self.name: str = _ir_namespace.create_name(self)
-        self.output_domain: SignalDomain | None = None
+        self.signal_semantics = SignalSemantics()
 
     def __repr__(self) -> str:
         parts = [f"name='{self.name}'"]
         if hasattr(self, "shape") and self.shape:
             parts.append(f"shape={self.shape}")
-        if self.output_domain is not None:
-            parts.append(f"output_domain={self.output_domain.name}")
+        if self.signal_semantics.output_domain is not None:
+            parts.append(
+                f"output_domain={self.signal_semantics.output_domain.name}"
+            )
+        if self.signal_semantics.known_code_range is not None:
+            parts.append(
+                f"known_code_range={self.signal_semantics.known_code_range}"
+            )
         return f"{self.__class__.__name__}({', '.join(parts)})"
 
 

--- a/paibox/paiir/ir/op_node.py
+++ b/paibox/paiir/ir/op_node.py
@@ -273,14 +273,14 @@ class OfflineCoreOp(OpNode):
     def _with_domain_derived_output_type(self, params: NeuronParams) -> NeuronParams:
         """Derive backend-visible output type from propagated frontend domain.
 
-        ``output_domain`` is the frontend semantic source of truth for whether a
+        ``signal_semantics.output_domain`` is the frontend semantic source of truth for whether a
         node emits VALUE- or POTENTIAL-domain data. When that annotation is
         available, keep backend-visible ``output_type`` aligned with it.
         """
-        if self.output_domain is None:
+        if self.signal_semantics.output_domain is None:
             return params
 
-        if self.output_domain is SignalDomain.VALUE:
+        if self.signal_semantics.output_domain is SignalDomain.VALUE:
             return replace(params, output_type=OutputType.VALUE)
         else:
             return replace(params, output_type=OutputType.POTENTIAL)

--- a/paibox/paiir/ir/signal_domain.py
+++ b/paibox/paiir/ir/signal_domain.py
@@ -1,8 +1,9 @@
 """IR-level signal-domain annotations."""
 
+from dataclasses import dataclass
 from enum import Enum, auto
 
-__all__ = ["SignalDomain"]
+__all__ = ["SignalDomain", "SignalSemantics"]
 
 
 class SignalDomain(Enum):
@@ -10,3 +11,11 @@ class SignalDomain(Enum):
 
     POTENTIAL = auto()
     VALUE = auto()
+
+
+@dataclass(slots=True)
+class SignalSemantics:
+    """Node-level signal semantics derived during compilation."""
+
+    output_domain: SignalDomain | None = None
+    known_code_range: tuple[int, int] | None = None

--- a/paibox/paiir/ir/value_code.py
+++ b/paibox/paiir/ir/value_code.py
@@ -1,0 +1,65 @@
+"""Shared VALUE-code range helpers used by IR and compile passes."""
+
+from collections.abc import Sequence
+
+from paicorelib import DataSign, DataWidth
+
+__all__ = [
+    "SIGNED_VALUE_CODE_RANGES",
+    "UNSIGNED_VALUE_CODE_RANGES",
+    "ValueCodeRange",
+    "code_range_for_data_format",
+    "code_range_for_format",
+    "fits_value_code_range",
+    "merge_code_ranges",
+]
+
+ValueCodeRange = tuple[int, int]
+
+SIGNED_VALUE_CODE_RANGES: dict[DataWidth, ValueCodeRange] = {
+    DataWidth.WIDTH_1BIT: (-1, 0),
+    DataWidth.WIDTH_2BIT: (-2, 1),
+    DataWidth.WIDTH_4BIT: (-8, 7),
+    DataWidth.WIDTH_8BIT: (-128, 127),
+}
+
+UNSIGNED_VALUE_CODE_RANGES: dict[DataWidth, ValueCodeRange] = {
+    DataWidth.WIDTH_1BIT: (0, 1),
+    DataWidth.WIDTH_2BIT: (0, 3),
+    DataWidth.WIDTH_4BIT: (0, 15),
+    DataWidth.WIDTH_8BIT: (0, 255),
+}
+
+
+def code_range_for_format(sign: DataSign, width: DataWidth) -> ValueCodeRange:
+    ranges = (
+        SIGNED_VALUE_CODE_RANGES
+        if sign == DataSign.SIGNED
+        else UNSIGNED_VALUE_CODE_RANGES
+    )
+    return ranges[width]
+
+
+def code_range_for_data_format(
+    fmt: tuple[DataSign, DataWidth],
+) -> ValueCodeRange:
+    sign, width = fmt
+    return code_range_for_format(sign, width)
+
+
+def fits_value_code_range(value_min: int, value_max: int) -> bool:
+    """Return whether one integer code range fits the 8-bit VALUE path."""
+    if value_min < 0:
+        lo, hi = SIGNED_VALUE_CODE_RANGES[DataWidth.WIDTH_8BIT]
+        return lo <= value_min and value_max <= hi
+
+    lo, hi = UNSIGNED_VALUE_CODE_RANGES[DataWidth.WIDTH_8BIT]
+    return lo <= value_min and value_max <= hi
+
+
+def merge_code_ranges(
+    code_ranges: Sequence[ValueCodeRange],
+) -> ValueCodeRange | None:
+    if not code_ranges:
+        return None
+    return min(lo for lo, _ in code_ranges), max(hi for _, hi in code_ranges)

--- a/paibox/paiir/pipeline/avgpool/standalone_rewrite.py
+++ b/paibox/paiir/pipeline/avgpool/standalone_rewrite.py
@@ -111,7 +111,7 @@ def _get_effective_value_source_mode(node: PAIIRNode) -> SNNMode | None:
     if not isinstance(node, OfflineCoreOp):
         return None
 
-    if node.output_domain is not SignalDomain.VALUE:
+    if node.signal_semantics.output_domain is not SignalDomain.VALUE:
         return None
 
     if isinstance(node, (SequentialOp, StandaloneActOp)):

--- a/paibox/paiir/pipeline/compile.py
+++ b/paibox/paiir/pipeline/compile.py
@@ -38,7 +38,7 @@ from .passes import (
     calibrate_avgpool_thresholds,
     fuse_to_offline_cores,
     propagate_data_format,
-    propagate_signal_domain,
+    propagate_signal_semantics,
     specialize_general_adds,
     validate_compiled_graph,
     validate_deployable_graph,
@@ -84,14 +84,14 @@ def compile_to_paiir(
        into deployable add IR where possible
     4. :func:`fuse_to_offline_cores` -- choose topology, rewrite nodes, and
        apply AvgPool deployment params
-    5. analysis phase -- validate graph, infer signal domains, infer data formats
+    5. analysis phase -- validate graph, infer signal semantics, infer data formats
     6. standalone AvgPool auto-rewrite that depends on those analyses
     7. re-run the analysis phase if a rewrite changed the graph
     8. :func:`assign_tick_params` -- assign timing parameters
     9. :func:`calibrate_avgpool_thresholds` -- (experimental) refine shared-core
        AvgPool+LIF thresholds via offline integer search
     10. :func:`validate_compiled_graph` -- final post-pass graph validation
-        after connectivity cleanup, signal-domain propagation, data-format
+        after connectivity cleanup, signal-semantics propagation, data-format
         propagation, and tick assignment
     11. :func:`validate_deployable_graph` -- ensure no frontend-only IR remains
     """
@@ -140,7 +140,7 @@ def _run_mid_compile_analyses(
 ) -> PAIIRGraph:
     """Run the standard analysis phase for a topology-stable graph."""
     validate_graph(graph)
-    propagate_signal_domain(graph)
+    propagate_signal_semantics(graph, input_formats)
     propagate_data_format(graph, input_formats)
     return graph
 

--- a/paibox/paiir/pipeline/compile.py
+++ b/paibox/paiir/pipeline/compile.py
@@ -34,15 +34,13 @@ from .layout_chain_canonicalization import canonicalize_layout_chains
 from .layout_cross_node_elision import commute_pre_activation_transforms
 from .passes import (
     TickOverride,
+    analyze_graph,
     assign_tick_params,
     calibrate_avgpool_thresholds,
     fuse_to_offline_cores,
-    propagate_data_format,
-    propagate_signal_semantics,
     specialize_general_adds,
     validate_compiled_graph,
     validate_deployable_graph,
-    validate_graph,
 )
 from .rewrite_phase import RewritePass, run_fixed_point_rewrite_phase
 
@@ -135,16 +133,6 @@ def compile_to_paiir(
     return graph
 
 
-def _run_mid_compile_analyses(
-    graph: PAIIRGraph, input_formats: dict[str, DataFormat] | None
-) -> PAIIRGraph:
-    """Run the standard analysis phase for a topology-stable graph."""
-    validate_graph(graph)
-    propagate_signal_semantics(graph, input_formats)
-    propagate_data_format(graph, input_formats)
-    return graph
-
-
 def _pre_fusion_rewrite_passes() -> tuple[RewritePass, ...]:
     """Return ordered topology rewrites that may interact before fusion."""
     return (
@@ -177,6 +165,6 @@ def _run_post_fusion_rewrite_phase(
     return run_fixed_point_rewrite_phase(
         graph,
         rewrite_passes,
-        lambda g: _run_mid_compile_analyses(g, input_formats),
+        lambda g: analyze_graph(g, input_formats),
         max_rounds,
     )

--- a/paibox/paiir/pipeline/data_format.py
+++ b/paibox/paiir/pipeline/data_format.py
@@ -11,7 +11,6 @@ data-format groups in :class:`OfflineCoreParams`:
 from collections.abc import Sequence
 
 import torch
-
 from paicorelib import DataSign, DataWidth, ThresholdNegMode
 
 from ..ir.core_neuron import CoreNeuronV25
@@ -32,6 +31,7 @@ __all__ = [
 
 
 DataFormat = tuple[DataSign, DataWidth]
+
 
 def _infer_narrowest_range_format(
     value_min: int, value_max: int, sign: DataSign, label: str

--- a/paibox/paiir/pipeline/data_format.py
+++ b/paibox/paiir/pipeline/data_format.py
@@ -10,12 +10,21 @@ data-format groups in :class:`OfflineCoreParams`:
 
 from collections.abc import Sequence
 
+import torch
+
 from paicorelib import DataSign, DataWidth, ThresholdNegMode
 
 from ..ir.core_neuron import CoreNeuronV25
+from ..ir.value_code import (
+    SIGNED_VALUE_CODE_RANGES as _SIGNED_RANGES,
+    UNSIGNED_VALUE_CODE_RANGES as _UNSIGNED_RANGES,
+    fits_value_code_range,
+)
 
 __all__ = [
     "DataFormat",
+    "fits_value_code_range",
+    "infer_output_code_range",
     "infer_output_format",
     "infer_weight_format",
     "merge_data_formats",
@@ -23,23 +32,6 @@ __all__ = [
 
 
 DataFormat = tuple[DataSign, DataWidth]
-
-# Bit ranges for each DataWidth (signed)
-_SIGNED_RANGES: dict[DataWidth, tuple[int, int]] = {
-    DataWidth.WIDTH_1BIT: (-1, 0),
-    DataWidth.WIDTH_2BIT: (-2, 1),
-    DataWidth.WIDTH_4BIT: (-8, 7),
-    DataWidth.WIDTH_8BIT: (-128, 127),
-}
-
-# Bit ranges for each DataWidth (unsigned)
-_UNSIGNED_RANGES: dict[DataWidth, tuple[int, int]] = {
-    DataWidth.WIDTH_1BIT: (0, 1),
-    DataWidth.WIDTH_2BIT: (0, 3),
-    DataWidth.WIDTH_4BIT: (0, 15),
-    DataWidth.WIDTH_8BIT: (0, 255),
-}
-
 
 def _infer_narrowest_range_format(
     value_min: int, value_max: int, sign: DataSign, label: str
@@ -85,6 +77,28 @@ def infer_output_format(act: CoreNeuronV25) -> tuple[DataSign, DataWidth]:
     value_min = int(lut.lut_values.min().item())
     value_max = int(lut.lut_values.max().item())
     return _infer_narrowest_range_format(value_min, value_max, sign, "LUT activation")
+
+
+def infer_output_code_range(act: CoreNeuronV25) -> tuple[int, int] | None:
+    """Infer the exact integer VALUE-code range emitted by an activation."""
+    if act.is_snn:
+        if act.thres_neg_mode == ThresholdNegMode.FIRE:
+            return -1, 1
+        return 0, 1
+
+    lut = act.lut
+    if lut is None:
+        return None
+
+    values = lut.lut_values.detach().to(torch.float32)
+    if not torch.allclose(values, values.round()):
+        return None
+
+    value_min = int(values.min().item())
+    value_max = int(values.max().item())
+    if not fits_value_code_range(value_min, value_max):
+        return None
+    return value_min, value_max
 
 
 def infer_weight_format(weight_min: int, weight_max: int) -> tuple[DataSign, DataWidth]:

--- a/paibox/paiir/pipeline/data_format.py
+++ b/paibox/paiir/pipeline/data_format.py
@@ -16,8 +16,8 @@ from paicorelib import DataSign, DataWidth, ThresholdNegMode
 
 from ..ir.core_neuron import CoreNeuronV25
 from ..ir.value_code import (
-    SIGNED_VALUE_CODE_RANGES as _SIGNED_RANGES,
-    UNSIGNED_VALUE_CODE_RANGES as _UNSIGNED_RANGES,
+    SIGNED_VALUE_CODE_RANGES,
+    UNSIGNED_VALUE_CODE_RANGES,
     fits_value_code_range,
 )
 
@@ -36,7 +36,11 @@ DataFormat = tuple[DataSign, DataWidth]
 def _infer_narrowest_range_format(
     value_min: int, value_max: int, sign: DataSign, label: str
 ) -> tuple[DataSign, DataWidth]:
-    ranges = _SIGNED_RANGES if sign == DataSign.SIGNED else _UNSIGNED_RANGES
+    ranges = (
+        SIGNED_VALUE_CODE_RANGES
+        if sign == DataSign.SIGNED
+        else UNSIGNED_VALUE_CODE_RANGES
+    )
 
     for width, (lo, hi) in ranges.items():
         if lo <= value_min and value_max <= hi:

--- a/paibox/paiir/pipeline/passes.py
+++ b/paibox/paiir/pipeline/passes.py
@@ -61,6 +61,7 @@ from .graph_utils import (
 )
 
 __all__ = [
+    "analyze_graph",
     "assign_tick_params",
     "calibrate_avgpool_thresholds",
     "CalibrationResult",
@@ -85,6 +86,16 @@ _DEPLOYABLE_GRAPH_NODE_TYPES = (
     StandaloneCompOp,
     StandaloneActOp,
 )
+
+
+def analyze_graph(
+    graph: PAIIRGraph, input_formats: dict[str, DataFormat] | None = None
+) -> PAIIRGraph:
+    """Run the standard compile-time graph analyses in dependency order."""
+    validate_graph(graph)
+    propagate_signal_semantics(graph, input_formats)
+    propagate_data_format(graph, input_formats)
+    return graph
 
 
 def _layout_shapes(node: OpNode) -> tuple[torch.Size, ...]:

--- a/paibox/paiir/pipeline/passes.py
+++ b/paibox/paiir/pipeline/passes.py
@@ -24,6 +24,7 @@ from paicorelib import AddPotentialMode, DataSign, DataWidth, OutputType, SNNMod
 
 from ..exceptions import GraphCleanupWarning, GraphValidationError
 from ..ir.add_ops import GeneralAddOp, PotentialAddOp
+from ..ir.core_neuron import CoreNeuronV25
 from ..ir.graph import Edge, PAIIRGraph
 from ..ir.ir_base import InputNode, OutputNode, PAIIRNode
 from ..ir.op_node import (
@@ -40,12 +41,14 @@ from ..ir.op_node import (
 from ..ir.reshape_semantics import shape_after_dims
 from ..ir.signal_domain import SignalDomain
 from ..ir.utils import infer_split_output_shapes
+from ..ir.value_code import code_range_for_data_format, merge_code_ranges
 from .avgpool import calibrate_avgpool_thresholds
 from .avgpool.calibration import CalibrationResult
 from .avgpool.fusion import _try_handle_avgpool_activation
 from .avgpool.utils import _is_avgpool
 from .data_format import (
     DataFormat,
+    infer_output_code_range,
     infer_output_format,
     infer_weight_format,
     merge_data_formats,
@@ -62,7 +65,7 @@ __all__ = [
     "calibrate_avgpool_thresholds",
     "CalibrationResult",
     "fuse_to_offline_cores",
-    "propagate_signal_domain",
+    "propagate_signal_semantics",
     "propagate_data_format",
     "specialize_general_adds",
     "TickOverride",
@@ -396,12 +399,12 @@ def validate_compiled_graph(graph: PAIIRGraph) -> None:
 
     for name, node in graph.nodes.items():
         if isinstance(node, InputNode):
-            if node.output_domain is None:
+            if node.signal_semantics.output_domain is None:
                 errors.append(f"InputNode '{name}' is missing output_domain")
             continue
 
         if isinstance(node, OutputNode):
-            if node.output_domain is None:
+            if node.signal_semantics.output_domain is None:
                 errors.append(f"OutputNode '{name}' is missing output_domain")
             continue
 
@@ -419,7 +422,7 @@ def validate_compiled_graph(graph: PAIIRGraph) -> None:
                 errors.append(f"SplitOp '{name}' is missing input layout dims")
             if not node.output_layouts:
                 errors.append(f"SplitOp '{name}' is missing output_layouts")
-            if node.output_domain is None:
+            if node.signal_semantics.output_domain is None:
                 errors.append(f"SplitOp '{name}' is missing output_domain")
             _validate_split_contract(errors, graph, name, node)
             continue
@@ -440,7 +443,7 @@ def validate_compiled_graph(graph: PAIIRGraph) -> None:
             not layout.dims for layout in node.output_layouts
         ):
             errors.append(f"OpNode '{name}' is missing output layout dims")
-        if node.output_domain is None:
+        if node.signal_semantics.output_domain is None:
             errors.append(f"OpNode '{name}' is missing output_domain")
 
         if isinstance(node, ConcatOp):
@@ -476,7 +479,7 @@ def validate_compiled_graph(graph: PAIIRGraph) -> None:
 def _validate_output_domain_consistency(
     errors: list[str], name: str, node: OfflineCoreOp
 ) -> None:
-    if (domain := node.output_domain) is None:
+    if (domain := node.signal_semantics.output_domain) is None:
         return
 
     output_type = node.neuron_params.output_type
@@ -765,34 +768,49 @@ def _validate_split_contract(
             )
 
 
-def propagate_signal_domain(graph: PAIIRGraph) -> None:
-    """Infer and fill node-level ``output_domain`` for every graph node.
+def propagate_signal_semantics(
+    graph: PAIIRGraph, input_formats: dict[str, DataFormat] | None = None
+) -> None:
+    """Infer and fill node-level semantic annotations for every graph node.
 
-    ``output_domain`` is currently a single semantic value per node rather than
-    a per-output-port annotation. This is sufficient for the current IR because
-    routing-only nodes preserve the signal domain of their inputs:
+    This pass writes:
 
-    - ``TransformOp`` inherits its sole predecessor domain
-    - ``SplitOp`` inherits its sole predecessor domain, and all split branches
-      therefore share that same domain
-    - ``ConcatOp`` requires all predecessors to agree on one domain, then
-      forwards that domain to its output
+    - ``signal_semantics.output_domain``: coarse VALUE vs POTENTIAL semantics
+    - ``signal_semantics.known_code_range``: optional exact VALUE code range when derivable
     """
+    if input_formats is None:
+        input_formats = {}
+
+    input_node_names = {
+        n for n, node in graph.nodes.items() if isinstance(node, InputNode)
+    }
+    for name in input_formats:
+        if name not in input_node_names:
+            warnings.warn(
+                f"input_formats key '{name}' does not match any InputNode in the graph"
+            )
+
+    for node in graph.nodes.values():
+        node.signal_semantics.output_domain = None
+        node.signal_semantics.known_code_range = None
+
     errors: list[str] = []
 
     for name in graph.topo_sort():
         node = graph.nodes[name]
 
         if isinstance(node, InputNode):
-            # Current minimal policy: external feeds enter the IR in VALUE
-            # domain. This is intentionally conservative and may need to be
-            # revisited if future frontends support explicit membrane-domain
-            # inputs or richer input-domain annotations.
-            node.output_domain = SignalDomain.VALUE
+            _set_node_signal_semantics(
+                node,
+                SignalDomain.VALUE,
+                code_range_for_data_format(
+                    _resolve_input_node_format(graph, name, input_formats)
+                ),
+            )
             continue
 
         preds = graph.predecessors(name)
-        pred_domains = [graph.nodes[p].output_domain for p in preds]
+        pred_domains = [graph.nodes[p].signal_semantics.output_domain for p in preds]
         if any(domain is None for domain in pred_domains):
             errors.append(
                 f"{type(node).__name__} '{name}' predecessor output_domain is missing"
@@ -800,20 +818,33 @@ def propagate_signal_domain(graph: PAIIRGraph) -> None:
             continue
 
         known_pred_domains = [domain for domain in pred_domains if domain is not None]
+        pred_code_ranges = _present_predecessor_known_code_ranges(graph, preds)
 
         if isinstance(node, OutputNode):
             if known_pred_domains:
-                node.output_domain = known_pred_domains[0]
+                _set_node_signal_semantics(
+                    node,
+                    known_pred_domains[0],
+                    _single_predecessor_known_code_range(graph, name),
+                )
             continue
 
         if isinstance(node, TransformOp):
             if known_pred_domains:
-                node.output_domain = known_pred_domains[0]
+                _set_node_signal_semantics(
+                    node,
+                    known_pred_domains[0],
+                    _single_predecessor_known_code_range(graph, name),
+                )
             continue
 
         if isinstance(node, SplitOp):
             if known_pred_domains:
-                node.output_domain = known_pred_domains[0]
+                _set_node_signal_semantics(
+                    node,
+                    known_pred_domains[0],
+                    _single_predecessor_known_code_range(graph, name),
+                )
             continue
 
         if isinstance(node, ConcatOp):
@@ -826,7 +857,11 @@ def propagate_signal_domain(graph: PAIIRGraph) -> None:
                 )
                 continue
             if known_pred_domains:
-                node.output_domain = known_pred_domains[0]
+                _set_node_signal_semantics(
+                    node,
+                    known_pred_domains[0],
+                    _merged_predecessor_known_code_range(graph, name),
+                )
             continue
 
         if isinstance(node, GeneralAddOp):
@@ -839,9 +874,9 @@ def propagate_signal_domain(graph: PAIIRGraph) -> None:
                 )
                 continue
             if known_pred_domains:
-                node.output_domain = known_pred_domains[0]
+                _set_node_signal_semantics(node, known_pred_domains[0], None)
             elif node.has_const_operands:
-                node.output_domain = SignalDomain.VALUE
+                _set_node_signal_semantics(node, SignalDomain.VALUE, None)
             else:
                 errors.append(f"GeneralAddOp '{name}' cannot infer output_domain")
             continue
@@ -855,16 +890,33 @@ def propagate_signal_domain(graph: PAIIRGraph) -> None:
                     f"{[domain.name for domain in known_pred_domains]}"
                 )
                 continue
-            node.output_domain = SignalDomain.POTENTIAL
+            _set_node_signal_semantics(node, SignalDomain.POTENTIAL, None)
             continue
 
         if is_standalone_maxpool(node):
+            if known_pred_domains and any(
+                domain is not SignalDomain.VALUE for domain in known_pred_domains
+            ):
+                errors.append(
+                    f"Standalone MaxPool '{name}' requires VALUE-domain predecessor, got "
+                    f"{[domain.name for domain in known_pred_domains]}"
+                )
+                continue
             if known_pred_domains:
-                node.output_domain = known_pred_domains[0]
+                _set_node_signal_semantics(
+                    node,
+                    SignalDomain.VALUE,
+                    _merged_predecessor_known_code_range(graph, name),
+                )
             continue
 
         if isinstance(node, OfflineCoreOp):
-            node.output_domain = _infer_output_signal_domain(node)
+            domain = _infer_output_signal_domain(node)
+            _set_node_signal_semantics(
+                node,
+                domain,
+                _infer_node_known_code_range(node, domain, pred_code_ranges),
+            )
             continue
 
     if errors:
@@ -875,6 +927,73 @@ def _infer_output_signal_domain(node: OfflineCoreOp) -> SignalDomain:
     if node.neuron_params.output_type == OutputType.POTENTIAL:
         return SignalDomain.POTENTIAL
     return SignalDomain.VALUE
+
+
+def _set_node_signal_semantics(
+    node: PAIIRNode,
+    output_domain: SignalDomain,
+    known_code_range: tuple[int, int] | None,
+) -> None:
+    node.signal_semantics.output_domain = output_domain
+    node.signal_semantics.known_code_range = known_code_range
+
+
+def _resolve_input_node_format(
+    graph: PAIIRGraph, name: str, input_formats: dict[str, DataFormat]
+) -> DataFormat:
+    return (
+        input_formats[name]
+        if name in input_formats
+        else _infer_input_node_default(graph, name)
+    )
+
+
+def _single_predecessor_known_code_range(
+    graph: PAIIRGraph, node_name: str
+) -> tuple[int, int] | None:
+    preds = graph.predecessors(node_name)
+    if not preds:
+        return None
+    return graph.nodes[preds[0]].signal_semantics.known_code_range
+
+
+def _merged_predecessor_known_code_range(
+    graph: PAIIRGraph, node_name: str
+) -> tuple[int, int] | None:
+    preds = graph.predecessors(node_name)
+    pred_ranges = [graph.nodes[p].signal_semantics.known_code_range for p in preds]
+    if not preds or any(code_range is None for code_range in pred_ranges):
+        return None
+    return merge_code_ranges(
+        [code_range for code_range in pred_ranges if code_range is not None]
+    )
+
+
+def _present_predecessor_known_code_ranges(
+    graph: PAIIRGraph, preds: list[str]
+) -> list[tuple[int, int]]:
+    present: list[tuple[int, int]] = []
+    for pred_name in preds:
+        code_range = graph.nodes[pred_name].signal_semantics.known_code_range
+        if code_range is not None:
+            present.append(code_range)
+    return present
+
+
+def _infer_node_known_code_range(
+    node: OfflineCoreOp,
+    output_domain: SignalDomain,
+    pred_code_ranges: list[tuple[int, int]],
+) -> tuple[int, int] | None:
+    if output_domain is not SignalDomain.VALUE:
+        return None
+    if is_standalone_maxpool(node):
+        return merge_code_ranges(pred_code_ranges)
+
+    act = _get_node_act(node)
+    if act is None:
+        return None
+    return infer_output_code_range(act)
 
 
 def validate_deployable_graph(graph: PAIIRGraph) -> None:
@@ -902,7 +1021,8 @@ def validate_deployable_graph(graph: PAIIRGraph) -> None:
 
         if isinstance(node, PotentialAddOp):
             pred_domains = [
-                graph.nodes[p].output_domain for p in graph.predecessors(name)
+                graph.nodes[p].signal_semantics.output_domain
+                for p in graph.predecessors(name)
             ]
             if any(domain is None for domain in pred_domains):
                 errors.append(
@@ -923,7 +1043,8 @@ def validate_deployable_graph(graph: PAIIRGraph) -> None:
 
         if isinstance(node, ConcatOp):
             pred_domains = [
-                graph.nodes[p].output_domain for p in graph.predecessors(name)
+                graph.nodes[p].signal_semantics.output_domain
+                for p in graph.predecessors(name)
             ]
             if any(domain is None for domain in pred_domains):
                 errors.append(f"ConcatOp '{name}' predecessor output_domain is missing")
@@ -1031,7 +1152,7 @@ def _validate_potential_add_contract(
 def _validate_lut_mode_consistency(
     errors: list[str], name: str, node: OfflineCoreOp
 ) -> None:
-    act = getattr(node, "act", None)
+    act = _get_node_act(node)
     if act is None:
         return
 
@@ -1098,9 +1219,6 @@ def propagate_data_format(
                 f"input_formats key '{name}' does not match any InputNode in the graph"
             )
 
-    # Effective data format per graph node, including routing-only nodes and
-    # graph boundaries. This is separate from `core_params`, which only exists
-    # on deployable offline-core operators.
     resolved: dict[str, DataFormat] = {}
 
     # Pass 1: establish each deployable core's own output and weight formats.
@@ -1110,11 +1228,7 @@ def propagate_data_format(
         node = graph.nodes[name]
 
         if isinstance(node, InputNode):
-            resolved[name] = (
-                input_formats[name]
-                if name in input_formats
-                else _infer_input_node_default(graph, name)
-            )
+            resolved[name] = _resolve_input_node_format(graph, name, input_formats)
             continue
         if isinstance(node, OutputNode):
             continue
@@ -1216,7 +1330,7 @@ def _infer_node_output_format(
     if output_type == OutputType.POTENTIAL:
         return DataSign.SIGNED, DataWidth.WIDTH_32BIT
 
-    act = getattr(node, "act", None)
+    act = _get_node_act(node)
     if act is None:
         raise ValueError(
             f"OfflineCoreOp '{node.name}' declares {output_type.name} output but has no "
@@ -1261,6 +1375,11 @@ def _derive_input_add_potential_mode(
         node.core_params.add_potential = AddPotentialMode.DIRECT_ADD
     else:
         node.core_params.add_potential = AddPotentialMode.NORMAL
+
+
+def _get_node_act(node: OfflineCoreOp) -> CoreNeuronV25 | None:
+    act = getattr(node, "act", None)
+    return act if isinstance(act, CoreNeuronV25) else None
 
 
 class TickOverride(TypedDict, total=False):

--- a/tests/paiir/ir/test_op_node.py
+++ b/tests/paiir/ir/test_op_node.py
@@ -211,10 +211,10 @@ class TestWeights:
     def test_standalone_comp_neuron_params_follow_output_domain(self):
         op = StandaloneCompOp(comp=nn.MaxPool2d(2))
 
-        op.output_domain = SignalDomain.VALUE
+        op.signal_semantics.output_domain = SignalDomain.VALUE
         assert op.neuron_params.output_type == OutputType.VALUE
 
-        op.output_domain = SignalDomain.POTENTIAL
+        op.signal_semantics.output_domain = SignalDomain.POTENTIAL
         assert op.neuron_params.output_type == OutputType.POTENTIAL
 
     def test_add_op_returns_none(self):

--- a/tests/paiir/pipeline/test_data_format.py
+++ b/tests/paiir/pipeline/test_data_format.py
@@ -35,8 +35,8 @@ from paibox.paiir.pipeline.data_format import (
 )
 from paibox.paiir.pipeline.passes import (
     fuse_to_offline_cores,
-    propagate_signal_semantics,
     propagate_data_format,
+    propagate_signal_semantics,
     specialize_general_adds,
 )
 from tests.paiir.conftest import (

--- a/tests/paiir/pipeline/test_data_format.py
+++ b/tests/paiir/pipeline/test_data_format.py
@@ -35,6 +35,7 @@ from paibox.paiir.pipeline.data_format import (
 )
 from paibox.paiir.pipeline.passes import (
     fuse_to_offline_cores,
+    propagate_signal_semantics,
     propagate_data_format,
     specialize_general_adds,
 )
@@ -349,6 +350,7 @@ class TestPropagateDataFormatANN:
         fused = fuse_to_offline_cores(specialize_general_adds(unfused))
 
         inp_name = fused.input_nodes()[0].name
+        propagate_signal_semantics(fused, input_formats={inp_name: input_format})
         propagate_data_format(fused, input_formats={inp_name: input_format})
 
         pool = next(

--- a/tests/paiir/pipeline/test_passes.py
+++ b/tests/paiir/pipeline/test_passes.py
@@ -6,7 +6,7 @@ in `PAIBox/paibox/paiir/pipeline/passes.py`:
 - add specialization / fusion
 - tick assignment
 - validation / deployability checks
-- signal-domain propagation
+- signal-semantics propagation
 """
 
 import pytest
@@ -15,7 +15,12 @@ from paicorelib import DataSign, DataWidth, OutputType, PoolingMode, SNNMode
 from spikingjelly.activation_based import neuron as sj
 from torch import nn
 
-from paibox.paiir.ir.add_ops import AddOperandKind, GeneralAddOp, PotentialAddOp
+from paibox.paiir.ir.add_ops import (
+    AddOperandKind,
+    AddOperandSpec,
+    GeneralAddOp,
+    PotentialAddOp,
+)
 from paibox.paiir.ir.calc_params import OfflineCoreParams
 from paibox.paiir.ir.core_neuron import ANNNodeV25, CoreNeuronV25, IFNodeV25, LIFNodeV25
 from paibox.paiir.ir.graph import Edge, PAIIRGraph
@@ -41,7 +46,7 @@ from paibox.paiir.pipeline.passes import (
     assign_tick_params,
     fuse_to_offline_cores,
     propagate_data_format,
-    propagate_signal_domain,
+    propagate_signal_semantics,
     specialize_general_adds,
     validate_compiled_graph,
     validate_deployable_graph,
@@ -871,9 +876,9 @@ class TestValidateCompiledGraph:
         op.core_params.tick_duration = 0
         op.core_params.tick_initial = 0
         out = OutputNode()
-        inp.output_domain = SignalDomain.VALUE
-        op.output_domain = SignalDomain.VALUE
-        out.output_domain = SignalDomain.VALUE
+        inp.signal_semantics.output_domain = SignalDomain.VALUE
+        op.signal_semantics.output_domain = SignalDomain.VALUE
+        out.signal_semantics.output_domain = SignalDomain.VALUE
         graph.add_node(inp)
         graph.add_node(op)
         graph.add_node(out)
@@ -911,7 +916,7 @@ class TestValidateCompiledGraph:
             node.core_params.tick_start = 1
             node.core_params.tick_duration = 0
             node.core_params.tick_initial = 0
-            node.output_domain = SignalDomain.VALUE
+            node.signal_semantics.output_domain = SignalDomain.VALUE
 
         inp = graph.input_nodes()[0]
         graph.add_node(branch)
@@ -931,10 +936,10 @@ class TestValidateCompiledGraph:
         cat = ConcatOp(dim=1)
         out = OutputNode()
 
-        inp_a.output_domain = SignalDomain.VALUE
-        inp_b.output_domain = SignalDomain.VALUE
-        cat.output_domain = SignalDomain.VALUE
-        out.output_domain = SignalDomain.VALUE
+        inp_a.signal_semantics.output_domain = SignalDomain.VALUE
+        inp_b.signal_semantics.output_domain = SignalDomain.VALUE
+        cat.signal_semantics.output_domain = SignalDomain.VALUE
+        out.signal_semantics.output_domain = SignalDomain.VALUE
 
         _set_multi_input_single_output_layouts(
             cat,
@@ -963,9 +968,9 @@ class TestValidateCompiledGraph:
         split = SplitOp(sections=(2, 4), dim=1)
         out = OutputNode()
 
-        inp.output_domain = SignalDomain.VALUE
-        split.output_domain = SignalDomain.VALUE
-        out.output_domain = SignalDomain.VALUE
+        inp.signal_semantics.output_domain = SignalDomain.VALUE
+        split.signal_semantics.output_domain = SignalDomain.VALUE
+        out.signal_semantics.output_domain = SignalDomain.VALUE
 
         split.input_layouts = (_layout((1, 5), (0, 1)),)
 
@@ -1004,13 +1009,16 @@ class TestSplitPassBehavior:
     def test_signal_domain_and_data_format_propagate_through_split(self):
         graph, inp, split, act = self._build_split_routing_graph()
 
-        propagate_signal_domain(graph)
+        propagate_signal_semantics(
+            graph,
+            input_formats={inp.name: (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT)},
+        )
         propagate_data_format(
             graph, input_formats={inp.name: (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT)}
         )
 
-        assert split.output_domain is SignalDomain.VALUE
-        assert act.output_domain is SignalDomain.VALUE
+        assert split.signal_semantics.output_domain is SignalDomain.VALUE
+        assert act.signal_semantics.output_domain is SignalDomain.VALUE
         assert act.core_params.input_sign == DataSign.UNSIGNED
         assert act.core_params.input_width == DataWidth.WIDTH_1BIT
 
@@ -1045,9 +1053,9 @@ class TestValidateDeployableGraph:
         cpu = CPUOp()
         out = OutputNode()
 
-        inp.output_domain = SignalDomain.VALUE
-        cpu.output_domain = SignalDomain.VALUE
-        out.output_domain = SignalDomain.VALUE
+        inp.signal_semantics.output_domain = SignalDomain.VALUE
+        cpu.signal_semantics.output_domain = SignalDomain.VALUE
+        out.signal_semantics.output_domain = SignalDomain.VALUE
 
         graph.add_node(inp)
         graph.add_node(cpu)
@@ -1064,9 +1072,9 @@ class TestValidateDeployableGraph:
         split = SplitOp(sections=2, dim=1)
         out = OutputNode()
 
-        inp.output_domain = SignalDomain.VALUE
-        split.output_domain = SignalDomain.VALUE
-        out.output_domain = SignalDomain.VALUE
+        inp.signal_semantics.output_domain = SignalDomain.VALUE
+        split.signal_semantics.output_domain = SignalDomain.VALUE
+        out.signal_semantics.output_domain = SignalDomain.VALUE
 
         graph.add_node(inp)
         graph.add_node(split)
@@ -1084,10 +1092,10 @@ class TestValidateDeployableGraph:
         add = PotentialAddOp(op_signs=(1, 1))
         out = OutputNode()
 
-        inp_a.output_domain = SignalDomain.VALUE
-        inp_b.output_domain = SignalDomain.VALUE
-        add.output_domain = SignalDomain.POTENTIAL
-        out.output_domain = SignalDomain.POTENTIAL
+        inp_a.signal_semantics.output_domain = SignalDomain.VALUE
+        inp_b.signal_semantics.output_domain = SignalDomain.VALUE
+        add.signal_semantics.output_domain = SignalDomain.POTENTIAL
+        out.signal_semantics.output_domain = SignalDomain.POTENTIAL
 
         graph.add_node(inp_a)
         graph.add_node(inp_b)
@@ -1107,10 +1115,10 @@ class TestValidateDeployableGraph:
         cat = ConcatOp(dim=1)
         out = OutputNode()
 
-        inp_a.output_domain = SignalDomain.VALUE
-        inp_b.output_domain = SignalDomain.POTENTIAL
-        cat.output_domain = SignalDomain.VALUE
-        out.output_domain = SignalDomain.VALUE
+        inp_a.signal_semantics.output_domain = SignalDomain.VALUE
+        inp_b.signal_semantics.output_domain = SignalDomain.POTENTIAL
+        cat.signal_semantics.output_domain = SignalDomain.VALUE
+        out.signal_semantics.output_domain = SignalDomain.VALUE
 
         graph.add_node(inp_a)
         graph.add_node(inp_b)
@@ -1134,10 +1142,10 @@ class TestValidateDeployableGraph:
         )
         out = OutputNode()
 
-        inp_a.output_domain = SignalDomain.VALUE
-        inp_b.output_domain = SignalDomain.VALUE
-        acc.output_domain = SignalDomain.VALUE
-        out.output_domain = SignalDomain.VALUE
+        inp_a.signal_semantics.output_domain = SignalDomain.VALUE
+        inp_b.signal_semantics.output_domain = SignalDomain.VALUE
+        acc.signal_semantics.output_domain = SignalDomain.VALUE
+        out.signal_semantics.output_domain = SignalDomain.VALUE
         _set_single_layouts(acc, (1, 4), (1, 4), (0, 1), (0, 1))
 
         graph.add_node(inp_a)
@@ -1169,7 +1177,55 @@ class ValueBranchAdd(nn.Module):
         return self.if_a(self.conv_a(x)) + self.if_b(self.conv_b(x))
 
 
-class TestSignalDomain:
+class TestSignalSemantics:
+    def test_input_node_sets_known_code_range_from_effective_input_format(self):
+        graph = PAIIRGraph("input_semantics")
+        inp = InputNode(shape=torch.Size((1, 4)))
+        out = OutputNode(shape=torch.Size((1, 4)))
+        graph.add_node(inp)
+        graph.add_node(out)
+        graph.add_edge(inp.name, out.name)
+
+        propagate_signal_semantics(
+            graph,
+            input_formats={inp.name: (DataSign.SIGNED, DataWidth.WIDTH_4BIT)},
+        )
+
+        assert inp.signal_semantics.output_domain is SignalDomain.VALUE
+        assert inp.signal_semantics.known_code_range == (-8, 7)
+        assert out.signal_semantics.output_domain is SignalDomain.VALUE
+        assert out.signal_semantics.known_code_range == (-8, 7)
+
+    def test_concat_known_code_range_requires_all_predecessors_known(self):
+        graph = PAIIRGraph("concat_known_code_range")
+        inp = InputNode(shape=torch.Size((1, 4)))
+        add = GeneralAddOp(
+            operands=(
+                AddOperandSpec(1, AddOperandKind.TENSOR, tensor_port=0),
+                AddOperandSpec(1, AddOperandKind.CONST, const_value=1),
+            )
+        )
+        cat = ConcatOp(dim=1)
+        out = OutputNode(shape=torch.Size((1, 8)))
+        for node in (inp, add, cat, out):
+            graph.add_node(node)
+        graph.add_edge(inp.name, add.name)
+        graph.add_edge(inp.name, cat.name, dst_port=0)
+        graph.add_edge(add.name, cat.name, dst_port=1)
+        graph.add_edge(cat.name, out.name)
+
+        propagate_signal_semantics(
+            graph,
+            input_formats={inp.name: (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT)},
+        )
+
+        assert inp.signal_semantics.known_code_range == (0, 1)
+        assert add.signal_semantics.output_domain is SignalDomain.VALUE
+        assert add.signal_semantics.known_code_range is None
+        assert cat.signal_semantics.output_domain is SignalDomain.VALUE
+        assert cat.signal_semantics.known_code_range is None
+        assert out.signal_semantics.known_code_range is None
+
     def test_standalone_maxpool_preserves_value_domain(self):
         class ValueMaxPool(nn.Module):
             def __init__(self):
@@ -1183,7 +1239,7 @@ class TestSignalDomain:
         unfused = torch_to_paiir(ValueMaxPool(), torch.randn(1, 3, 8, 8))
         fused = fuse_to_offline_cores(specialize_general_adds(unfused))
 
-        propagate_signal_domain(fused)
+        propagate_signal_semantics(fused)
 
         pool = next(
             node
@@ -1192,11 +1248,13 @@ class TestSignalDomain:
             and isinstance(node.comp, nn.MaxPool2d)
         )
         out = fused.output_nodes()[0]
-        assert pool.output_domain == SignalDomain.VALUE
+        assert pool.signal_semantics.output_domain == SignalDomain.VALUE
+        assert pool.signal_semantics.known_code_range == (0, 254)
         assert pool.neuron_params.output_type == OutputType.VALUE
-        assert out.output_domain == SignalDomain.VALUE
+        assert out.signal_semantics.output_domain == SignalDomain.VALUE
+        assert out.signal_semantics.known_code_range == (0, 254)
 
-    def test_standalone_maxpool_preserves_potential_domain(self):
+    def test_standalone_maxpool_rejects_potential_domain(self):
         class PotentialMaxPool(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -1209,29 +1267,32 @@ class TestSignalDomain:
         unfused = torch_to_paiir(PotentialMaxPool(), torch.randn(1, 3, 8, 8))
         fused = fuse_to_offline_cores(specialize_general_adds(unfused))
 
-        propagate_signal_domain(fused)
-
-        pool = next(
-            node
-            for node in fused.nodes.values()
-            if isinstance(node, StandaloneCompOp)
-            and isinstance(node.comp, nn.MaxPool2d)
-        )
-        out = fused.output_nodes()[0]
-        assert pool.output_domain == SignalDomain.POTENTIAL
-        assert pool.neuron_params.output_type == OutputType.POTENTIAL
-        assert out.output_domain == SignalDomain.POTENTIAL
+        with pytest.raises(GraphValidationError, match="Standalone MaxPool"):
+            propagate_signal_semantics(fused)
 
     def test_general_add_from_scalar_propagates_value_domain(self):
         graph = torch_to_paiir(AddScalarDomain(), torch.randn(1, 3, 8, 8), strict=False)
 
-        propagate_signal_domain(graph)
+        propagate_signal_semantics(
+            graph,
+            input_formats={
+                graph.input_nodes()[0].name: (
+                    DataSign.UNSIGNED,
+                    DataWidth.WIDTH_1BIT,
+                )
+            },
+        )
 
         add = find_first(graph, GeneralAddOp)
         out = graph.output_nodes()[0]
-        assert graph.input_nodes()[0].output_domain == SignalDomain.VALUE
-        assert add.output_domain == SignalDomain.VALUE
-        assert out.output_domain == SignalDomain.VALUE
+        assert (
+            graph.input_nodes()[0].signal_semantics.output_domain == SignalDomain.VALUE
+        )
+        assert graph.input_nodes()[0].signal_semantics.known_code_range == (0, 1)
+        assert add.signal_semantics.output_domain == SignalDomain.VALUE
+        assert add.signal_semantics.known_code_range is None
+        assert out.signal_semantics.output_domain == SignalDomain.VALUE
+        assert out.signal_semantics.known_code_range is None
 
     def test_potential_add_from_residual_comp_propagates_potential_domain(self):
         class MembraneAdd(nn.Module):
@@ -1246,30 +1307,34 @@ class TestSignalDomain:
         unfused = torch_to_paiir(MembraneAdd(), torch.randn(1, 3, 8, 8))
         fused = fuse_to_offline_cores(specialize_general_adds(unfused))
 
-        propagate_signal_domain(fused)
+        propagate_signal_semantics(fused)
 
         add = find_first(fused, PotentialAddOp)
         out = fused.output_nodes()[0]
-        assert add.output_domain == SignalDomain.POTENTIAL
-        assert out.output_domain == SignalDomain.POTENTIAL
+        assert add.signal_semantics.output_domain == SignalDomain.POTENTIAL
+        assert add.signal_semantics.known_code_range is None
+        assert out.signal_semantics.output_domain == SignalDomain.POTENTIAL
+        assert out.signal_semantics.known_code_range is None
 
     def test_accumulate_with_activation_propagates_value_domain(self):
         unfused = torch_to_paiir(SNNResidualAdd(), make_img_3ch_8x8())
         fused = fuse_to_offline_cores(specialize_general_adds(unfused))
 
-        propagate_signal_domain(fused)
+        propagate_signal_semantics(fused)
 
         accum = find_first(fused, AccumulateOp)
         out = fused.output_nodes()[0]
-        assert accum.output_domain == SignalDomain.VALUE
-        assert out.output_domain == SignalDomain.VALUE
+        assert accum.signal_semantics.output_domain == SignalDomain.VALUE
+        assert accum.signal_semantics.known_code_range == (0, 1)
+        assert out.signal_semantics.output_domain == SignalDomain.VALUE
+        assert out.signal_semantics.known_code_range == (0, 1)
 
     def test_potential_add_rejects_value_domain_inputs(self):
         unfused = torch_to_paiir(ValueBranchAdd(), torch.randn(1, 3, 8, 8))
         fused = fuse_to_offline_cores(specialize_general_adds(unfused))
 
         with pytest.raises(GraphValidationError, match="PotentialAddOp"):
-            propagate_signal_domain(fused)
+            propagate_signal_semantics(fused)
 
     def test_rechecks_accumulate_signs(self):
         graph = PAIIRGraph("bad_accumulate_signs")
@@ -1282,10 +1347,10 @@ class TestSignalDomain:
         )
         out = OutputNode()
 
-        inp_a.output_domain = SignalDomain.VALUE
-        inp_b.output_domain = SignalDomain.VALUE
-        acc.output_domain = SignalDomain.VALUE
-        out.output_domain = SignalDomain.VALUE
+        inp_a.signal_semantics.output_domain = SignalDomain.VALUE
+        inp_b.signal_semantics.output_domain = SignalDomain.VALUE
+        acc.signal_semantics.output_domain = SignalDomain.VALUE
+        out.signal_semantics.output_domain = SignalDomain.VALUE
         _set_multi_input_single_output_layouts(
             acc,
             [(1, 4), (1, 4)],


### PR DESCRIPTION
## Summary
- introduce `SignalSemantics` and migrate node annotations to `node.signal_semantics`
- rename the public analysis entrypoint to `propagate_signal_semantics(...)`
- propagate `output_domain` and `known_code_range` in one pass
- keep `known_code_range` as node-level compile-time semantics instead of pass-local state
- update PAIIR tests to the new API and semantics model