### PR TITLE
feat: support fold neuron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,8 @@ target/
 profile_default/
 ipython_config.py
 
+debug*
+
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:

--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -165,8 +165,7 @@ class OfflineCorePlacementV2(CorePlacement):
     def set_auto_core_config(self) -> None:
         neuron_number = 0
         for neu in self.neus:
-            neu_count = 1 if neu.neuron_type == NeuronType.HALF else 2
-            neuron_number += neu_count
+            neuron_number += neu.n_sram_required
         self.auto_core_config.neuron_number = neuron_number
         pkt_offset, _ = find_coordxy_shortest_path(self.coord, TEST_DEST_CORE)
         self.auto_core_config.test_core_xy = pkt_offset.z

--- a/paibox/backendv2/fold_neu.py
+++ b/paibox/backendv2/fold_neu.py
@@ -1,0 +1,158 @@
+import numpy as np
+
+
+def get_skew_info(offsets: list[int]):
+    offset_diff = np.diff(offsets)
+    diff_num = len(np.unique(offset_diff))
+    if diff_num > 3:
+        return None
+
+    if diff_num == 1:
+        diff = offsets[1] - offsets[0]
+        skews = [diff]
+        ranges = [len(offsets)]
+        return skews, ranges
+
+    skews = []
+    ranges = []
+    distances = []
+    for i, diff in enumerate(offset_diff):
+        if len(skews) == 0:
+            skews.append(diff.item())
+            distances.append(1)
+        else:
+            # has not meet the next skew, continue counting
+            for j in reversed(range(len(distances))):
+                last_distance = distances[j]
+                if (i + 1) % last_distance == 0:
+                    if diff == skews[j]:
+                        break
+                    else:
+                        # meet the next skew, insert it after the current skew
+                        if j == len(distances) - 1:
+                            skews.append(diff.item())
+                            distances.append(i + 1)
+                            break
+                        else:
+                            return None
+                else:
+                    continue
+
+    skews = skews
+
+    last_distance = len(offsets)
+    for i in reversed(range(len(distances))):
+        if last_distance % distances[i] != 0:
+            return None
+        ranges.insert(0, last_distance // distances[i])
+        last_distance = distances[i]
+    ranges = ranges
+    return skews, ranges
+
+
+import math
+
+
+def closest_factor(n, partition_num) -> int:
+    if partition_num == 1:
+        return n
+    if n <= 0:
+        raise ValueError("n must be a positive integer.")
+
+    # 1. 计算立方根并取整作为起点
+    start = int(math.pow(n, 1 / partition_num))
+
+    # 2. 从起点向 1 递减搜索
+    for i in range(start, 0, -1):
+        if n % i == 0:
+            return i
+    return 1  # 如果没有找到任何因数，返回 1
+
+
+def process_exceed(ranges, weight_skews, axon_addr_skews):
+    processed_ranges = []
+    processed_weight_skews = []
+    processed_axon_addr_skews = []
+    remain_space = 3 - len(ranges)
+    for i, range_ in enumerate(ranges):
+        if range_ < 2048:
+            processed_ranges.append(range_)
+            processed_weight_skews.append(weight_skews[i])
+            processed_axon_addr_skews.append(axon_addr_skews[i])
+        else:
+            num_partition = math.ceil(math.log(range_, 2047))
+            if num_partition > remain_space:
+                return None
+            remain_num = range_
+            for j in range(num_partition):
+                patial_num = num_partition - j
+                factor = closest_factor(remain_num, patial_num)
+                if factor < 2048:
+                    processed_ranges.append(factor)
+                    processed_weight_skews.append(weight_skews[i])
+                    processed_axon_addr_skews.append(axon_addr_skews[i])
+                    remain_num = remain_num // factor
+                    continue
+                else:
+                    return None
+            remain_space -= num_partition - 1
+    processed_ranges = processed_ranges + [1] * (3 - len(processed_ranges))
+    processed_weight_skews = processed_weight_skews + [1] * (
+        3 - len(processed_weight_skews)
+    )
+    processed_axon_addr_skews = processed_axon_addr_skews + [1] * (
+        3 - len(processed_axon_addr_skews)
+    )
+    return processed_ranges, processed_weight_skews, processed_axon_addr_skews
+
+
+def get_fold_info(weight_offsets: list[int], axon_addr_offsets: list[int]):
+    # weight_offsets_diff = np.diff(weight_offsets)
+    # axon_addr_offsets_diff = np.diff(axon_addr_offsets)
+    weight_info = get_skew_info(weight_offsets)
+    axon_addr_info = get_skew_info(axon_addr_offsets)
+    if weight_info is None or axon_addr_info is None:
+        return None
+    weight_skews, weight_ranges = weight_info
+    # print(f"weight_skews: {weight_skews}, weight_ranges: {weight_ranges}")
+    axon_addr_skews, axon_addr_ranges = axon_addr_info
+    # print(f"axon_addr_skews: {axon_addr_skews}, axon_addr_ranges: {axon_addr_ranges}")
+    if len(weight_ranges) == len(axon_addr_ranges):
+        if weight_ranges == axon_addr_ranges:
+            ranges = weight_ranges
+            process_result = process_exceed(ranges, weight_skews, axon_addr_skews)
+            return process_result
+        else:
+            return None
+    elif len(weight_ranges) == 1 or len(axon_addr_ranges) == 1:
+        if len(weight_ranges) == 1:
+            ranges = axon_addr_ranges
+            weight_skews = weight_skews * len(ranges)
+        else:
+            ranges = weight_ranges
+            axon_addr_skews = axon_addr_skews * len(ranges)
+        return process_exceed(ranges, weight_skews, axon_addr_skews)
+    elif len(weight_ranges) == 3 and len(axon_addr_ranges) == 2:
+        if weight_ranges[0] == axon_addr_ranges[0]:
+            ranges = weight_ranges
+            axon_addr_skews = axon_addr_skews + [axon_addr_skews[-1]]
+            return ranges, axon_addr_skews, weight_skews
+        elif weight_ranges[-1] == axon_addr_ranges[-1]:
+            ranges = weight_ranges
+            axon_addr_skews = [axon_addr_skews[0]] + axon_addr_skews
+            return ranges, axon_addr_skews, weight_skews
+        else:
+            return None
+    elif len(weight_ranges) == 2 and len(axon_addr_ranges) == 3:
+        if weight_ranges[0] == axon_addr_ranges[0]:
+            ranges = axon_addr_ranges
+            weight_skews = weight_skews + [weight_skews[-1]]
+            return ranges, axon_addr_skews, weight_skews
+        elif weight_ranges[-1] == axon_addr_ranges[-1]:
+            ranges = axon_addr_ranges
+            weight_skews = [weight_skews[0]] + weight_skews
+            return ranges, axon_addr_skews, weight_skews
+        else:
+            return None
+    else:
+        return None

--- a/paibox/backendv2/get_weight.py
+++ b/paibox/backendv2/get_weight.py
@@ -358,6 +358,9 @@ def expanded_path_weight_matrix(
         return direct_weight_matrix(weight, input_shape, output_shape, sign)
 
     if isinstance(comp, nn.Conv1d):
+        print(
+            f"\tExpanding Conv1d weight from {input_shape} to {output_shape} with stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}, groups={comp.groups}."
+        )
         assert weight is not None
         assert not isinstance(
             comp.padding, str
@@ -383,7 +386,7 @@ def expanded_path_weight_matrix(
 
     if isinstance(comp, nn.Conv2d):
         print(
-            f"Expanding Conv2d weight from {input_shape} to {output_shape} with stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}, groups={comp.groups}."
+            f"\tExpanding Conv2d weight from {input_shape} to {output_shape} with stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}, groups={comp.groups}."
         )
         assert weight is not None
         assert not isinstance(
@@ -409,6 +412,7 @@ def expanded_path_weight_matrix(
         )
 
     if isinstance(comp, nn.MaxPool1d):
+        print(f"\tExpanding MaxPool1d from {input_shape} to {output_shape} with kernel_size={comp.kernel_size}, stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}.")
         if comp.ceil_mode:
             raise NotImplementedError("MaxPool1d with ceil_mode=True is not supported.")
 
@@ -435,6 +439,7 @@ def expanded_path_weight_matrix(
         )
 
     if isinstance(comp, SumPool1d) or isinstance(comp, nn.AvgPool1d):
+        print(f"\tExpanding AvgPool1d from {input_shape} to {output_shape} with kernel_size={comp.kernel_size}, stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}.")
         if comp.ceil_mode:
             raise NotImplementedError("AvgPool1d with ceil_mode=True is not supported.")
         kernel_size = to_nd_tuple(comp.kernel_size, 1)
@@ -458,6 +463,7 @@ def expanded_path_weight_matrix(
         )
 
     if isinstance(comp, nn.MaxPool2d):
+        print(f"\tExpanding MaxPool2d from {input_shape} to {output_shape} with kernel_size={comp.kernel_size}, stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}.")
         if comp.ceil_mode:
             raise NotImplementedError("MaxPool2d with ceil_mode=True is not supported.")
         kernel_size = to_nd_tuple(comp.kernel_size, 2)
@@ -483,6 +489,7 @@ def expanded_path_weight_matrix(
         )
 
     if isinstance(comp, nn.AvgPool2d) or isinstance(comp, SumPool2d):
+        print(f"\tExpanding AvgPool2d from {input_shape} to {output_shape} with kernel_size={comp.kernel_size}, stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}.")
         if comp.ceil_mode:
             raise NotImplementedError("AvgPool2d with ceil_mode=True is not supported.")
         kernel_size = to_nd_tuple(comp.kernel_size, 2)
@@ -770,7 +777,7 @@ def group_shift_weights_optimized(
 
     for i in track(
         range(n_weights),
-        description="weight optimization",
+        description="computing base weights",
         total=len(range(n_weights)),
     ):
         row = matrix[i]

--- a/paibox/backendv2/get_weight.py
+++ b/paibox/backendv2/get_weight.py
@@ -412,7 +412,9 @@ def expanded_path_weight_matrix(
         )
 
     if isinstance(comp, nn.MaxPool1d):
-        print(f"\tExpanding MaxPool1d from {input_shape} to {output_shape} with kernel_size={comp.kernel_size}, stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}.")
+        print(
+            f"\tExpanding MaxPool1d from {input_shape} to {output_shape} with kernel_size={comp.kernel_size}, stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}."
+        )
         if comp.ceil_mode:
             raise NotImplementedError("MaxPool1d with ceil_mode=True is not supported.")
 
@@ -439,7 +441,9 @@ def expanded_path_weight_matrix(
         )
 
     if isinstance(comp, SumPool1d) or isinstance(comp, nn.AvgPool1d):
-        print(f"\tExpanding AvgPool1d from {input_shape} to {output_shape} with kernel_size={comp.kernel_size}, stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}.")
+        print(
+            f"\tExpanding AvgPool1d from {input_shape} to {output_shape} with kernel_size={comp.kernel_size}, stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}."
+        )
         if comp.ceil_mode:
             raise NotImplementedError("AvgPool1d with ceil_mode=True is not supported.")
         kernel_size = to_nd_tuple(comp.kernel_size, 1)
@@ -463,7 +467,9 @@ def expanded_path_weight_matrix(
         )
 
     if isinstance(comp, nn.MaxPool2d):
-        print(f"\tExpanding MaxPool2d from {input_shape} to {output_shape} with kernel_size={comp.kernel_size}, stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}.")
+        print(
+            f"\tExpanding MaxPool2d from {input_shape} to {output_shape} with kernel_size={comp.kernel_size}, stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}."
+        )
         if comp.ceil_mode:
             raise NotImplementedError("MaxPool2d with ceil_mode=True is not supported.")
         kernel_size = to_nd_tuple(comp.kernel_size, 2)
@@ -489,7 +495,9 @@ def expanded_path_weight_matrix(
         )
 
     if isinstance(comp, nn.AvgPool2d) or isinstance(comp, SumPool2d):
-        print(f"\tExpanding AvgPool2d from {input_shape} to {output_shape} with kernel_size={comp.kernel_size}, stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}.")
+        print(
+            f"\tExpanding AvgPool2d from {input_shape} to {output_shape} with kernel_size={comp.kernel_size}, stride={comp.stride}, padding={comp.padding}, dilation={comp.dilation}."
+        )
         if comp.ceil_mode:
             raise NotImplementedError("AvgPool2d with ceil_mode=True is not supported.")
         kernel_size = to_nd_tuple(comp.kernel_size, 2)
@@ -750,7 +758,7 @@ class WeightInfo:
 
 
 def group_shift_weights_optimized(
-    raw_weights: list[np.ndarray],
+    raw_weights: list[np.ndarray], prefix: str = ""
 ) -> tuple[list[WeightInfo], list[np.ndarray]]:
     if not raw_weights:
         return [], []
@@ -777,7 +785,7 @@ def group_shift_weights_optimized(
 
     for i in track(
         range(n_weights),
-        description="computing base weights",
+        description=f"{prefix}computing base weights",
         total=len(range(n_weights)),
     ):
         row = matrix[i]
@@ -808,13 +816,13 @@ def group_shift_weights_optimized(
 
 def reorder_by_base_weight(
     group_items: list[tuple[Neuron, np.ndarray]], weights_info: list[WeightInfo]
-) -> tuple[list[tuple[Neuron, np.ndarray]], list[WeightInfo]]:
+) -> tuple[list[Neuron], list[WeightInfo]]:
 
     paired = list(zip(group_items, weights_info))
 
     paired_sorted = sorted(paired, key=lambda x: (x[1].index, x[1].offset))
 
-    reordered_items = [p[0] for p in paired_sorted]
+    reordered_neus = [p[0][0] for p in paired_sorted]
     reordered_infos = [p[1] for p in paired_sorted]
 
-    return reordered_items, reordered_infos
+    return reordered_neus, reordered_infos

--- a/paibox/backendv2/group_tile.py
+++ b/paibox/backendv2/group_tile.py
@@ -242,6 +242,7 @@ def build_tile_group(
             raw_neus=tile_output_lists[t],
             input_list=tile_input_lists[t],
         )
+        tiled_group.recommand_lcn = MAX_LCN # recommend using max lcn for tiled groups to avoid further tiling
         tiled_groups.append(tiled_group)
     return copied_input_elems, tiled_groups
 

--- a/paibox/backendv2/group_tile.py
+++ b/paibox/backendv2/group_tile.py
@@ -242,7 +242,9 @@ def build_tile_group(
             raw_neus=tile_output_lists[t],
             input_list=tile_input_lists[t],
         )
-        tiled_group.recommand_lcn = MAX_LCN # recommend using max lcn for tiled groups to avoid further tiling
+        tiled_group.recommand_lcn = (
+            MAX_LCN  # recommend using max lcn for tiled groups to avoid further tiling
+        )
         tiled_groups.append(tiled_group)
     return copied_input_elems, tiled_groups
 

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -290,7 +290,7 @@ class Mapper:
         self,
         pai_graph: PAIIRGraph,
         base: str = "bin",  # 新增参数，指定导出格式
-        output_path: str = "./output",
+        output_path: str | None = None,
     ) -> None:
         # determine raw_neus in routing groups, other properties remain unset
         self.generate_routing_groups(pai_graph)
@@ -347,18 +347,23 @@ class Mapper:
         self.routing()
 
         print("\nAfter routing:")
-        for grp in all_groups:
-            print(grp.info())
+        # for grp in all_groups:
+        #     print(grp.info())
 
         for rg in all_groups:
-            print(rg.routing_summary())
+            print(rg.routing_summary(prefix="    "))
 
         self.set_detail_dest()
 
         self.set_auto_core_config()
 
         # export to hardware executable format
-
+        if output_path is None:
+            env_output_path = os.environ.get("PAIBOX_OUTPUT_PATH")
+            if env_output_path is not None:
+                output_path = env_output_path
+            else:
+                output_path = "./output"
         self.export(output_path=output_path)
         self.export_merge(output_path=output_path)
         self.export_cheader_file(output_path=output_path, base=base)

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -339,8 +339,9 @@ class Mapper:
         for rg in self.routing_groups:
             rg.allocate_neurons()
 
+        print("\nAll groups after neuron allocation:")
         for rg in all_groups:
-            print(rg.info())
+            print(rg.routing_summary())
 
         # set core placements' coord, and generate detailed dest info for each neuron
         self.routing()

--- a/paibox/backendv2/neuron.py
+++ b/paibox/backendv2/neuron.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 import numpy as np
 from paicorelib import (
     FRAME_DTYPE,
@@ -29,14 +31,20 @@ class OfflineNeuronPlacement(NeuronPlacement):
         neu: list[Neuron],
         attrs_part1: OfflineNeuFullAttrsV2Part1,
         attrs_part2: OfflineNeuFullAttrsV2Part2,
+        fold_attrs_part1: Optional[OfflineNeuFoldedAttrsV2Part1] = None,
+        fold_attrs_part2s: list[OfflineNeuFoldedAttrsV2Part2] = [],
     ):
         super().__init__(neu)
         self.neu_attrs_part1: OfflineNeuFullAttrsV2Part1 = attrs_part1
         self.neu_attrs_part2: OfflineNeuFullAttrsV2Part2 | None = (
             attrs_part2 if attrs_part1.neuron_type == NeuronType.FULL else None
         )
-        self.folded_neu_attrs_part1: OfflineNeuFoldedAttrsV2Part1 | None = None
-        self.folded_neu_attrs_part2s: list[OfflineNeuFoldedAttrsV2Part2] = []
+        self.folded_neu_attrs_part1: Optional[OfflineNeuFoldedAttrsV2Part1] = (
+            fold_attrs_part1
+        )
+        self.folded_neu_attrs_part2s: list[OfflineNeuFoldedAttrsV2Part2] = (
+            fold_attrs_part2s
+        )
         self.n_sram_required: int = self.n_sram_required_()
 
     def n_sram_required_(self) -> int:

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from collections.abc import Sequence, Set
-from typing import AbstractSet, Generic, Optional, TypeVar
+from collections import defaultdict, deque
+from collections.abc import Set
+from typing import AbstractSet, Generic, List, Optional, Sequence, TypeVar
 
 import numpy as np
 from paicorelib import (
@@ -12,6 +13,8 @@ from paicorelib import (
     FoldType,
     NeuronType,
     OfflineNeuDestInfoV2,
+    OfflineNeuFoldedAttrsV2Part1,
+    OfflineNeuFoldedAttrsV2Part2,
     OfflineNeuFullAttrsV2Part1,
     OfflineNeuFullAttrsV2Part2,
     WeightCompressType,
@@ -25,6 +28,7 @@ from .coreplacement import (
     EmptyOfflineCorePlacementV2,
     OfflineCorePlacementV2,
 )
+from .fold_neu import get_fold_info
 from .get_weight import (
     WeightInfo,
     choose_weight_strategy,
@@ -43,6 +47,7 @@ from .op_node import (
     SourceElem,
     SourceNode,
 )
+from .weight import Weight
 
 FANIN_BASE = 512
 
@@ -178,21 +183,26 @@ class SourceGroup(Generic[SOURCE_ELEM, SOURCE_NODE]):
         return info_str + "\n"
 
     def get_detail_dest(
-        self, elem: SOURCE_ELEM, self_coord: CoordXY = CoordXY(0, 0)
+        self, elems: list[SOURCE_ELEM], self_coord: CoordXY = CoordXY(0, 0)
     ) -> OfflineNeuDestInfoV2:
-        dest_routing_group = self.get_dest(elem)
-        axon_elem = self.get_axon(elem)
+        dest_routing_group = self.get_dest(elems[0])
+        axon_elem = self.get_axon(elems[0])
         if isinstance(dest_routing_group, RoutingGroup):
             axon_addr_logic = dest_routing_group.index_map.get(axon_elem, -1)
             assert axon_addr_logic >= 0, "axon_addr_logic should be non-negative"
             assert (
-                elem.output_bit_num == dest_routing_group.input_bit_num
+                elems[0].output_bit_num == dest_routing_group.input_bit_num
             ), "Output bit num of elem must match input bit num of dest routing group"
             axon_bit_count = axon_addr_logic * dest_routing_group.input_bit_num
         elif isinstance(dest_routing_group, OutputGroup):
-            axon_bit_count = dest_routing_group.axon_bit_allocator.allocate(
-                self_coord, elem
-            )
+            axon_bit_count = -1
+            for i, elem in enumerate(elems):
+                if i == 0:
+                    axon_bit_count = dest_routing_group.axon_bit_allocator.allocate(
+                        CoordXY(0, 0), elem
+                    )
+                else:
+                    dest_routing_group.axon_bit_allocator.allocate(CoordXY(0, 0), elem)
             assert axon_bit_count < FANIN_BASE * (
                 2**LCN_EX.LCN_128X.value
             ), "Total axon bit count for output group exceeds the maximum supported by LCN_128X"
@@ -413,8 +423,12 @@ class RoutingGroup(
             )
             weight_sram_req = selected_weight.n_sram_required
             attrs_part2.weight_compress = weight_compress
-            print(f"\tno zero elements in base weight {weight_info.index} is {np.count_nonzero(base_weight)}")
-            print(f"\tbase weight {weight_info.index} requires {weight_sram_req} SRAM lines with compression {weight_compress}.")
+            print(
+                f"\tno zero elements in base weight {weight_info.index} is {np.count_nonzero(base_weight)}"
+            )
+            print(
+                f"\tbase weight {weight_info.index} requires {weight_sram_req} SRAM lines with compression {weight_compress}."
+            )
             if weight_sram_req > 4096:
                 raise NotImplementedError(
                     f"Base weight {weight_info.index} requires {weight_sram_req} SRAM lines, which exceeds the limit."
@@ -493,41 +507,234 @@ class RoutingGroup(
             )
         return current_core
 
+    def try_to_fold_neuron(
+        self,
+        base_weights: List[np.ndarray],
+        ordered_neus: list[Neuron],
+        ordered_infos: list[WeightInfo],
+        frontend_core_conf: Frontend_Core_Config,
+        backend_core_conf: Backend_Core_Config,
+        prefix: str = "",
+    ):
+        folded_neurons: set[Neuron] = set()
+        buckets: dict[int, list[tuple[Neuron, WeightInfo]]] = defaultdict(
+            list[tuple[Neuron, WeightInfo]]
+        )
+        for neu, info in zip(ordered_neus, ordered_infos):
+            buckets[info.index].append((neu, info))
+        current_core = OfflineCorePlacementV2(frontend_core_conf, backend_core_conf)
+        stored_base_weight: dict[int, tuple[int, WeightCompressType]] = {}
+        weight_strategy_cache: dict[int, tuple[Weight, WeightCompressType]] = {}
+        for index, bucket in buckets.items():
+            neurons = [neu for neu, _ in bucket]
+            neu_nodes = [neu.target for neu in neurons]
+            if len(set(neu_nodes)) != 1:
+                # 这个 base weight 对应的 neurons 来自不同的 neuron nodes 上，暂时不考虑折叠
+                continue
+            sub_buckets: dict[
+                RoutingGroup | OutputGroup, list[tuple[Neuron, WeightInfo]]
+            ] = defaultdict(list[tuple[Neuron, WeightInfo]])
+            for neu, info in bucket:
+                dest_group = self.get_dest(neu)
+                sub_buckets[dest_group].append((neu, info))
+
+            for dest_group, sub_bucket in sub_buckets.items():
+                if isinstance(dest_group, OutputGroup):
+                    # OutputGroup 的 axon bit 依赖路由后坐标分配，当前阶段不做 fold
+                    continue
+                sub_neurons = [neu for neu, _ in sub_bucket]
+                weight_offsets = [info.offset for _, info in sub_bucket]
+                axon_addr_offsets = [self.get_dest_info(neu)[1] for neu in sub_neurons]
+
+                fold_info = get_fold_info(weight_offsets, axon_addr_offsets)
+                if fold_info is None:
+                    continue
+                ranges, fold_axon_skews, fold_weight_skews = fold_info
+                print(
+                    f"{prefix}Find fold neurons with base weight {index} "
+                    f"to dest group {dest_group.name}:"
+                )
+                print(f"{prefix}    fold_range: {ranges}")
+                print(f"{prefix}    fold_weight_skews: {fold_weight_skews}")
+                print(f"{prefix}    fold_axon_skews: {fold_axon_skews}")
+                skip_fold = False
+                for skew in fold_weight_skews:
+                    if skew * self.input_bit_num > 2047:
+                        print(
+                            f"{prefix}Fold weight skew {skew} is too large for input bit num {self.input_bit_num}, skipping fold."
+                        )
+                        skip_fold = True
+                        break
+                for skew in fold_axon_skews:
+                    if skew * dest_group.input_bit_num > 2047:
+                        print(
+                            f"{prefix}Fold axon skew {skew} is too large for input bit num {self.input_bit_num}, skipping fold."
+                        )
+                        skip_fold = True
+                        break
+                if skip_fold:
+                    continue
+
+                if index not in weight_strategy_cache:
+                    current_weight_width = frontend_core_conf.weight_width
+                    base_weight = base_weights[index]
+                    selected_weight, weight_compress = choose_weight_strategy(
+                        base_weight,
+                        current_weight_width,
+                        frontend_core_conf.input_width,
+                        frontend_core_conf.add_potential,
+                    )
+                    weight_strategy_cache[index] = (selected_weight, weight_compress)
+                selected_weight, weight_compress = weight_strategy_cache[index]
+                weight_sram_req = selected_weight.n_sram_required
+
+                attrs_part2 = sub_neurons[0].attrs_part2()
+                attrs_part2.weight_compress = weight_compress
+                neuron_type = NeuronType.FULL
+                output_type = sub_neurons[0].output_type()
+                attrs_part1 = OfflineNeuFullAttrsV2Part1(
+                    weight_skew=weight_offsets[0] * self.input_bit_num,
+                    weight_address_start=0,  # 之后会统一设置
+                    weight_address_end=0,  # 之后会统一设置
+                    fold_type=FoldType.FOLDED,
+                    neuron_type=neuron_type,
+                    output_type=output_type,
+                )
+
+                if isinstance(dest_group, OutputGroup):
+                    # if folded neurons send to output group,
+                    # axon skews should be all 1.
+                    assert fold_axon_skews == [
+                        1,
+                        1,
+                        1,
+                    ], "Folded neurons sending to output group should have axon skew of 1"
+
+                fold_attrs_part1 = OfflineNeuFoldedAttrsV2Part1(
+                    fold_axon_y=fold_axon_skews[0] * dest_group.input_bit_num,
+                    fold_axon_x=fold_axon_skews[1] * dest_group.input_bit_num,
+                    fold_axon_xy=fold_axon_skews[2] * dest_group.input_bit_num,
+                    fold_skew_y=fold_weight_skews[0] * self.input_bit_num,
+                    fold_skew_x=fold_weight_skews[1] * self.input_bit_num,
+                    fold_skew_xy=fold_weight_skews[2] * self.input_bit_num,
+                    fold_range_y=ranges[0],
+                    fold_range_x=ranges[1],
+                    fold_range_xy=ranges[2],
+                    fold_number=len(sub_neurons),
+                )
+                num_fold_part2 = (len(sub_neurons) - 1 + 3) // 4
+                fold_attrs_part2s = [
+                    OfflineNeuFoldedAttrsV2Part2() for _ in range(num_fold_part2)
+                ]
+                neu_placement = OfflineNeuronPlacement(
+                    sub_neurons,
+                    attrs_part1,
+                    attrs_part2,
+                    fold_attrs_part1,
+                    fold_attrs_part2s,
+                )
+                neu_sram_req = neu_placement.n_sram_required
+
+                added_weight_sram_req = (
+                    0 if index in stored_base_weight else weight_sram_req
+                )
+                total_sram_req = neu_sram_req + added_weight_sram_req
+                if total_sram_req > 4096:
+                    print(
+                        f"{prefix}Folding neurons with base weight {index} to dest group "
+                        f"{dest_group.name} requires {total_sram_req} SRAM lines, "
+                        "which exceeds the limit. Skipping folding."
+                    )
+                    continue
+
+                if current_core.n_sram_required + total_sram_req > 4096:
+                    if len(current_core.neus) > 0:
+                        self.core_placements.append(current_core)
+                    current_core = OfflineCorePlacementV2(
+                        frontend_core_conf, backend_core_conf
+                    )
+                    stored_base_weight.clear()
+                    added_weight_sram_req = weight_sram_req
+                    total_sram_req = neu_sram_req + added_weight_sram_req
+                    if total_sram_req > 4096:
+                        print(
+                            f"{prefix}Folding neurons with base weight {index} to dest group "
+                            f"{dest_group.name} requires {total_sram_req} SRAM lines, "
+                            "which exceeds the limit. Skipping folding."
+                        )
+                        continue
+
+                remaining_sram = 4096 - current_core.n_sram_required - total_sram_req
+                print(
+                    f"{prefix}core[{len(self.core_placements)}]:Folded neuron stored with base weight {index} "
+                    f"to dest group {dest_group.name}:"
+                )
+                print(f"{prefix}    num neurons: {len(sub_neurons)}")
+                print(f"{prefix}    num sram lines: {neu_sram_req}")
+                print(f"{prefix}    weight sram lines: {added_weight_sram_req}")
+                print(f"{prefix}    total sram lines: {total_sram_req}")
+                print(f"{prefix}    remaining sram lines: {remaining_sram}")
+
+                if index not in stored_base_weight:
+                    current_core.weights.append(selected_weight)
+                    stored_base_weight[index] = (
+                        len(current_core.weights) - 1,
+                        weight_compress,
+                    )
+                stored_weight_index, _ = stored_base_weight[index]
+                current_core.neus.append(neu_placement)
+                current_core.neu_weight_map[len(current_core.neus) - 1] = (
+                    stored_weight_index
+                )
+                folded_neurons.update(sub_neurons)
+
+        return folded_neurons, current_core, stored_base_weight
+
     def place_neurons_optimal(
         self,
         frontend_core_conf: Frontend_Core_Config,
         backend_core_conf: Backend_Core_Config,
         group_items: list[tuple[Neuron, np.ndarray]],
         block_id: int = 0,
+        prefix: str = "",
     ):
         weights_of_group = [item[1] for item in group_items]
-        weight_infos, base_weights = group_shift_weights_optimized(weights_of_group)
+        weight_infos, base_weights = group_shift_weights_optimized(
+            weights_of_group, prefix
+        )
         # reorder group_items making the ones with the same base weight together, to improve weight storage efficiency
-        reordered_items, reordered_infos = reorder_by_base_weight(
+        reordered_neus, reordered_infos = reorder_by_base_weight(
             group_items, weight_infos
         )
 
         # import os
-        # os.makedirs("debug_padding", exist_ok=True)
-        # with open(f"debug_padding/{self.name}_weight_base.txt", "w") as f:
+        # os.makedirs("debug_fold_256", exist_ok=True)
+        # with open(f"debug_fold_256/{self.name}_weight_base.txt", "w") as f:
         #     for weight in base_weights:
         #         f.write(" ".join(map(str, weight)) + "\n")
         #     for info in reordered_infos:
         #         f.write(f"index: {info.index}, offset: {info.offset}\n")
 
-        current_core = OfflineCorePlacementV2(frontend_core_conf, backend_core_conf)
-        self.last_full_attrs = None
-        stored_base_weight: dict[int, tuple[int, WeightCompressType]] = (
-            {}
-        )  # map from base weight index to the index of core's weight list where it's stored
+        print(f"{prefix}trying to fold neurons")
+        folded_neurons, current_core, stored_base_weight = self.try_to_fold_neuron(
+            base_weights,
+            reordered_neus,
+            reordered_infos,
+            frontend_core_conf,
+            backend_core_conf,
+            prefix=f"{prefix}    ",
+        )
 
-        print(f"\nallocating {self.name} block [{block_id}]")
-        description = f"allocating {self.name} block [{block_id}]"
-        for (neu, weight_of_neu), weight_info in track(
-            zip(reordered_items, reordered_infos),
+        # current_core = OfflineCorePlacementV2(frontend_core_conf, backend_core_conf)
+        self.last_full_attrs = None
+        description = f"{prefix}place unfolded neurons"
+        for neu, weight_info in track(
+            zip(reordered_neus, reordered_infos),
             description=description,
-            total=len(reordered_items),  # 明确指定总数，确保进度条计算准确
+            total=len(reordered_neus),  # 明确指定总数，确保进度条计算准确
         ):
+            if neu in folded_neurons:
+                continue
             current_core = self.try_store_neuron(
                 neu,
                 stored_base_weight,
@@ -540,80 +747,6 @@ class RoutingGroup(
         if len(current_core.neus) > 0:
             self.core_placements.append(current_core)
 
-    def place_neurons_raw(
-        self,
-        frontend_core_conf: Frontend_Core_Config,
-        backend_core_conf: Backend_Core_Config,
-        group_items: list[tuple[Neuron, np.ndarray]],
-        block_id: int = 0,
-    ):
-        current_core = OfflineCorePlacementV2(frontend_core_conf, backend_core_conf)
-
-        self.last_full_attrs = None
-
-        for neu, weight_of_neu in group_items:
-            attrs_part2 = neu.attrs_part2()
-
-            # Weight Strategy
-            current_weight_width = frontend_core_conf.weight_width
-            selected_weight, attrs_part2.weight_compress = choose_weight_strategy(
-                weight_of_neu,
-                current_weight_width,
-                frontend_core_conf.input_width,
-                frontend_core_conf.add_potential,
-            )
-
-            neuron_type = (
-                NeuronType.HALF
-                if attrs_part2 == self.last_full_attrs
-                else NeuronType.FULL
-            )
-            output_type = neu.output_type()
-            attrs_part1 = OfflineNeuFullAttrsV2Part1(
-                weight_skew=0,
-                weight_address_start=0,
-                weight_address_end=0,
-                fold_type=FoldType.UNFOLDED,
-                neuron_type=neuron_type,
-                output_type=output_type,
-            )
-            neu_placement = OfflineNeuronPlacement([neu], attrs_part1, attrs_part2)
-
-            # SRAM Check
-            neu_sram_req = neu_placement.n_sram_required
-            weight_sram_req = selected_weight.n_sram_required
-            total_req = neu_sram_req + weight_sram_req
-
-            if total_req > 4096:
-                raise NotImplementedError(
-                    f"Neuron {neu} with its weight requires {total_req} SRAM lines."
-                )
-
-            if current_core.n_sram_required + total_req > 4096:
-                if len(current_core.neus) > 0:
-                    self.core_placements.append(current_core)
-
-                # Create new core with inheritance
-                current_core = OfflineCorePlacementV2(
-                    frontend_core_conf, backend_core_conf
-                )
-                neuron_type = NeuronType.FULL
-                neu_placement.neu_attrs_part1.neuron_type = NeuronType.FULL
-                self.last_full_attrs = attrs_part2
-
-            elif neuron_type == NeuronType.FULL:
-                self.last_full_attrs = attrs_part2
-
-            # print(f"Neuron {neu} assigned type {neu_placement.neuron_type}.")
-            current_core.neus.append(neu_placement)
-            current_core.weights.append(selected_weight)
-
-            idx = len(current_core.neus) - 1
-            current_core.neu_weight_map[idx] = idx
-
-        if len(current_core.neus) > 0:
-            self.core_placements.append(current_core)
-
     def allocate_neurons(self):
         """core placement generation"""
         # you can get neu_attrs_part2, inherited_core_config, target_lcn, lcn for each neuron in self.raw_elems, like:
@@ -621,6 +754,7 @@ class RoutingGroup(
         # inherited core_config are valid except weight_width, you can set weight_width larger than or equal to the original value for optimization
 
         print(f"\nAllocating neurons for Routing Group {self.name}...")
+        prefix = "    "
         if self.nodes is not None and self.input_nodes is not None:
             node = list(self.nodes)[0]
             # print(f"kernel weight from node {node.name}:\n", node.weights[0])
@@ -628,7 +762,7 @@ class RoutingGroup(
         weights = get_raw_weights(self.raw_elems, self.input_list)
 
         # print(f"weight of routing group {self.name}:\n", weights)
-        print(f"\tweight shape of routing group {self.name}: {weights.shape}")
+        print(f"{prefix}weight shape of routing group {self.name}: {weights.shape}")
 
         # print compelet weights into file for debug
         # with open(f"{self.name}_weights.txt", "w") as f:
@@ -655,28 +789,32 @@ class RoutingGroup(
             core_groups[key].append((neu, weight_of_neu))
 
         self.core_placements: list[CorePlacement] = []
-        print(f"\tNumber of core blocks: {len(core_groups)}")
-        for key, group_items in core_groups.items():
-            print(f"\n\tCore block with {len(group_items)}:")
-            print(f"\t\tfrontend_core_conf={key[0]}")
-            print(f"\t\tbackend_core_conf={key[1]}")
+        print(f"{prefix}Number of core blocks: {len(core_groups)}")
+        # for key, group_items in core_groups.items():
+        #     print(f"\n\tCore block with {len(group_items)}:")
+        #     print(f"\t\tfrontend_core_conf={key[0]}")
+        #     print(f"\t\tbackend_core_conf={key[1]}")
 
         # 2. Allocation Phase
         for i, (key, group_items) in enumerate(core_groups.items()):
             # print(f"\n\nAllocating group with frontend_core_conf={key[0]}")
             # print(f"backend_core_conf={key[1]}")
             # print(f"Neu of this group: {[str(item[0]) for item in group_items]}")
-            print(f"\tNumber of neurons in this group: {len(group_items)}")
+            print(f"{prefix}allocating core_block[{i}] ({len(group_items)} neurons)...")
             frontend_core_conf, backend_core_conf = key
             # Initialize the first core for the current group
             current_core = OfflineCorePlacementV2(frontend_core_conf, backend_core_conf)
 
             self.last_full_attrs = None
             self.place_neurons_optimal(
-                frontend_core_conf, backend_core_conf, group_items, i
+                frontend_core_conf,
+                backend_core_conf,
+                group_items,
+                i,
+                prefix=f"{prefix}    ",
             )
             print(
-                f"\tNumber of cores after allocating this group: {len(self.core_placements)}"
+                f"{prefix}Number of cores of core_block[{i}]: {len(self.core_placements)}"
             )
 
         self.n_core_required = len(self.core_placements)
@@ -709,7 +847,7 @@ class RoutingGroup(
                 # but we only need to set dest_info for the first raw_neu
                 main_neu = neu_placement.raw_neus[0]
                 dest_info = self.get_detail_dest(
-                    main_neu, self_coord=core_placement.coord
+                    neu_placement.raw_neus, self_coord=core_placement.coord
                 )
                 neu_placement.dest_info = dest_info
 
@@ -750,22 +888,23 @@ class RoutingGroup(
         return info_str
 
     def routing_summary(self, prefix: str = "") -> str:
-        summary_str = (
-            f"{prefix}{self.name} Routing Summary ({len(self.core_placements)} cores):\n"
-        )
+        summary_str = f"{prefix}{self.name} Routing Summary ({len(self.core_placements)} cores):\n"
         for i, core_placement in enumerate(self.core_placements):
             if core_placement._coord is not None:
-                summary_str += f"{prefix}  Core Placement {i} at {core_placement.coord}:\n"
+                summary_str += (
+                    f"{prefix}  Core Placement {i} at {core_placement.coord}:\n"
+                )
             else:
                 summary_str += f"{prefix}  Core Placement {i} at Unassigned Coord:\n"
-            summary_str += f"{prefix}    Number of Neurons: {len(core_placement.neus)}\n"
-            summary_str += f"{prefix}    Number of Weights: {len(core_placement.weights)}\n"
+            summary_str += f"{prefix}    Number of Neurons: {sum([len(neu_placement.raw_neus) for neu_placement in core_placement.neus])}\n"
             summary_str += (
-                f"{prefix}    Neuron SRAM Required: {core_placement.neuron_sram_required}\n"
+                f"{prefix}    Number of Weights: {len(core_placement.weights)}\n"
             )
             summary_str += (
-                f"{prefix}    Weight SRAM Required: {core_placement.weight_sram_required}\n"
+                f"{prefix}    Number of Neuron Placements: {len(core_placement.neus)}\n"
             )
+            summary_str += f"{prefix}    Neuron SRAM Required: {core_placement.neuron_sram_required}\n"
+            summary_str += f"{prefix}    Weight SRAM Required: {core_placement.weight_sram_required}\n"
             summary_str += (
                 f"{prefix}    Total SRAM Required: {core_placement.n_sram_required}\n"
             )
@@ -808,7 +947,7 @@ class InputGroup(Group, SourceGroup[InputElem, InNode]):
 
     def set_detail_dest(self):
         for elem in self.raw_elems:
-            dest_info = self.get_detail_dest(elem)
+            dest_info = self.get_detail_dest([elem])
             self.dest_infos[elem] = dest_info
 
 
@@ -860,6 +999,10 @@ class OutputAxonAllocator:
             raise ValueError(
                 f"Unsupported output bit num {elem.output_bit_num} for element {elem}."
             )
+        if axon_bit >= FANIN_BASE * (2**LCN_EX.LCN_128X.value):
+            raise ValueError(
+                f"Axon bit {axon_bit} allocated for element {elem} exceeds the maximum supported axon bit {FANIN_BASE * (2 ** LCN_EX.LCN_128X.value)}."
+            )
         return axon_bit
 
 
@@ -884,9 +1027,11 @@ class OutputGroup(Group, DestGroup[SourceElem, SourceNode]):
         info_str += "\n"
         return info_str
 
-    def routing_summary(self) -> str:
-        summary_str = f"Output Group {self.name}:\n"
-        summary_str += "   Output Group is the final destination, no further routing.\n"
+    def routing_summary(self, prefix: str = "") -> str:
+        summary_str = f"{prefix}Output Group {self.name}:\n"
+        summary_str += (
+            f"{prefix}   Output Group is the final destination, no further routing.\n"
+        )
         return summary_str
 
     def __str__(self) -> str:
@@ -909,8 +1054,6 @@ def toposort_for_rg(
     groups: list[RemapGroup | RoutingGroup],
 ) -> tuple[list[RoutingGroup], dict[int, list[int]]]:
     """topological sort for routing groups based on their dests"""
-    from collections import defaultdict, deque
-
     routing_groups = [rg for rg in groups if isinstance(rg, RoutingGroup)]
     rg_set = set(routing_groups)
 

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -169,8 +169,8 @@ class SourceGroup(Generic[SOURCE_ELEM, SOURCE_NODE]):
         info_str += f"\n{prefix}   ".join(dest_strs)
         return info_str
 
-    def routing_summary(self) -> str:
-        summary_str = "    Not Deploy Group\n"
+    def routing_summary(self, prefix: str = "") -> str:
+        summary_str = f"{prefix}    Not Deploy Group\n"
         return summary_str
 
     def __str__(self) -> str:
@@ -313,9 +313,9 @@ class RemapGroup(
         info_str += "\n"
         return info_str
 
-    def routing_summary(self) -> str:
-        summary_str = f"Remap Group {self.name}:\n"
-        summary_str += SourceGroup.routing_summary(self)
+    def routing_summary(self, prefix: str = "") -> str:
+        summary_str = f"{prefix}Remap Group {self.name}:\n"
+        summary_str += SourceGroup.routing_summary(self, prefix=prefix)
         return summary_str
 
     def __str__(self) -> str:
@@ -339,6 +339,7 @@ class RoutingGroup(
         self.name: str = f"RG_{self.id}"
 
         self.lcn: LCN_EX = LCN_EX.LCN_1X
+        self.recommand_lcn: Optional[LCN_EX] = None
         self.input_bit_num: int = 0
 
         # self.core_blocks: list[CoreBlock] = []
@@ -372,8 +373,8 @@ class RoutingGroup(
         assert (
             len(pred_output_bit_nums) == 1
         ), "All input elements in the routing group must have the same output bit num."
-        print(f"{self.raw_elems[0]}: input_bit_nums: {intput_bit_nums}")
-        print(f"{self.input_list[0]}: pred_output_bit_nums: {pred_output_bit_nums}")
+        # print(f"{self.raw_elems[0]}: input_bit_nums: {intput_bit_nums}")
+        # print(f"{self.input_list[0]}: pred_output_bit_nums: {pred_output_bit_nums}")
 
         self.input_bit_num = intput_bit_nums.pop()
         assert (
@@ -381,7 +382,10 @@ class RoutingGroup(
         ), "Input bit num of neurons must match output bit num of input elements."
         max_axon_addr = len(self.input_list) * self.input_bit_num
         lcn = ((max_axon_addr - 1) // FANIN_BASE).bit_length()
-        self.lcn = LCN_EX(lcn)
+        if self.recommand_lcn is not None and lcn < self.recommand_lcn.value:
+            self.lcn = self.recommand_lcn
+        else:
+            self.lcn = LCN_EX(lcn)
 
     def try_store_neuron(
         self,
@@ -409,6 +413,8 @@ class RoutingGroup(
             )
             weight_sram_req = selected_weight.n_sram_required
             attrs_part2.weight_compress = weight_compress
+            print(f"\tno zero elements in base weight {weight_info.index} is {np.count_nonzero(base_weight)}")
+            print(f"\tbase weight {weight_info.index} requires {weight_sram_req} SRAM lines with compression {weight_compress}.")
             if weight_sram_req > 4096:
                 raise NotImplementedError(
                     f"Base weight {weight_info.index} requires {weight_sram_req} SRAM lines, which exceeds the limit."
@@ -515,6 +521,7 @@ class RoutingGroup(
             {}
         )  # map from base weight index to the index of core's weight list where it's stored
 
+        print(f"\nallocating {self.name} block [{block_id}]")
         description = f"allocating {self.name} block [{block_id}]"
         for (neu, weight_of_neu), weight_info in track(
             zip(reordered_items, reordered_infos),
@@ -613,6 +620,7 @@ class RoutingGroup(
         # all the attrs in neu_attrs_part2 are valid except weight compress, you should set weight compress according to your weight storage strategy
         # inherited core_config are valid except weight_width, you can set weight_width larger than or equal to the original value for optimization
 
+        print(f"\nAllocating neurons for Routing Group {self.name}...")
         if self.nodes is not None and self.input_nodes is not None:
             node = list(self.nodes)[0]
             # print(f"kernel weight from node {node.name}:\n", node.weights[0])
@@ -620,17 +628,13 @@ class RoutingGroup(
         weights = get_raw_weights(self.raw_elems, self.input_list)
 
         # print(f"weight of routing group {self.name}:\n", weights)
-        print(f"weight shape of routing group {self.name}: {weights.shape}")
+        print(f"\tweight shape of routing group {self.name}: {weights.shape}")
 
         # print compelet weights into file for debug
         # with open(f"{self.name}_weights.txt", "w") as f:
         #     weights_transposed = weights.T
         #     for row in weights_transposed:
         #         f.write(" ".join(map(str, row)) + "\n")
-
-        print(
-            f"Allocating neurons for Routing Group {self.name} with {len(self.raw_elems)} neurons."
-        )
 
         # 1. Grouping Phase
         core_groups: dict[
@@ -651,14 +655,18 @@ class RoutingGroup(
             core_groups[key].append((neu, weight_of_neu))
 
         self.core_placements: list[CorePlacement] = []
-        print(f"grouping finished, number of core groups: {len(core_groups)}")
+        print(f"\tNumber of core blocks: {len(core_groups)}")
+        for key, group_items in core_groups.items():
+            print(f"\n\tCore block with {len(group_items)}:")
+            print(f"\t\tfrontend_core_conf={key[0]}")
+            print(f"\t\tbackend_core_conf={key[1]}")
 
         # 2. Allocation Phase
         for i, (key, group_items) in enumerate(core_groups.items()):
             # print(f"\n\nAllocating group with frontend_core_conf={key[0]}")
             # print(f"backend_core_conf={key[1]}")
             # print(f"Neu of this group: {[str(item[0]) for item in group_items]}")
-            print(f"Number of neurons in this group: {len(group_items)}")
+            print(f"\tNumber of neurons in this group: {len(group_items)}")
             frontend_core_conf, backend_core_conf = key
             # Initialize the first core for the current group
             current_core = OfflineCorePlacementV2(frontend_core_conf, backend_core_conf)
@@ -668,7 +676,7 @@ class RoutingGroup(
                 frontend_core_conf, backend_core_conf, group_items, i
             )
             print(
-                f"Number of cores after allocating this group: {len(self.core_placements)}"
+                f"\tNumber of cores after allocating this group: {len(self.core_placements)}"
             )
 
         self.n_core_required = len(self.core_placements)
@@ -741,22 +749,25 @@ class RoutingGroup(
         info_str = self.info()
         return info_str
 
-    def routing_summary(self) -> str:
+    def routing_summary(self, prefix: str = "") -> str:
         summary_str = (
-            f"{self.name} Routing Summary ({len(self.core_placements)} cores):\n"
+            f"{prefix}{self.name} Routing Summary ({len(self.core_placements)} cores):\n"
         )
         for i, core_placement in enumerate(self.core_placements):
-            summary_str += f"  Core Placement {i} at {core_placement.coord}:\n"
-            summary_str += f"    Number of Neurons: {len(core_placement.neus)}\n"
-            summary_str += f"    Number of Weights: {len(core_placement.weights)}\n"
+            if core_placement._coord is not None:
+                summary_str += f"{prefix}  Core Placement {i} at {core_placement.coord}:\n"
+            else:
+                summary_str += f"{prefix}  Core Placement {i} at Unassigned Coord:\n"
+            summary_str += f"{prefix}    Number of Neurons: {len(core_placement.neus)}\n"
+            summary_str += f"{prefix}    Number of Weights: {len(core_placement.weights)}\n"
             summary_str += (
-                f"    Neuron SRAM Required: {core_placement.neuron_sram_required}\n"
+                f"{prefix}    Neuron SRAM Required: {core_placement.neuron_sram_required}\n"
             )
             summary_str += (
-                f"    Weight SRAM Required: {core_placement.weight_sram_required}\n"
+                f"{prefix}    Weight SRAM Required: {core_placement.weight_sram_required}\n"
             )
             summary_str += (
-                f"    Total SRAM Required: {core_placement.n_sram_required}\n"
+                f"{prefix}    Total SRAM Required: {core_placement.n_sram_required}\n"
             )
         return summary_str
 
@@ -786,9 +797,9 @@ class InputGroup(Group, SourceGroup[InputElem, InNode]):
         info_str += "\n"
         return info_str
 
-    def routing_summary(self) -> str:
-        summary_str = f"Input Group {self.name}:\n"
-        summary_str += SourceGroup.routing_summary(self)
+    def routing_summary(self, prefix: str = "") -> str:
+        summary_str = f"{prefix}Input Group {self.name}:\n"
+        summary_str += SourceGroup.routing_summary(self, prefix=prefix)
         return summary_str
 
     def __str__(self) -> str:


### PR DESCRIPTION
支持 backendv2 的 folded neuron 编译与放置能力。

 1. 新增 paibox/backendv2/fold_neu.py，用于从权重偏移和轴突地址偏移中推导 fold 的 range/skew 
信息，并处理超硬件范围时的分解策略。  
 2. routing.py 增加 try_to_fold_neuron 流程：按 base weight 与目标分组识别可折叠神经元，生成 folded 
attrs，并与未折叠神经元共同完成 core 放置。  
 3. neuron.py 与 coreplacement.py 适配 folded 配置：OfflineNeuronPlacement 支持 folded attrs，SRAM 需求与 auto core config 改为按实际包行数计算。  