### PR TITLE
Feat(maxpool): export standalone maxpool exactly

### DIFF
--- a/paibox/backendv2/op_node.py
+++ b/paibox/backendv2/op_node.py
@@ -377,11 +377,7 @@ class CoreOpNode(BaseNode["OfflineCoreOp"]):
         self.comps: list[nn.Module | None] = []
         self.weights: list[Tensor | None] = []
         # 初始化前端配置
-        lut_data: LutData | None = None
-        if isinstance(raw_node, SequentialOp):
-            lut = raw_node.act.lut
-            if lut is not None:
-                lut_data = lut.export_lut()
+        lut_data = raw_node.lut_data
 
         self.frontend_core_config: "Frontend_Core_Config" = get_frontend_core_conf(
             raw_node.core_params, lut_data

--- a/paibox/paiir/ir/ir_base.py
+++ b/paibox/paiir/ir/ir_base.py
@@ -35,9 +35,19 @@ class PAIIRNode:
     Each node is automatically assigned a unique name for identification
     within the computation graph.
 
-    ``signal_semantics`` stores node-level compile-time signal semantics such
-    as the coarse VALUE/POTENTIAL domain and an optional exact VALUE code
-    range.
+    ``signal_semantics.output_domain`` is a node-level semantic annotation
+    describing the signal domain of the node's output:
+
+    - :class:`~paibox.paiir.ir.signal_domain.SignalDomain.VALUE`
+    - :class:`~paibox.paiir.ir.signal_domain.SignalDomain.POTENTIAL`
+
+    The current IR treats this as one value per node, not one value per output
+    port. This remains valid for today's multi-output ``SplitOp`` because all
+    split branches inherit the same output domain from the split input.
+
+    ``signal_semantics.known_code_range`` stores an optional exact VALUE code
+    range for the node's output. ``None`` means the current compile-time
+    analyses cannot determine one precisely.
     """
 
     def __init__(self) -> None:

--- a/paibox/paiir/ir/maxpool_export.py
+++ b/paibox/paiir/ir/maxpool_export.py
@@ -1,0 +1,139 @@
+"""Helpers for standalone MaxPool export-strategy selection.
+
+This module owns the compile-time decision of how a VALUE-domain standalone
+MaxPool is exported:
+
+- keep spike-domain identity semantics with a neuron path, or
+- switch to ANN mode and emit an explicit identity LUT.
+"""
+
+from enum import Enum, auto
+from typing import TYPE_CHECKING, TypeGuard
+
+import torch
+from paicorelib import DataSign, DataWidth, SNNMode, ThresholdNegMode
+from torch import nn
+
+from .calc_params import LutData, NeuronParams
+from .core_neuron import ANNNodeV25, IFNodeV25
+from .lut_activation import LutCustom
+from .signal_domain import SignalDomain
+from .value_code import ValueCodeRange, code_range_for_format
+
+if TYPE_CHECKING:
+    from .op_node import StandaloneCompOp
+
+__all__ = [
+    "MaxPoolExportKind",
+    "build_identity_lut_data",
+    "build_identity_lut_neuron_params",
+    "build_spike_identity_neuron_params",
+    "is_maxpool_comp",
+    "refresh_maxpool_export_kind",
+    "select_maxpool_export_kind",
+]
+
+
+class MaxPoolExportKind(Enum):
+    """Concrete export strategies for standalone MaxPool VALUE outputs."""
+
+    U_SPIKE = auto()
+    S_SPIKE = auto()
+    LUT = auto()
+
+
+def is_maxpool_comp(comp: nn.Module) -> TypeGuard[nn.MaxPool1d | nn.MaxPool2d]:
+    """Return whether ``comp`` is a standalone MaxPool compute op."""
+    return isinstance(comp, (nn.MaxPool1d, nn.MaxPool2d))
+
+
+def select_maxpool_export_kind(
+    input_sign: DataSign,
+    input_width: DataWidth,
+    known_input_code_range: ValueCodeRange | None,
+) -> MaxPoolExportKind:
+    """Choose the export strategy from resolved input encoding information.
+
+    ``known_input_code_range`` is the strongest signal when available. If the
+    exact integer alphabet is not known, the function falls back to the input
+    sign/width envelope and chooses the most conservative export strategy that
+    stays correct for that format.
+    """
+    if known_input_code_range is not None:
+        lo, hi = known_input_code_range
+        if 0 <= lo and hi <= 1:
+            return MaxPoolExportKind.U_SPIKE
+        if -1 <= lo and hi <= 1:
+            return MaxPoolExportKind.S_SPIKE
+        return MaxPoolExportKind.LUT
+
+    if (input_sign, input_width) == (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT):
+        return MaxPoolExportKind.U_SPIKE
+    if (input_sign, input_width) == (DataSign.SIGNED, DataWidth.WIDTH_2BIT):
+        return MaxPoolExportKind.S_SPIKE
+    return MaxPoolExportKind.LUT
+
+
+def refresh_maxpool_export_kind(node: "StandaloneCompOp") -> MaxPoolExportKind | None:
+    """Refresh MaxPool export-side core params and return the chosen strategy.
+
+    Today the refresh is limited to keeping ``core_params.snn_mode`` aligned
+    with the resolved export strategy. The return value lets callers reuse the
+    same decision for neuron-params/LUT export without recalculating policy in
+    multiple places.
+    """
+    if node.signal_semantics.output_domain is not SignalDomain.VALUE:
+        return None
+
+    kind = select_maxpool_export_kind(
+        node.core_params.input_sign,
+        node.core_params.input_width,
+        node.signal_semantics.known_code_range,
+    )
+    node.core_params.snn_mode = (
+        SNNMode.ANN if kind is MaxPoolExportKind.LUT else SNNMode.SNN
+    )
+    return kind
+
+
+def build_spike_identity_neuron_params(export: MaxPoolExportKind) -> NeuronParams:
+    """Build exact identity neuron params for spike-code standalone MaxPool."""
+    if export is MaxPoolExportKind.U_SPIKE:
+        act = IFNodeV25(thres_neg_mode=ThresholdNegMode.FLOOR, thres_neg=0)
+    elif export is MaxPoolExportKind.S_SPIKE:
+        act = IFNodeV25(thres_neg_mode=ThresholdNegMode.FIRE, thres_neg=-1)
+    else:
+        raise ValueError(f"'{export.name}' is not a spike-identity export kind")
+
+    return act.to_neuron_params()
+
+
+def _build_identity_lut(
+    sign: DataSign, width: DataWidth, known_range: ValueCodeRange | None
+) -> LutCustom:
+    """Build an exact integer identity LUT over the effective input code range."""
+    lo, hi = (
+        known_range if known_range is not None else code_range_for_format(sign, width)
+    )
+    output_sign = 1 if lo < 0 else 0
+    values = torch.full((256,), hi, dtype=torch.int32)
+    thresholds = torch.full((256,), hi, dtype=torch.int32)
+
+    codes = torch.arange(lo, hi + 1, dtype=torch.int32)
+    values[: codes.numel()] = codes
+    thresholds[: codes.numel()] = codes
+    return LutCustom(thresholds, values, output_sign=output_sign)
+
+
+def build_identity_lut_data(
+    sign: DataSign, width: DataWidth, known_range: ValueCodeRange | None
+) -> LutData:
+    """Export the standalone MaxPool identity LUT as backend-visible table data."""
+    return _build_identity_lut(sign, width, known_range).export_lut()
+
+
+def build_identity_lut_neuron_params(
+    sign: DataSign, width: DataWidth, known_range: ValueCodeRange | None
+) -> NeuronParams:
+    """Build ANN-mode neuron params that pair with the identity LUT export path."""
+    return ANNNodeV25(_build_identity_lut(sign, width, known_range)).to_neuron_params()

--- a/paibox/paiir/ir/op_node.py
+++ b/paibox/paiir/ir/op_node.py
@@ -27,6 +27,14 @@ from torch import Tensor, nn
 from .calc_params import LutData, NeuronParams, OfflineCoreParams, OnlineCoreParams
 from .core_neuron import CoreNeuronV25
 from .ir_base import PAIIRNode, TensorLayout
+from .maxpool_export import (
+    MaxPoolExportKind,
+    build_identity_lut_data,
+    build_identity_lut_neuron_params,
+    build_spike_identity_neuron_params,
+    is_maxpool_comp,
+    refresh_maxpool_export_kind,
+)
 from .reshape_semantics import materialize_logical_layout
 from .signal_domain import SignalDomain
 
@@ -120,7 +128,7 @@ def _get_weight_tensor(comp: nn.Module) -> Tensor | None:
 
 def _get_pooling_mode(comp: nn.Module) -> PoolingMode:
     """Infer pooling mode from the compute operation."""
-    if isinstance(comp, (nn.MaxPool1d, nn.MaxPool2d)):
+    if is_maxpool_comp(comp):
         return PoolingMode.MAX
     return PoolingMode.AVERAGE
 
@@ -596,9 +604,43 @@ class StandaloneCompOp(OfflineCoreOp):
         backend-visible ``output_type`` must be derived from the propagated
         graph semantic domain instead of using a hard-coded default.
         """
+        if (
+            is_maxpool_comp(self.comp)
+            and self.signal_semantics.output_domain is SignalDomain.VALUE
+        ):
+            kind = refresh_maxpool_export_kind(self)
+            if kind in (MaxPoolExportKind.U_SPIKE, MaxPoolExportKind.S_SPIKE):
+                return self._with_domain_derived_output_type(
+                    build_spike_identity_neuron_params(kind)
+                )
+            if kind is MaxPoolExportKind.LUT:
+                return self._with_domain_derived_output_type(
+                    build_identity_lut_neuron_params(
+                        self.core_params.input_sign,
+                        self.core_params.input_width,
+                        self.signal_semantics.known_code_range,
+                    )
+                )
+
         return self._with_domain_derived_output_type(
             NeuronParams(output_type=OutputType.POTENTIAL)
         )
+
+    @property
+    def lut_data(self) -> LutData | None:
+        """Standalone MaxPool may synthesize an identity LUT for wider VALUE code."""
+        if (
+            is_maxpool_comp(self.comp)
+            and self.signal_semantics.output_domain is SignalDomain.VALUE
+        ):
+            export = refresh_maxpool_export_kind(self)
+            if export is MaxPoolExportKind.LUT:
+                return build_identity_lut_data(
+                    self.core_params.input_sign,
+                    self.core_params.input_width,
+                    self.signal_semantics.known_code_range,
+                )
+        return None
 
     def extra_repr(self) -> str:
         return f"{super().extra_repr()}, comp={type(self.comp).__name__}"

--- a/paibox/paiir/ir/signal_domain.py
+++ b/paibox/paiir/ir/signal_domain.py
@@ -15,7 +15,13 @@ class SignalDomain(Enum):
 
 @dataclass(slots=True)
 class SignalSemantics:
-    """Node-level signal semantics derived during compilation."""
+    """Node-level signal semantics derived during compilation.
+
+    Attributes:
+        output_domain: Coarse VALUE/POTENTIAL domain annotation.
+        known_code_range: Exact VALUE code range when derivable; otherwise
+            ``None``.
+    """
 
     output_domain: SignalDomain | None = None
     known_code_range: tuple[int, int] | None = None

--- a/paibox/paiir/ir/value_code.py
+++ b/paibox/paiir/ir/value_code.py
@@ -40,9 +40,7 @@ def code_range_for_format(sign: DataSign, width: DataWidth) -> ValueCodeRange:
     return ranges[width]
 
 
-def code_range_for_data_format(
-    fmt: tuple[DataSign, DataWidth],
-) -> ValueCodeRange:
+def code_range_for_data_format(fmt: tuple[DataSign, DataWidth]) -> ValueCodeRange:
     sign, width = fmt
     return code_range_for_format(sign, width)
 
@@ -57,9 +55,7 @@ def fits_value_code_range(value_min: int, value_max: int) -> bool:
     return lo <= value_min and value_max <= hi
 
 
-def merge_code_ranges(
-    code_ranges: Sequence[ValueCodeRange],
-) -> ValueCodeRange | None:
+def merge_code_ranges(code_ranges: Sequence[ValueCodeRange]) -> ValueCodeRange | None:
     if not code_ranges:
         return None
     return min(lo for lo, _ in code_ranges), max(hi for _, hi in code_ranges)

--- a/paibox/paiir/pipeline/passes.py
+++ b/paibox/paiir/pipeline/passes.py
@@ -1322,7 +1322,7 @@ def _seed_node_data_formats(
     graph: PAIIRGraph,
     node_name: str,
     resolved: dict[str, DataFormat],
-    input_formats: dict[str, DataFormat]
+    input_formats: dict[str, DataFormat],
 ) -> None:
     """Seed node-local output/weight formats before input back-fill starts."""
     node = graph.nodes[node_name]
@@ -1347,10 +1347,7 @@ def _seed_node_data_formats(
 
 
 def _infer_routing_resolved_format(
-    graph: PAIIRGraph,
-    node_name: str,
-    node: PAIIRNode,
-    resolved: dict[str, DataFormat]
+    graph: PAIIRGraph, node_name: str, node: PAIIRNode, resolved: dict[str, DataFormat]
 ) -> DataFormat | None:
     """Propagate already-resolved formats through non-deploy routing nodes."""
     match node:

--- a/paibox/paiir/pipeline/passes.py
+++ b/paibox/paiir/pipeline/passes.py
@@ -17,7 +17,8 @@ Two validation stages live in this module:
 
 import math
 import warnings
-from typing import TypedDict
+from dataclasses import dataclass
+from typing import Literal, TypedDict
 
 import torch
 from paicorelib import AddPotentialMode, DataSign, DataWidth, OutputType, SNNMode
@@ -27,6 +28,7 @@ from ..ir.add_ops import GeneralAddOp, PotentialAddOp
 from ..ir.core_neuron import CoreNeuronV25
 from ..ir.graph import Edge, PAIIRGraph
 from ..ir.ir_base import InputNode, OutputNode, PAIIRNode
+from ..ir.maxpool_export import refresh_maxpool_export_kind
 from ..ir.op_node import (
     AccumulateOp,
     ConcatOp,
@@ -87,11 +89,67 @@ _DEPLOYABLE_GRAPH_NODE_TYPES = (
     StandaloneActOp,
 )
 
+KnownCodeRange = tuple[int, int] | None
+NodeSignal = tuple[SignalDomain, KnownCodeRange]
+
+
+@dataclass(frozen=True, slots=True)
+class _PredSignalFacts:
+    """Predecessor signal facts gathered once for one node.
+
+    The semantics pass repeatedly needs the same three views of predecessor
+    state:
+
+    - raw predecessor domains, which may still contain ``None``
+    - exact predecessor code ranges, which may also be partially unknown
+    - filtered/merged views consumed by operator-specific rules
+    """
+
+    domains: tuple[SignalDomain | None, ...]
+    code_ranges: tuple[KnownCodeRange, ...]
+
+    @property
+    def has_missing_domain(self) -> bool:
+        return any(domain is None for domain in self.domains)
+
+    @property
+    def known_domains(self) -> list[SignalDomain]:
+        return [domain for domain in self.domains if domain is not None]
+
+    @property
+    def present_code_ranges(self) -> list[tuple[int, int]]:
+        return [code_range for code_range in self.code_ranges if code_range is not None]
+
+    def single_domain(self) -> SignalDomain | None:
+        if not self.domains:
+            return None
+        return self.domains[0]
+
+    def single_code_range(self) -> KnownCodeRange:
+        if not self.code_ranges:
+            return None
+        return self.code_ranges[0]
+
+    def merged_code_range(self) -> KnownCodeRange:
+        if not self.code_ranges or any(
+            code_range is None for code_range in self.code_ranges
+        ):
+            return None
+        return merge_code_ranges(
+            [code_range for code_range in self.code_ranges if code_range is not None]
+        )
+
 
 def analyze_graph(
     graph: PAIIRGraph, input_formats: dict[str, DataFormat] | None = None
 ) -> PAIIRGraph:
-    """Run the standard compile-time graph analyses in dependency order."""
+    """Run the standard compile-time graph analyses in dependency order.
+
+    The public contract stays intentionally small: validate structure first,
+    then derive node-level signal semantics, then derive backend-facing data
+    formats. The implementation keeps semantics and data-format propagation as
+    two separate stages even though they share some operator-specific rules.
+    """
     validate_graph(graph)
     propagate_signal_semantics(graph, input_formats)
     propagate_data_format(graph, input_formats)
@@ -788,6 +846,11 @@ def propagate_signal_semantics(
 
     - ``signal_semantics.output_domain``: coarse VALUE vs POTENTIAL semantics
     - ``signal_semantics.known_code_range``: optional exact VALUE code range when derivable
+
+    The pass is intentionally operator-driven rather than format-driven:
+    routing-like nodes mostly forward predecessor annotations, while deployable
+    cores derive semantics from their own activation or from explicit operator
+    contracts such as standalone MaxPool.
     """
     if input_formats is None:
         input_formats = {}
@@ -815,118 +878,82 @@ def propagate_signal_semantics(
                 node,
                 SignalDomain.VALUE,
                 code_range_for_data_format(
-                    _resolve_input_node_format(graph, name, input_formats)
+                    _resolve_input_node_format(name, input_formats)
                 ),
             )
             continue
 
-        preds = graph.predecessors(name)
-        pred_domains = [graph.nodes[p].signal_semantics.output_domain for p in preds]
-        if any(domain is None for domain in pred_domains):
+        pred_facts = _gather_pred_signal_facts(graph, name)
+        if pred_facts.has_missing_domain:
             errors.append(
                 f"{type(node).__name__} '{name}' predecessor output_domain is missing"
             )
             continue
 
-        known_pred_domains = [domain for domain in pred_domains if domain is not None]
-        pred_code_ranges = _present_predecessor_known_code_ranges(graph, preds)
-
-        if isinstance(node, OutputNode):
-            if known_pred_domains:
-                _set_node_signal_semantics(
-                    node,
-                    known_pred_domains[0],
-                    _single_predecessor_known_code_range(graph, name),
-                )
-            continue
-
-        if isinstance(node, TransformOp):
-            if known_pred_domains:
-                _set_node_signal_semantics(
-                    node,
-                    known_pred_domains[0],
-                    _single_predecessor_known_code_range(graph, name),
-                )
-            continue
-
-        if isinstance(node, SplitOp):
-            if known_pred_domains:
-                _set_node_signal_semantics(
-                    node,
-                    known_pred_domains[0],
-                    _single_predecessor_known_code_range(graph, name),
-                )
+        if isinstance(node, (OutputNode, TransformOp, SplitOp)):
+            inferred = _infer_passthrough_signal_semantics(pred_facts)
+            if inferred is not None:
+                _set_node_signal_semantics(node, *inferred)
             continue
 
         if isinstance(node, ConcatOp):
-            if known_pred_domains and any(
-                domain != known_pred_domains[0] for domain in known_pred_domains
+            if pred_facts.known_domains and any(
+                domain != pred_facts.known_domains[0]
+                for domain in pred_facts.known_domains
             ):
                 errors.append(
                     f"ConcatOp '{name}' all predecessor domains must match, got "
-                    f"{[domain.name for domain in known_pred_domains]}"
+                    f"{[domain.name for domain in pred_facts.known_domains]}"
                 )
                 continue
-            if known_pred_domains:
-                _set_node_signal_semantics(
-                    node,
-                    known_pred_domains[0],
-                    _merged_predecessor_known_code_range(graph, name),
-                )
+            inferred = _infer_concat_signal_semantics(pred_facts)
+            if inferred is not None:
+                _set_node_signal_semantics(node, *inferred)
             continue
 
         if isinstance(node, GeneralAddOp):
-            if known_pred_domains and any(
-                domain != known_pred_domains[0] for domain in known_pred_domains
-            ):
+            inferred = _infer_general_add_signal_semantics(node, pred_facts)
+            if inferred is None:
+                errors.append(f"GeneralAddOp '{name}' cannot infer output_domain")
+            elif inferred is False:
                 errors.append(
                     f"GeneralAddOp '{name}' mixed tensor operand domains are not supported, got "
-                    f"{[domain.name for domain in known_pred_domains]}"
+                    f"{[domain.name for domain in pred_facts.known_domains]}"
                 )
-                continue
-            if known_pred_domains:
-                _set_node_signal_semantics(node, known_pred_domains[0], None)
-            elif node.has_const_operands:
-                _set_node_signal_semantics(node, SignalDomain.VALUE, None)
             else:
-                errors.append(f"GeneralAddOp '{name}' cannot infer output_domain")
+                _set_node_signal_semantics(node, *inferred)
             continue
 
         if isinstance(node, PotentialAddOp):
-            if known_pred_domains and any(
-                domain is not SignalDomain.POTENTIAL for domain in known_pred_domains
+            if pred_facts.known_domains and any(
+                domain is not SignalDomain.POTENTIAL
+                for domain in pred_facts.known_domains
             ):
                 errors.append(
                     f"PotentialAddOp '{name}' all predecessor domains must be POTENTIAL, got "
-                    f"{[domain.name for domain in known_pred_domains]}"
+                    f"{[domain.name for domain in pred_facts.known_domains]}"
                 )
                 continue
             _set_node_signal_semantics(node, SignalDomain.POTENTIAL, None)
             continue
 
         if is_standalone_maxpool(node):
-            if known_pred_domains and any(
-                domain is not SignalDomain.VALUE for domain in known_pred_domains
+            if pred_facts.known_domains and any(
+                domain is not SignalDomain.VALUE for domain in pred_facts.known_domains
             ):
                 errors.append(
                     f"Standalone MaxPool '{name}' requires VALUE-domain predecessor, got "
-                    f"{[domain.name for domain in known_pred_domains]}"
+                    f"{[domain.name for domain in pred_facts.known_domains]}"
                 )
                 continue
-            if known_pred_domains:
-                _set_node_signal_semantics(
-                    node,
-                    SignalDomain.VALUE,
-                    _merged_predecessor_known_code_range(graph, name),
-                )
+            inferred = _infer_standalone_maxpool_signal_semantics(pred_facts)
+            if inferred is not None:
+                _set_node_signal_semantics(node, *inferred)
             continue
 
         if isinstance(node, OfflineCoreOp):
-            domain = _infer_output_signal_domain(node)
             _set_node_signal_semantics(
-                node,
-                domain,
-                _infer_node_known_code_range(node, domain, pred_code_ranges),
+                node, *_infer_offline_core_signal_semantics(node, pred_facts)
             )
             continue
 
@@ -935,60 +962,91 @@ def propagate_signal_semantics(
 
 
 def _infer_output_signal_domain(node: OfflineCoreOp) -> SignalDomain:
+    """Infer the coarse output domain for a generic offline core."""
     if node.neuron_params.output_type == OutputType.POTENTIAL:
         return SignalDomain.POTENTIAL
     return SignalDomain.VALUE
 
 
 def _set_node_signal_semantics(
-    node: PAIIRNode,
-    output_domain: SignalDomain,
-    known_code_range: tuple[int, int] | None,
+    node: PAIIRNode, output_domain: SignalDomain, known_code_range: KnownCodeRange
 ) -> None:
+    """Write both signal-semantics fields together to keep them in sync."""
     node.signal_semantics.output_domain = output_domain
     node.signal_semantics.known_code_range = known_code_range
 
 
+def _gather_pred_signal_facts(graph: PAIIRGraph, node_name: str) -> _PredSignalFacts:
+    """Gather predecessor domains and exact code ranges for one node."""
+    preds = graph.predecessors(node_name)
+    return _PredSignalFacts(
+        domains=tuple(graph.nodes[p].signal_semantics.output_domain for p in preds),
+        code_ranges=tuple(
+            graph.nodes[p].signal_semantics.known_code_range for p in preds
+        ),
+    )
+
+
+def _infer_passthrough_signal_semantics(
+    pred_facts: _PredSignalFacts,
+) -> NodeSignal | None:
+    """Forward predecessor semantics through transparent single-input nodes."""
+    domain = pred_facts.single_domain()
+    if domain is None:
+        return None
+    return domain, pred_facts.single_code_range()
+
+
+def _infer_concat_signal_semantics(pred_facts: _PredSignalFacts) -> NodeSignal | None:
+    """Infer concat semantics once domain compatibility is already validated."""
+    if not pred_facts.known_domains:
+        return None
+    return pred_facts.known_domains[0], pred_facts.merged_code_range()
+
+
+def _infer_general_add_signal_semantics(
+    node: GeneralAddOp, pred_facts: _PredSignalFacts
+) -> tuple[SignalDomain, None] | Literal[False] | None:
+    """Infer coarse add semantics without attempting exact value-range algebra.
+
+    ``False`` is a sentinel for "mixed predecessor domains", letting the caller
+    preserve the existing error wording without duplicating the rule.
+    """
+    if pred_facts.known_domains and any(
+        domain != pred_facts.known_domains[0] for domain in pred_facts.known_domains
+    ):
+        return False
+    if pred_facts.known_domains:
+        return pred_facts.known_domains[0], None
+    if node.has_const_operands:
+        return SignalDomain.VALUE, None
+    return None
+
+
+def _infer_standalone_maxpool_signal_semantics(
+    pred_facts: _PredSignalFacts,
+) -> NodeSignal | None:
+    """Infer standalone MaxPool semantics from VALUE-domain predecessors."""
+    if not pred_facts.known_domains:
+        return None
+    return SignalDomain.VALUE, pred_facts.merged_code_range()
+
+
+def _infer_offline_core_signal_semantics(
+    node: OfflineCoreOp, pred_facts: _PredSignalFacts
+) -> NodeSignal:
+    """Infer semantics for generic deployable offline cores."""
+    domain = _infer_output_signal_domain(node)
+    return domain, _infer_node_known_code_range(
+        node, domain, pred_facts.present_code_ranges
+    )
+
+
 def _resolve_input_node_format(
-    graph: PAIIRGraph, name: str, input_formats: dict[str, DataFormat]
+    name: str, input_formats: dict[str, DataFormat]
 ) -> DataFormat:
-    return (
-        input_formats[name]
-        if name in input_formats
-        else _infer_input_node_default(graph, name)
-    )
-
-
-def _single_predecessor_known_code_range(
-    graph: PAIIRGraph, node_name: str
-) -> tuple[int, int] | None:
-    preds = graph.predecessors(node_name)
-    if not preds:
-        return None
-    return graph.nodes[preds[0]].signal_semantics.known_code_range
-
-
-def _merged_predecessor_known_code_range(
-    graph: PAIIRGraph, node_name: str
-) -> tuple[int, int] | None:
-    preds = graph.predecessors(node_name)
-    pred_ranges = [graph.nodes[p].signal_semantics.known_code_range for p in preds]
-    if not preds or any(code_range is None for code_range in pred_ranges):
-        return None
-    return merge_code_ranges(
-        [code_range for code_range in pred_ranges if code_range is not None]
-    )
-
-
-def _present_predecessor_known_code_ranges(
-    graph: PAIIRGraph, preds: list[str]
-) -> list[tuple[int, int]]:
-    present: list[tuple[int, int]] = []
-    for pred_name in preds:
-        code_range = graph.nodes[pred_name].signal_semantics.known_code_range
-        if code_range is not None:
-            present.append(code_range)
-    return present
+    """Resolve external input format from explicit overrides or fixed default."""
+    return input_formats[name] if name in input_formats else _DEFAULT_INPUT_FORMAT
 
 
 def _infer_node_known_code_range(
@@ -996,6 +1054,12 @@ def _infer_node_known_code_range(
     output_domain: SignalDomain,
     pred_code_ranges: list[tuple[int, int]],
 ) -> tuple[int, int] | None:
+    """Infer the exact VALUE code range emitted by one offline core.
+
+    The pass stays conservative: when a rule cannot guarantee an exact integer
+    output range, it returns ``None`` and lets later stages fall back to format
+    envelopes instead of pretending the range is known.
+    """
     if output_domain is not SignalDomain.VALUE:
         return None
     if is_standalone_maxpool(node):
@@ -1180,9 +1244,8 @@ def _validate_lut_mode_consistency(
         )
 
 
-_DEFAULT_SNN_INPUT: DataFormat = (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT)
-_DEFAULT_ANN_INPUT: DataFormat = (DataSign.SIGNED, DataWidth.WIDTH_8BIT)
-_WEIGHTLESS_WEIGHT_FORMAT: DataFormat = (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT)
+_DEFAULT_INPUT_FORMAT = (DataSign.SIGNED, DataWidth.WIDTH_8BIT)
+_WEIGHTLESS_WEIGHT_FORMAT = (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT)
 
 
 def propagate_data_format(
@@ -1214,7 +1277,7 @@ def propagate_data_format(
             validated.
         input_formats: Optional mapping from ``InputNode`` name to explicit
             external input format. Any omitted input falls back to
-            :func:`_infer_input_node_default`.
+            a fixed signed 8-bit default.
     """
     if input_formats is None:
         input_formats = {}
@@ -1236,27 +1299,7 @@ def propagate_data_format(
     # This gives later consumers a stable predecessor-output view before we
     # compute per-core input formats.
     for name in graph.topo_sort():
-        node = graph.nodes[name]
-
-        if isinstance(node, InputNode):
-            resolved[name] = _resolve_input_node_format(graph, name, input_formats)
-            continue
-        if isinstance(node, OutputNode):
-            continue
-        if is_format_transparent_routing_node(node):
-            # Routing nodes have no `core_params`; their effective formats are
-            # propagated in the second pass after predecessor outputs are known.
-            continue
-        if not isinstance(node, OfflineCoreOp):
-            continue
-
-        pred_formats = _collect_effective_predecessor_formats(graph, name, resolved)
-        out_fmt = _infer_node_output_format(node, pred_formats)
-        node.core_params.set_output_format(out_fmt)
-        resolved[name] = out_fmt
-
-        w_fmt = _infer_node_weight_format(node)
-        node.core_params.set_weight_format(w_fmt)
+        _seed_node_data_formats(graph, name, resolved, input_formats)
 
     # Pass 2: thread those resolved formats through non-deploy routing nodes
     # and then back-fill each deployable core's input format from predecessor
@@ -1264,50 +1307,103 @@ def propagate_data_format(
     for name in graph.topo_sort():
         node = graph.nodes[name]
 
-        if isinstance(node, (InputNode, OutputNode)):
-            if isinstance(node, OutputNode):
-                # Output nodes are pure pass-through graph boundaries: they
-                # inherit the effective format of their sole predecessor.
-                preds = graph.predecessors(name)
-                if preds and preds[0] in resolved:
-                    resolved[name] = resolved[preds[0]]
-            continue
-
-        if isinstance(node, ConcatOp):
-            # Concat preserves element encoding and therefore resolves to the
-            # merged predecessor format.
-            pred_formats = [
-                resolved[p] for p in graph.predecessors(name) if p in resolved
-            ]
-            if pred_formats:
-                resolved[node.name] = merge_data_formats(pred_formats)
-            continue
-
-        if isinstance(node, TransformOp):
-            # Reshape/view/flatten do not change the scalar representation.
-            preds = graph.predecessors(name)
-            if preds and preds[0] in resolved:
-                resolved[name] = resolved[preds[0]]
-            continue
-
-        if isinstance(node, SplitOp):
-            preds = graph.predecessors(name)
-            if preds and preds[0] in resolved:
-                resolved[name] = resolved[preds[0]]
+        routing_fmt = _infer_routing_resolved_format(graph, name, node, resolved)
+        if routing_fmt is not None:
+            resolved[name] = routing_fmt
             continue
 
         if not isinstance(node, OfflineCoreOp):
             continue
 
-        pred_formats = [resolved[p] for p in graph.predecessors(name) if p in resolved]
-        in_fmt = merge_data_formats(pred_formats)
-        node.core_params.set_input_format(in_fmt)
-        _derive_input_add_potential_mode(node, in_fmt)
+        _update_offline_core_input_format(graph, name, node, resolved)
+
+
+def _seed_node_data_formats(
+    graph: PAIIRGraph,
+    node_name: str,
+    resolved: dict[str, DataFormat],
+    input_formats: dict[str, DataFormat]
+) -> None:
+    """Seed node-local output/weight formats before input back-fill starts."""
+    node = graph.nodes[node_name]
+
+    if isinstance(node, InputNode):
+        resolved[node_name] = _resolve_input_node_format(node_name, input_formats)
+        return
+    if isinstance(node, OutputNode):
+        return
+    if is_format_transparent_routing_node(node):
+        # Routing nodes have no `core_params`; their effective formats are
+        # propagated in the second pass after predecessor outputs are known.
+        return
+    if not isinstance(node, OfflineCoreOp):
+        return
+
+    pred_formats = _collect_effective_predecessor_formats(graph, node_name, resolved)
+    out_fmt = _infer_node_output_format(node, pred_formats)
+    node.core_params.set_output_format(out_fmt)
+    resolved[node_name] = out_fmt
+    node.core_params.set_weight_format(_infer_node_weight_format(node))
+
+
+def _infer_routing_resolved_format(
+    graph: PAIIRGraph,
+    node_name: str,
+    node: PAIIRNode,
+    resolved: dict[str, DataFormat]
+) -> DataFormat | None:
+    """Propagate already-resolved formats through non-deploy routing nodes."""
+    match node:
+        case InputNode():
+            return None
+        case OutputNode() | TransformOp() | SplitOp():
+            # Graph boundaries and shape-only routing preserve scalar encoding.
+            return _single_resolved_predecessor_format(graph, node_name, resolved)
+        case ConcatOp():
+            # Concat preserves element encoding and therefore resolves to the
+            # merged predecessor format.
+            pred_formats = _resolved_predecessor_formats(graph, node_name, resolved)
+            return merge_data_formats(pred_formats) if pred_formats else None
+        case _:
+            return None
+
+
+def _resolved_predecessor_formats(
+    graph: PAIIRGraph, node_name: str, resolved: dict[str, DataFormat]
+) -> list[DataFormat]:
+    """Return already-resolved direct predecessor formats for one node."""
+    return [resolved[p] for p in graph.predecessors(node_name) if p in resolved]
+
+
+def _single_resolved_predecessor_format(
+    graph: PAIIRGraph, node_name: str, resolved: dict[str, DataFormat]
+) -> DataFormat | None:
+    """Return the first resolved predecessor format for pass-through rules."""
+    pred_formats = _resolved_predecessor_formats(graph, node_name, resolved)
+    if not pred_formats:
+        return None
+    return pred_formats[0]
+
+
+def _update_offline_core_input_format(
+    graph: PAIIRGraph,
+    node_name: str,
+    node: OfflineCoreOp,
+    resolved: dict[str, DataFormat],
+) -> None:
+    """Back-fill one deployable core's input format and dependent config."""
+    pred_formats = _resolved_predecessor_formats(graph, node_name, resolved)
+    in_fmt = merge_data_formats(pred_formats)
+    node.core_params.set_input_format(in_fmt)
+    _derive_input_add_potential_mode(graph, node_name, node)
+    if is_standalone_maxpool(node):
+        refresh_maxpool_export_kind(node)
 
 
 def _collect_effective_predecessor_formats(
     graph: PAIIRGraph, node_name: str, resolved: dict[str, DataFormat]
 ) -> list[DataFormat]:
+    """Collect predecessor output formats through transparent routing nodes."""
     return collect_effective_predecessor_values(
         graph,
         node_name,
@@ -1316,20 +1412,10 @@ def _collect_effective_predecessor_formats(
     )
 
 
-def _infer_input_node_default(graph: PAIIRGraph, name: str) -> DataFormat:
-    succs = graph.successors(name)
-    for succ_name in succs:
-        succ = graph.nodes[succ_name]
-        if isinstance(succ, OfflineCoreOp):
-            if succ.core_params.snn_mode == SNNMode.SNN:
-                return _DEFAULT_SNN_INPUT
-            return _DEFAULT_ANN_INPUT
-    return _DEFAULT_ANN_INPUT
-
-
 def _infer_node_output_format(
     node: OfflineCoreOp, pred_formats: list[DataFormat] | None = None
 ) -> DataFormat:
+    """Infer the backend-facing output format for one offline core."""
     if is_standalone_maxpool(node):
         if not pred_formats:
             raise ValueError(
@@ -1352,6 +1438,7 @@ def _infer_node_output_format(
 
 
 def _infer_node_weight_format(node: OfflineCoreOp) -> DataFormat:
+    """Infer the backend-facing weight format for one offline core."""
     weight_range = node.get_weight_value_range()
     if weight_range is not None:
         w_min, w_max = weight_range
@@ -1368,27 +1455,29 @@ def _infer_node_weight_format(node: OfflineCoreOp) -> DataFormat:
 
 
 def _derive_input_add_potential_mode(
-    node: OfflineCoreOp, input_format: DataFormat
+    graph: PAIIRGraph, node_name: str, node: OfflineCoreOp
 ) -> None:
-    """Derive hardware add-potential mode from the resolved input format.
+    """Derive hardware add-potential mode from predecessor signal semantics.
 
     Standalone activation cores synthesize an implicit identity connectivity
     path in the backend. When that path carries membrane potentials, the chip
     expects direct membrane accumulation rather than normal weighted
-    accumulation. In practice the membrane domain is represented as signed
-    32-bit input format, so derive ``DIRECT_ADD`` from that resolved input.
+    accumulation.
     """
     if not isinstance(node, StandaloneActOp):
         return
 
-    _, input_width = input_format
-    if input_width == DataWidth.WIDTH_32BIT:
+    if (
+        _gather_pred_signal_facts(graph, node_name).single_domain()
+        is SignalDomain.POTENTIAL
+    ):
         node.core_params.add_potential = AddPotentialMode.DIRECT_ADD
     else:
         node.core_params.add_potential = AddPotentialMode.NORMAL
 
 
 def _get_node_act(node: OfflineCoreOp) -> CoreNeuronV25 | None:
+    """Return a node's activation object when the node actually has one."""
     act = getattr(node, "act", None)
     return act if isinstance(act, CoreNeuronV25) else None
 

--- a/tests/paiir/conftest.py
+++ b/tests/paiir/conftest.py
@@ -19,6 +19,7 @@ from paibox.paiir.pipeline.layout_cross_node_elision import (
 from paibox.paiir.pipeline.passes import (
     fuse_to_offline_cores,
     propagate_data_format,
+    propagate_signal_semantics,
     specialize_general_adds,
 )
 
@@ -393,7 +394,8 @@ def convert_fuse_propagate(
     *sample_inputs: Tensor,
     input_formats: dict[str, DataFormat] | None = None,
 ) -> PAIIRGraph:
-    """Full pipeline: trace -> fuse -> propagate data format."""
+    """Full pipeline: trace -> fuse -> propagate semantics and data format."""
     fused = convert_and_fuse(model, *sample_inputs)
+    propagate_signal_semantics(fused, input_formats=input_formats)
     propagate_data_format(fused, input_formats=input_formats)
     return fused

--- a/tests/paiir/ir/test_op_node.py
+++ b/tests/paiir/ir/test_op_node.py
@@ -13,12 +13,14 @@ from paicorelib import (
     OutputType,
     PoolingMode,
     SNNMode,
+    ThresholdNegMode,
+    ThresholdPosMode,
 )
 from torch import nn
 
 from paibox.paiir.ir.add_ops import PotentialAddOp
 from paibox.paiir.ir.calc_params import NeuronParams, OfflineCoreParams
-from paibox.paiir.ir.core_neuron import ANNNodeV25, IFNodeV25, LIFNodeV25
+from paibox.paiir.ir.core_neuron import ANNNodeV25, CoreNeuronV25, IFNodeV25, LIFNodeV25
 from paibox.paiir.ir.lut_activation import LutReLU, LutSigmoid
 from paibox.paiir.ir.op_node import (
     AccumulateOp,
@@ -323,6 +325,58 @@ class TestNeuronParams:
         params = op.neuron_params
         assert params.thres_pos == 1
         assert params.output_type == OutputType.VALUE
+
+    def test_standalone_maxpool_unsigned_spike_bypass_neuron_params(self):
+        op = StandaloneCompOp(comp=nn.MaxPool2d(2))
+        op.signal_semantics.output_domain = SignalDomain.VALUE
+        op.core_params.set_input_format((DataSign.UNSIGNED, DataWidth.WIDTH_1BIT))
+
+        params = op.neuron_params
+        assert params.output_type == OutputType.VALUE
+        assert params.reset_mode == RM.MODE_NORMAL
+        assert params.reset_v == 0
+        assert params.thres_pos_mode == ThresholdPosMode.FIRE
+        assert params.thres_neg_mode == ThresholdNegMode.FLOOR
+        assert params.thres_pos == 1
+        assert params.thres_neg == 0
+        assert op.lut_data is None
+
+        act = CoreNeuronV25(
+            reset_mode=params.reset_mode,
+            reset_v=params.reset_v,
+            thres_pos_mode=params.thres_pos_mode,
+            thres_neg_mode=params.thres_neg_mode,
+            thres_pos=params.thres_pos,
+            thres_neg=params.thres_neg,
+            lateral_inhi=params.lateral_inhi,
+            leak_multi_sequence=params.leak_multi_sequence,
+            leak_multi_input=params.leak_multi_input,
+            leak_multi_mode=params.leak_multi_mode,
+            leak_add_mode=params.leak_add_mode,
+            leak_tau_shift=params.leak_tau,
+            leak_v=params.leak_v,
+            init_v=params.init_v,
+        )
+        outputs = [
+            int(act(torch.tensor([x], dtype=torch.float32)).item())
+            for x in [0, 1, 0, 1]
+        ]
+        assert outputs == [0, 1, 0, 1]
+        assert int(act.v.item()) == 0
+
+    def test_standalone_maxpool_wider_value_exports_identity_lut(self):
+        op = StandaloneCompOp(comp=nn.MaxPool2d(2))
+        op.signal_semantics.output_domain = SignalDomain.VALUE
+        op.core_params.set_input_format((DataSign.UNSIGNED, DataWidth.WIDTH_4BIT))
+
+        params = op.neuron_params
+        data = op.lut_data
+
+        assert params.output_type == OutputType.VALUE
+        assert data is not None
+        assert torch.equal(data.thresholds[:16], torch.arange(16, dtype=torch.int32))
+        assert torch.equal(data.values[:16], torch.arange(16, dtype=torch.uint8))
+        assert torch.all(data.values[16:] == 15)
 
 
 class TestLutData:

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -271,7 +271,8 @@ class TestUnsupported32BitConsumers:
 
     def test_compile_rejects_standalone_compute_consumer_of_potential_domain(self):
         with pytest.raises(
-            GraphValidationError, match="StandaloneCompOp.*WIDTH_32BIT|WIDTH_32BIT"
+            GraphValidationError,
+            match="Standalone MaxPool .*VALUE-domain predecessor|WIDTH_32BIT",
         ):
             compile_to_paiir(PotentialIntoStandalonePool().eval(), make_img_3ch_8x8())
 
@@ -368,17 +369,22 @@ class TestDataFormat:
     """Verify data/weight sign & width are correctly inferred after compilation."""
 
     def test_snn_output_unsigned_1bit(self):
-        """SNN (IF/LIF default): output UNSIGNED 1BIT, input propagated."""
+        """SNN (IF/LIF default): fixed signed-8 input, spike outputs remain 1BIT."""
         graph = compile_to_paiir(SNNTwoLayer(), make_img_3ch_8x8())
 
-        for node in offline_nodes(graph):
-            cp = node.core_params
-            # SNN default: spike output is unsigned 1-bit
-            assert cp.output_sign == DataSign.UNSIGNED
-            assert cp.output_width == DataWidth.WIDTH_1BIT
-            # Input format must be filled
-            assert cp.input_sign == DataSign.UNSIGNED
-            assert cp.input_width == DataWidth.WIDTH_1BIT
+        nodes = offline_nodes(graph)
+        topo = graph.topo_sort()
+        first, second = sorted(nodes, key=lambda node: topo.index(node.name))
+
+        assert first.core_params.input_sign == DataSign.SIGNED
+        assert first.core_params.input_width == DataWidth.WIDTH_8BIT
+        assert first.core_params.output_sign == DataSign.UNSIGNED
+        assert first.core_params.output_width == DataWidth.WIDTH_1BIT
+
+        assert second.core_params.input_sign == DataSign.UNSIGNED
+        assert second.core_params.input_width == DataWidth.WIDTH_1BIT
+        assert second.core_params.output_sign == DataSign.UNSIGNED
+        assert second.core_params.output_width == DataWidth.WIDTH_1BIT
 
     def test_ann_output_8bit(self):
         """ANN (ReLU/Sigmoid): output 8BIT, sign matches activation."""

--- a/tests/paiir/pipeline/test_data_format.py
+++ b/tests/paiir/pipeline/test_data_format.py
@@ -7,6 +7,7 @@ from paicorelib import (
     DataSign,
     DataWidth,
     OutputType,
+    SNNMode,
     ThresholdNegMode,
 )
 from spikingjelly.activation_based import neuron as sj
@@ -229,7 +230,7 @@ class TestPropagateDataFormatSNN:
     """SNN networks: spike-based data flow."""
 
     def test_two_layer_snn(self):
-        """Conv-LIF -> Conv-IF: output 1BIT, second layer input 1BIT."""
+        """Conv-LIF -> Conv-IF: fixed signed-8 input, spike outputs remain 1BIT."""
 
         class Model(nn.Module):
             def __init__(self):
@@ -250,8 +251,8 @@ class TestPropagateDataFormatSNN:
         ops_sorted = sorted(ops, key=lambda o: topo.index(o.name))
         first, second = ops_sorted
 
-        assert first.core_params.input_sign == DataSign.UNSIGNED
-        assert first.core_params.input_width == DataWidth.WIDTH_1BIT
+        assert first.core_params.input_sign == DataSign.SIGNED
+        assert first.core_params.input_width == DataWidth.WIDTH_8BIT
         assert first.core_params.output_sign == DataSign.UNSIGNED
         assert first.core_params.output_width == DataWidth.WIDTH_1BIT
 
@@ -277,6 +278,7 @@ class TestPropagateDataFormatSNN:
 
         inp_name = fused.input_nodes()[0].name
         custom_fmt = {inp_name: (DataSign.SIGNED, DataWidth.WIDTH_8BIT)}
+        propagate_signal_semantics(fused, input_formats=custom_fmt)
         propagate_data_format(fused, input_formats=custom_fmt)
 
         ops = find_nodes(fused, OfflineCoreOp)
@@ -287,6 +289,22 @@ class TestPropagateDataFormatSNN:
         assert op.core_params.input_width == DataWidth.WIDTH_8BIT
         assert op.core_params.output_sign == DataSign.UNSIGNED
         assert op.core_params.output_width == DataWidth.WIDTH_1BIT
+
+    def test_default_input_format_is_fixed_signed_8bit(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(3, 16, 3, padding=1)
+                self.ifn = sj.IFNode()
+
+            def forward(self, x):
+                return self.ifn(self.conv(x))
+
+        fused = convert_fuse_propagate(Model(), torch.randn(1, 3, 8, 8))
+        op = find_nodes(fused, OfflineCoreOp)[0]
+
+        assert op.core_params.input_sign == DataSign.SIGNED
+        assert op.core_params.input_width == DataWidth.WIDTH_8BIT
 
 
 class TestPropagateDataFormatANN:
@@ -377,6 +395,46 @@ class TestPropagateDataFormatANN:
             conv.core_params.input_sign,
             conv.core_params.input_width,
         ) == input_format
+        if input_format == (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT):
+            assert pool.core_params.snn_mode == SNNMode.SNN
+            assert pool.lut_data is None
+        else:
+            assert pool.core_params.snn_mode == SNNMode.ANN
+            assert pool.lut_data is not None
+
+    def test_standalone_maxpool_uses_signed_spike_bypass_for_signed_spike_source(self):
+        class SignedSpikeMaxPool(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.spike = CoreNeuronV25(
+                    thres_pos=1.0,
+                    thres_neg=-1.0,
+                    thres_neg_mode=ThresholdNegMode.FIRE,
+                )
+                self.pool = nn.MaxPool2d(2, 2)
+
+            def forward(self, x):
+                return self.pool(self.spike(x))
+
+        unfused = torch_to_paiir(SignedSpikeMaxPool(), torch.randn(1, 1, 8, 8))
+        fused = fuse_to_offline_cores(specialize_general_adds(unfused))
+
+        propagate_signal_semantics(fused)
+        propagate_data_format(fused)
+
+        pool = next(
+            node
+            for node in fused.nodes.values()
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.MaxPool2d)
+        )
+
+        assert pool.core_params.input_sign == DataSign.SIGNED
+        assert pool.core_params.input_width == DataWidth.WIDTH_2BIT
+        assert pool.core_params.snn_mode == SNNMode.SNN
+        assert pool.lut_data is None
+        assert pool.neuron_params.thres_neg_mode == ThresholdNegMode.FIRE
+        assert pool.neuron_params.thres_neg == -1.0
 
     def test_subtract_tanh(self):
         """Two linear branches with subtraction -> tanh: UNSIGNED 8BIT."""
@@ -465,6 +523,9 @@ class TestPropagateDataFormatANN:
         graph.add_edge(reshape_skip.name, add.name)
         graph.add_edge(add.name, out.name)
 
+        propagate_signal_semantics(
+            graph, input_formats={inp.name: (DataSign.SIGNED, DataWidth.WIDTH_8BIT)}
+        )
         propagate_data_format(
             graph, input_formats={inp.name: (DataSign.SIGNED, DataWidth.WIDTH_8BIT)}
         )
@@ -480,6 +541,29 @@ class TestPropagateDataFormatANN:
         assert add.core_params.input_sign == DataSign.SIGNED
         assert add.core_params.input_width == DataWidth.WIDTH_32BIT
         assert add.core_params.output_width == DataWidth.WIDTH_32BIT
+
+    def test_standalone_act_with_value_predecessor_keeps_normal_add_potential(self):
+        graph = PAIIRGraph("value_to_standalone_act")
+        inp = InputNode(shape=torch.Size((1, 4)))
+        act = StandaloneActOp(ANNNodeV25(lut=LutReLU()))
+        out = OutputNode(shape=torch.Size((1, 4)))
+
+        for node in (inp, act, out):
+            graph.add_node(node)
+
+        graph.add_edge(inp.name, act.name)
+        graph.add_edge(act.name, out.name)
+
+        propagate_signal_semantics(
+            graph, input_formats={inp.name: (DataSign.SIGNED, DataWidth.WIDTH_8BIT)}
+        )
+        propagate_data_format(
+            graph, input_formats={inp.name: (DataSign.SIGNED, DataWidth.WIDTH_8BIT)}
+        )
+
+        assert act.core_params.add_potential == AddPotentialMode.NORMAL
+        assert act.core_params.input_sign == DataSign.SIGNED
+        assert act.core_params.input_width == DataWidth.WIDTH_8BIT
 
     def test_value_output_without_activation_raises(self):
         class ValueWithoutActOp(OfflineCoreOp):
@@ -502,6 +586,9 @@ class TestPropagateDataFormatANN:
             ValueError,
             match="declares VALUE output but has no activation",
         ):
+            propagate_signal_semantics(
+                graph, input_formats={inp.name: (DataSign.SIGNED, DataWidth.WIDTH_8BIT)}
+            )
             propagate_data_format(
                 graph, input_formats={inp.name: (DataSign.SIGNED, DataWidth.WIDTH_8BIT)}
             )
@@ -529,8 +616,8 @@ class TestPropagateDataFormatResidual:
         assert len(accum) == 1
         op = accum[0]
 
-        assert op.core_params.input_sign == DataSign.UNSIGNED
-        assert op.core_params.input_width == DataWidth.WIDTH_1BIT
+        assert op.core_params.input_sign == DataSign.SIGNED
+        assert op.core_params.input_width == DataWidth.WIDTH_8BIT
         assert op.core_params.output_sign == DataSign.UNSIGNED
         assert op.core_params.output_width == DataWidth.WIDTH_1BIT
 

--- a/tests/paiir/pipeline/test_passes.py
+++ b/tests/paiir/pipeline/test_passes.py
@@ -323,6 +323,7 @@ class TestComplexPatterns:
         assert len(preds) == 2
 
         fused = fuse_to_offline_cores(specialize_general_adds(unfused))
+        propagate_signal_semantics(fused)
         propagate_data_format(fused)
         assign_tick_params(fused)
 
@@ -983,6 +984,47 @@ class TestValidateCompiledGraph:
         with pytest.raises(GraphValidationError, match="invalid split spec"):
             validate_compiled_graph(graph)
 
+    def test_rejects_standalone_act_32bit_input_without_direct_add(self):
+        graph = PAIIRGraph("bad_standalone_act_direct_add")
+        inp = InputNode(shape=torch.Size((1, 4)))
+        comp = StandaloneCompOp(nn.Linear(4, 4, bias=False))
+        act = StandaloneActOp(ANNNodeV25(lut=LutReLU()))
+        out = OutputNode(shape=torch.Size((1, 4)))
+
+        _set_single_layouts(comp, (1, 4), (1, 4), (0, 1), (0, 1))
+        _set_single_layouts(act, (1, 4), (1, 4), (0, 1), (0, 1))
+
+        for node in (comp, act):
+            node.core_params.tick_start = 1
+            node.core_params.tick_duration = 0
+            node.core_params.tick_initial = 0
+
+        comp.core_params.set_input_format((DataSign.SIGNED, DataWidth.WIDTH_8BIT))
+        comp.core_params.set_output_format((DataSign.SIGNED, DataWidth.WIDTH_32BIT))
+        comp.core_params.set_weight_format((DataSign.SIGNED, DataWidth.WIDTH_8BIT))
+        act.core_params.set_input_format((DataSign.SIGNED, DataWidth.WIDTH_32BIT))
+        act.core_params.set_output_format((DataSign.UNSIGNED, DataWidth.WIDTH_8BIT))
+        act.core_params.set_weight_format((DataSign.UNSIGNED, DataWidth.WIDTH_1BIT))
+
+        inp.signal_semantics.output_domain = SignalDomain.VALUE
+        comp.signal_semantics.output_domain = SignalDomain.POTENTIAL
+        act.signal_semantics.output_domain = SignalDomain.VALUE
+        out.signal_semantics.output_domain = SignalDomain.VALUE
+
+        graph.add_node(inp)
+        graph.add_node(comp)
+        graph.add_node(act)
+        graph.add_node(out)
+        graph.add_edge(inp.name, comp.name)
+        graph.add_edge(comp.name, act.name)
+        graph.add_edge(act.name, out.name)
+
+        with pytest.raises(
+            GraphValidationError,
+            match="receives WIDTH_32BIT input but add_potential is not AddPotentialMode.DIRECT_ADD",
+        ):
+            validate_compiled_graph(graph)
+
 
 class TestSplitPassBehavior:
     def _build_split_routing_graph(
@@ -1195,6 +1237,21 @@ class TestSignalSemantics:
         assert inp.signal_semantics.known_code_range == (-8, 7)
         assert out.signal_semantics.output_domain is SignalDomain.VALUE
         assert out.signal_semantics.known_code_range == (-8, 7)
+
+    def test_input_node_default_known_code_range_uses_fixed_signed_8bit(self):
+        graph = PAIIRGraph("input_semantics_default")
+        inp = InputNode(shape=torch.Size((1, 4)))
+        out = OutputNode(shape=torch.Size((1, 4)))
+        graph.add_node(inp)
+        graph.add_node(out)
+        graph.add_edge(inp.name, out.name)
+
+        propagate_signal_semantics(graph)
+
+        assert inp.signal_semantics.output_domain is SignalDomain.VALUE
+        assert inp.signal_semantics.known_code_range == (-128, 127)
+        assert out.signal_semantics.output_domain is SignalDomain.VALUE
+        assert out.signal_semantics.known_code_range == (-128, 127)
 
     def test_concat_known_code_range_requires_all_predecessors_known(self):
         graph = PAIIRGraph("concat_known_code_range")


### PR DESCRIPTION
## Summary
- add exact standalone MaxPool export paths for spike-preserving bypass and identity LUT cases
- tighten signal-semantics and data-format inference around stable node annotations and fixed input defaults
- make backendv2 read LUT config directly from IR nodes instead of only `SequentialOp.act.lut`
- add focused PAIIR regressions for standalone MaxPool export, signal semantics, and 32-bit input consumer contracts