### PR TITLE
Feat(paiir): add canonical module registration

### DIFF
--- a/docs/paiir_backend_guide.md
+++ b/docs/paiir_backend_guide.md
@@ -48,6 +48,54 @@ paibox.paiir/
 - `paibox.paiir.pipeline.passes` 是当前编译 pass 的公共入口
 - `paibox.paiir.pipeline.pass_manager` 目前仍是实验性基础设施，不驱动默认 `compile_to_paiir()` 路径
 
+## 前端 lowering 扩展点
+
+PAIIR 前端默认支持标准 PyTorch 模块和少量 canonical function-form 算子。自定义模块不要依赖 lowering 猜测字段名或量化表达式，应显式注册到受支持的 canonical 模块或神经元。
+
+### 自定义计算模块
+
+`register_module(...)` 用于把用户自定义 `nn.Module` 转换为 PAIIR 已支持的 canonical `nn.Module`，例如 `nn.Conv1d`、`nn.Conv2d`、`nn.Linear`、pooling 模块、标准激活模块或 PAIIR 神经元/LUT 模块。
+
+```python
+from torch import nn
+from paibox.paiir import register_module
+
+
+def to_canonical_conv(module: MyQuantConv) -> nn.Module:
+    conv = nn.Conv2d(
+        in_channels=module.in_channels,
+        out_channels=module.out_channels,
+        kernel_size=module.kernel_size,
+        stride=module.stride,
+        padding=module.padding,
+        dilation=module.dilation,
+        groups=module.groups,
+        bias=module.bias_int32 is not None,
+    )
+    # 在这里显式完成 int8 权重、scale、zero-point 等用户语义到
+    # canonical Conv2d.weight / Conv2d.bias 的转换。
+    return conv
+
+
+register_module(MyQuantConv, to_canonical_conv)
+```
+
+注册函数返回的模块必须已经是当前 PAIIR lowering 支持的模块；返回 bypass 模块或未知模块会报错。重复注册同一模块类型也会报错，避免全局 lowering 规则被静默覆盖。
+
+### 自定义神经元或 LUT 激活
+
+`register_neuron(...)` 是面向神经元/激活的兼容入口。converter 可以返回 `CoreNeuronV25`，也可以返回 `LutActivation`；后者会被包装为 `ANNNodeV25(lut)`。
+
+```python
+from paibox.paiir import ANNNodeV25, LutReLU, register_neuron
+
+register_neuron(MyActivation, lambda module: ANNNodeV25(LutReLU()))
+```
+
+### function-form conv 边界
+
+`F.conv1d` / `F.conv2d` 会在 lowering 分析阶段 materialize 为 canonical `nn.Conv1d` / `nn.Conv2d`，但只支持权重和 bias 能直接解析为静态 tensor 的形式，以及简单的 tensor `to` / `view` / `reshape` 辅助节点。形如 `weight_int8 * scale` 的用户量化表达式不在核心 functional conv lowering 中推断；应通过 `register_module(...)` 在用户 converter 中显式构造 canonical conv。
+
 ## 编译流程与 API
 
 ### 编译流程概览

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -310,7 +310,9 @@ class Mapper:
 
         proto_files = ["compile_artifacts.proto"]
         if export_python and target_platform == "x86":
-            proto_files.extend(["compile_artifacts_pb2.py", "compile_artifacts_pb2.pyi"])
+            proto_files.extend(
+                ["compile_artifacts_pb2.py", "compile_artifacts_pb2.pyi"]
+            )
 
         for file_name in proto_files:
             src_file = proto_dir / file_name

--- a/paibox/backendv2/proto/compile_artifacts_pb2.py
+++ b/paibox/backendv2/proto/compile_artifacts_pb2.py
@@ -4,6 +4,7 @@
 # source: compile_artifacts.proto
 # Protobuf Python Version: 5.27.1
 """Generated protocol buffer code."""
+
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import runtime_version as _runtime_version
@@ -11,53 +12,48 @@ from google.protobuf import symbol_database as _symbol_database
 from google.protobuf.internal import builder as _builder
 
 _runtime_version.ValidateProtobufRuntimeVersion(
-    _runtime_version.Domain.PUBLIC,
-    5,
-    27,
-    1,
-    '',
-    'compile_artifacts.proto'
+    _runtime_version.Domain.PUBLIC, 5, 27, 1, "", "compile_artifacts.proto"
 )
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
 
 
-
-
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x17\x63ompile_artifacts.proto\x12\tbackendv2\"P\n\nCoreOffset\x12\x0f\n\x02xy\x18\x01 \x01(\x05H\x00\x88\x01\x01\x12\x0e\n\x01x\x18\x02 \x01(\x05H\x01\x88\x01\x01\x12\x0e\n\x01y\x18\x03 \x01(\x05H\x02\x88\x01\x01\x42\x05\n\x03_xyB\x04\n\x02_xB\x04\n\x02_y\"O\n\tCopyCount\x12\x0f\n\x02xy\x18\x01 \x01(\x05H\x00\x88\x01\x01\x12\x0e\n\x01x\x18\x02 \x01(\x05H\x01\x88\x01\x01\x12\x0e\n\x01y\x18\x03 \x01(\x05H\x02\x88\x01\x01\x42\x05\n\x03_xyB\x04\n\x02_xB\x04\n\x02_y\"\xca\x02\n\nInputEntry\x12\x15\n\x08\x65lem_idx\x18\x01 \x01(\rH\x00\x88\x01\x01\x12*\n\x0b\x63ore_offset\x18\x02 \x01(\x0b\x32\x15.backendv2.CoreOffset\x12(\n\ncopy_count\x18\x03 \x01(\x0b\x32\x14.backendv2.CopyCount\x12\x1a\n\rtick_relative\x18\x04 \x01(\rH\x01\x88\x01\x01\x12\x16\n\taddr_axon\x18\x05 \x01(\rH\x02\x88\x01\x01\x12\x17\n\ntarget_lcn\x18\x06 \x01(\rH\x03\x88\x01\x01\x12\x14\n\x07\x63opy_id\x18\x07 \x01(\rH\x04\x88\x01\x01\x12\x16\n\tbit_width\x18\x08 \x01(\rH\x05\x88\x01\x01\x42\x0b\n\t_elem_idxB\x10\n\x0e_tick_relativeB\x0c\n\n_addr_axonB\r\n\x0b_target_lcnB\n\n\x08_copy_idB\x0c\n\n_bit_width\"\xa5\x01\n\x0bOutputEntry\x12\x15\n\x08\x65lem_idx\x18\x01 \x01(\rH\x00\x88\x01\x01\x12\x14\n\x07\x63opy_id\x18\x02 \x01(\rH\x01\x88\x01\x01\x12\x16\n\tbit_width\x18\x03 \x01(\rH\x02\x88\x01\x01\x12\x19\n\x0c\x61xon_bit_idx\x18\x04 \x01(\rH\x03\x88\x01\x01\x42\x0b\n\t_elem_idxB\n\n\x08_copy_idB\x0c\n\n_bit_widthB\x0f\n\r_axon_bit_idx\"\x15\n\x05Shape\x12\x0c\n\x04size\x18\x01 \x03(\x05\"k\n\x12InputTensorMapping\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1f\n\x05shape\x18\x02 \x01(\x0b\x32\x10.backendv2.Shape\x12&\n\x07\x65ntries\x18\x03 \x03(\x0b\x32\x15.backendv2.InputEntry\"m\n\x13OutputTensorMapping\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1f\n\x05shape\x18\x02 \x01(\x0b\x32\x10.backendv2.Shape\x12\'\n\x07\x65ntries\x18\x03 \x03(\x0b\x32\x16.backendv2.OutputEntry\"C\n\x13InputTensorMappings\x12,\n\x05items\x18\x01 \x03(\x0b\x32\x1d.backendv2.InputTensorMapping\"E\n\x14OutputTensorMappings\x12-\n\x05items\x18\x01 \x03(\x0b\x32\x1e.backendv2.OutputTensorMapping\"\xda\x01\n\x0fThreadIOMapping\x12\x16\n\tthread_id\x18\x01 \x01(\rH\x00\x88\x01\x01\x12/\n\x10root_core_offset\x18\x02 \x01(\x0b\x32\x15.backendv2.CoreOffset\x12\x36\n\x0einput_mappings\x18\x03 \x01(\x0b\x32\x1e.backendv2.InputTensorMappings\x12\x38\n\x0foutput_mappings\x18\x04 \x01(\x0b\x32\x1f.backendv2.OutputTensorMappingsB\x0c\n\n_thread_id\"8\n\tIOMapping\x12+\n\x07threads\x18\x01 \x03(\x0b\x32\x1a.backendv2.ThreadIOMapping\"\x80\x01\n\x0c\x43onfigFrames\x12\r\n\x05words\x18\x01 \x03(\r\x12\x35\n\nword_order\x18\x02 \x01(\x0e\x32!.backendv2.ConfigFrames.WordOrder\"*\n\tWordOrder\x12\x0e\n\nHIGH_FIRST\x10\x00\x12\r\n\tLOW_FIRST\x10\x01\"\x84\x01\n\x10\x43ompileArtifacts\x12\x16\n\x0eschema_version\x18\x01 \x01(\r\x12(\n\nio_mapping\x18\x02 \x01(\x0b\x32\x14.backendv2.IOMapping\x12.\n\rconfig_frames\x18\x03 \x01(\x0b\x32\x17.backendv2.ConfigFramesb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
+    b'\n\x17\x63ompile_artifacts.proto\x12\tbackendv2"P\n\nCoreOffset\x12\x0f\n\x02xy\x18\x01 \x01(\x05H\x00\x88\x01\x01\x12\x0e\n\x01x\x18\x02 \x01(\x05H\x01\x88\x01\x01\x12\x0e\n\x01y\x18\x03 \x01(\x05H\x02\x88\x01\x01\x42\x05\n\x03_xyB\x04\n\x02_xB\x04\n\x02_y"O\n\tCopyCount\x12\x0f\n\x02xy\x18\x01 \x01(\x05H\x00\x88\x01\x01\x12\x0e\n\x01x\x18\x02 \x01(\x05H\x01\x88\x01\x01\x12\x0e\n\x01y\x18\x03 \x01(\x05H\x02\x88\x01\x01\x42\x05\n\x03_xyB\x04\n\x02_xB\x04\n\x02_y"\xca\x02\n\nInputEntry\x12\x15\n\x08\x65lem_idx\x18\x01 \x01(\rH\x00\x88\x01\x01\x12*\n\x0b\x63ore_offset\x18\x02 \x01(\x0b\x32\x15.backendv2.CoreOffset\x12(\n\ncopy_count\x18\x03 \x01(\x0b\x32\x14.backendv2.CopyCount\x12\x1a\n\rtick_relative\x18\x04 \x01(\rH\x01\x88\x01\x01\x12\x16\n\taddr_axon\x18\x05 \x01(\rH\x02\x88\x01\x01\x12\x17\n\ntarget_lcn\x18\x06 \x01(\rH\x03\x88\x01\x01\x12\x14\n\x07\x63opy_id\x18\x07 \x01(\rH\x04\x88\x01\x01\x12\x16\n\tbit_width\x18\x08 \x01(\rH\x05\x88\x01\x01\x42\x0b\n\t_elem_idxB\x10\n\x0e_tick_relativeB\x0c\n\n_addr_axonB\r\n\x0b_target_lcnB\n\n\x08_copy_idB\x0c\n\n_bit_width"\xa5\x01\n\x0bOutputEntry\x12\x15\n\x08\x65lem_idx\x18\x01 \x01(\rH\x00\x88\x01\x01\x12\x14\n\x07\x63opy_id\x18\x02 \x01(\rH\x01\x88\x01\x01\x12\x16\n\tbit_width\x18\x03 \x01(\rH\x02\x88\x01\x01\x12\x19\n\x0c\x61xon_bit_idx\x18\x04 \x01(\rH\x03\x88\x01\x01\x42\x0b\n\t_elem_idxB\n\n\x08_copy_idB\x0c\n\n_bit_widthB\x0f\n\r_axon_bit_idx"\x15\n\x05Shape\x12\x0c\n\x04size\x18\x01 \x03(\x05"k\n\x12InputTensorMapping\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1f\n\x05shape\x18\x02 \x01(\x0b\x32\x10.backendv2.Shape\x12&\n\x07\x65ntries\x18\x03 \x03(\x0b\x32\x15.backendv2.InputEntry"m\n\x13OutputTensorMapping\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1f\n\x05shape\x18\x02 \x01(\x0b\x32\x10.backendv2.Shape\x12\'\n\x07\x65ntries\x18\x03 \x03(\x0b\x32\x16.backendv2.OutputEntry"C\n\x13InputTensorMappings\x12,\n\x05items\x18\x01 \x03(\x0b\x32\x1d.backendv2.InputTensorMapping"E\n\x14OutputTensorMappings\x12-\n\x05items\x18\x01 \x03(\x0b\x32\x1e.backendv2.OutputTensorMapping"\xda\x01\n\x0fThreadIOMapping\x12\x16\n\tthread_id\x18\x01 \x01(\rH\x00\x88\x01\x01\x12/\n\x10root_core_offset\x18\x02 \x01(\x0b\x32\x15.backendv2.CoreOffset\x12\x36\n\x0einput_mappings\x18\x03 \x01(\x0b\x32\x1e.backendv2.InputTensorMappings\x12\x38\n\x0foutput_mappings\x18\x04 \x01(\x0b\x32\x1f.backendv2.OutputTensorMappingsB\x0c\n\n_thread_id"8\n\tIOMapping\x12+\n\x07threads\x18\x01 \x03(\x0b\x32\x1a.backendv2.ThreadIOMapping"\x80\x01\n\x0c\x43onfigFrames\x12\r\n\x05words\x18\x01 \x03(\r\x12\x35\n\nword_order\x18\x02 \x01(\x0e\x32!.backendv2.ConfigFrames.WordOrder"*\n\tWordOrder\x12\x0e\n\nHIGH_FIRST\x10\x00\x12\r\n\tLOW_FIRST\x10\x01"\x84\x01\n\x10\x43ompileArtifacts\x12\x16\n\x0eschema_version\x18\x01 \x01(\r\x12(\n\nio_mapping\x18\x02 \x01(\x0b\x32\x14.backendv2.IOMapping\x12.\n\rconfig_frames\x18\x03 \x01(\x0b\x32\x17.backendv2.ConfigFramesb\x06proto3'
+)
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
-_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'compile_artifacts_pb2', _globals)
+_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "compile_artifacts_pb2", _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
-  DESCRIPTOR._loaded_options = None
-  _globals['_COREOFFSET']._serialized_start=38
-  _globals['_COREOFFSET']._serialized_end=118
-  _globals['_COPYCOUNT']._serialized_start=120
-  _globals['_COPYCOUNT']._serialized_end=199
-  _globals['_INPUTENTRY']._serialized_start=202
-  _globals['_INPUTENTRY']._serialized_end=532
-  _globals['_OUTPUTENTRY']._serialized_start=535
-  _globals['_OUTPUTENTRY']._serialized_end=700
-  _globals['_SHAPE']._serialized_start=702
-  _globals['_SHAPE']._serialized_end=723
-  _globals['_INPUTTENSORMAPPING']._serialized_start=725
-  _globals['_INPUTTENSORMAPPING']._serialized_end=832
-  _globals['_OUTPUTTENSORMAPPING']._serialized_start=834
-  _globals['_OUTPUTTENSORMAPPING']._serialized_end=943
-  _globals['_INPUTTENSORMAPPINGS']._serialized_start=945
-  _globals['_INPUTTENSORMAPPINGS']._serialized_end=1012
-  _globals['_OUTPUTTENSORMAPPINGS']._serialized_start=1014
-  _globals['_OUTPUTTENSORMAPPINGS']._serialized_end=1083
-  _globals['_THREADIOMAPPING']._serialized_start=1086
-  _globals['_THREADIOMAPPING']._serialized_end=1304
-  _globals['_IOMAPPING']._serialized_start=1306
-  _globals['_IOMAPPING']._serialized_end=1362
-  _globals['_CONFIGFRAMES']._serialized_start=1365
-  _globals['_CONFIGFRAMES']._serialized_end=1493
-  _globals['_CONFIGFRAMES_WORDORDER']._serialized_start=1451
-  _globals['_CONFIGFRAMES_WORDORDER']._serialized_end=1493
-  _globals['_COMPILEARTIFACTS']._serialized_start=1496
-  _globals['_COMPILEARTIFACTS']._serialized_end=1628
+    DESCRIPTOR._loaded_options = None
+    _globals["_COREOFFSET"]._serialized_start = 38
+    _globals["_COREOFFSET"]._serialized_end = 118
+    _globals["_COPYCOUNT"]._serialized_start = 120
+    _globals["_COPYCOUNT"]._serialized_end = 199
+    _globals["_INPUTENTRY"]._serialized_start = 202
+    _globals["_INPUTENTRY"]._serialized_end = 532
+    _globals["_OUTPUTENTRY"]._serialized_start = 535
+    _globals["_OUTPUTENTRY"]._serialized_end = 700
+    _globals["_SHAPE"]._serialized_start = 702
+    _globals["_SHAPE"]._serialized_end = 723
+    _globals["_INPUTTENSORMAPPING"]._serialized_start = 725
+    _globals["_INPUTTENSORMAPPING"]._serialized_end = 832
+    _globals["_OUTPUTTENSORMAPPING"]._serialized_start = 834
+    _globals["_OUTPUTTENSORMAPPING"]._serialized_end = 943
+    _globals["_INPUTTENSORMAPPINGS"]._serialized_start = 945
+    _globals["_INPUTTENSORMAPPINGS"]._serialized_end = 1012
+    _globals["_OUTPUTTENSORMAPPINGS"]._serialized_start = 1014
+    _globals["_OUTPUTTENSORMAPPINGS"]._serialized_end = 1083
+    _globals["_THREADIOMAPPING"]._serialized_start = 1086
+    _globals["_THREADIOMAPPING"]._serialized_end = 1304
+    _globals["_IOMAPPING"]._serialized_start = 1306
+    _globals["_IOMAPPING"]._serialized_end = 1362
+    _globals["_CONFIGFRAMES"]._serialized_start = 1365
+    _globals["_CONFIGFRAMES"]._serialized_end = 1493
+    _globals["_CONFIGFRAMES_WORDORDER"]._serialized_start = 1451
+    _globals["_CONFIGFRAMES_WORDORDER"]._serialized_end = 1493
+    _globals["_COMPILEARTIFACTS"]._serialized_start = 1496
+    _globals["_COMPILEARTIFACTS"]._serialized_end = 1628
 # @@protoc_insertion_point(module_scope)

--- a/paibox/backendv2/proto/compile_artifacts_pb2.pyi
+++ b/paibox/backendv2/proto/compile_artifacts_pb2.pyi
@@ -19,7 +19,9 @@ class CoreOffset(_message.Message):
     xy: int
     x: int
     y: int
-    def __init__(self, xy: _Optional[int] = ..., x: _Optional[int] = ..., y: _Optional[int] = ...) -> None: ...
+    def __init__(
+        self, xy: _Optional[int] = ..., x: _Optional[int] = ..., y: _Optional[int] = ...
+    ) -> None: ...
 
 class CopyCount(_message.Message):
     __slots__ = ("xy", "x", "y")
@@ -29,10 +31,21 @@ class CopyCount(_message.Message):
     xy: int
     x: int
     y: int
-    def __init__(self, xy: _Optional[int] = ..., x: _Optional[int] = ..., y: _Optional[int] = ...) -> None: ...
+    def __init__(
+        self, xy: _Optional[int] = ..., x: _Optional[int] = ..., y: _Optional[int] = ...
+    ) -> None: ...
 
 class InputEntry(_message.Message):
-    __slots__ = ("elem_idx", "core_offset", "copy_count", "tick_relative", "addr_axon", "target_lcn", "copy_id", "bit_width")
+    __slots__ = (
+        "elem_idx",
+        "core_offset",
+        "copy_count",
+        "tick_relative",
+        "addr_axon",
+        "target_lcn",
+        "copy_id",
+        "bit_width",
+    )
     ELEM_IDX_FIELD_NUMBER: _ClassVar[int]
     CORE_OFFSET_FIELD_NUMBER: _ClassVar[int]
     COPY_COUNT_FIELD_NUMBER: _ClassVar[int]
@@ -49,7 +62,17 @@ class InputEntry(_message.Message):
     target_lcn: int
     copy_id: int
     bit_width: int
-    def __init__(self, elem_idx: _Optional[int] = ..., core_offset: _Optional[_Union[CoreOffset, _Mapping]] = ..., copy_count: _Optional[_Union[CopyCount, _Mapping]] = ..., tick_relative: _Optional[int] = ..., addr_axon: _Optional[int] = ..., target_lcn: _Optional[int] = ..., copy_id: _Optional[int] = ..., bit_width: _Optional[int] = ...) -> None: ...
+    def __init__(
+        self,
+        elem_idx: _Optional[int] = ...,
+        core_offset: _Optional[_Union[CoreOffset, _Mapping]] = ...,
+        copy_count: _Optional[_Union[CopyCount, _Mapping]] = ...,
+        tick_relative: _Optional[int] = ...,
+        addr_axon: _Optional[int] = ...,
+        target_lcn: _Optional[int] = ...,
+        copy_id: _Optional[int] = ...,
+        bit_width: _Optional[int] = ...,
+    ) -> None: ...
 
 class OutputEntry(_message.Message):
     __slots__ = ("elem_idx", "copy_id", "bit_width", "axon_bit_idx")
@@ -61,7 +84,13 @@ class OutputEntry(_message.Message):
     copy_id: int
     bit_width: int
     axon_bit_idx: int
-    def __init__(self, elem_idx: _Optional[int] = ..., copy_id: _Optional[int] = ..., bit_width: _Optional[int] = ..., axon_bit_idx: _Optional[int] = ...) -> None: ...
+    def __init__(
+        self,
+        elem_idx: _Optional[int] = ...,
+        copy_id: _Optional[int] = ...,
+        bit_width: _Optional[int] = ...,
+        axon_bit_idx: _Optional[int] = ...,
+    ) -> None: ...
 
 class Shape(_message.Message):
     __slots__ = ("size",)
@@ -77,7 +106,12 @@ class InputTensorMapping(_message.Message):
     name: str
     shape: Shape
     entries: _containers.RepeatedCompositeFieldContainer[InputEntry]
-    def __init__(self, name: _Optional[str] = ..., shape: _Optional[_Union[Shape, _Mapping]] = ..., entries: _Optional[_Iterable[_Union[InputEntry, _Mapping]]] = ...) -> None: ...
+    def __init__(
+        self,
+        name: _Optional[str] = ...,
+        shape: _Optional[_Union[Shape, _Mapping]] = ...,
+        entries: _Optional[_Iterable[_Union[InputEntry, _Mapping]]] = ...,
+    ) -> None: ...
 
 class OutputTensorMapping(_message.Message):
     __slots__ = ("name", "shape", "entries")
@@ -87,19 +121,28 @@ class OutputTensorMapping(_message.Message):
     name: str
     shape: Shape
     entries: _containers.RepeatedCompositeFieldContainer[OutputEntry]
-    def __init__(self, name: _Optional[str] = ..., shape: _Optional[_Union[Shape, _Mapping]] = ..., entries: _Optional[_Iterable[_Union[OutputEntry, _Mapping]]] = ...) -> None: ...
+    def __init__(
+        self,
+        name: _Optional[str] = ...,
+        shape: _Optional[_Union[Shape, _Mapping]] = ...,
+        entries: _Optional[_Iterable[_Union[OutputEntry, _Mapping]]] = ...,
+    ) -> None: ...
 
 class InputTensorMappings(_message.Message):
     __slots__ = ("items",)
     ITEMS_FIELD_NUMBER: _ClassVar[int]
     items: _containers.RepeatedCompositeFieldContainer[InputTensorMapping]
-    def __init__(self, items: _Optional[_Iterable[_Union[InputTensorMapping, _Mapping]]] = ...) -> None: ...
+    def __init__(
+        self, items: _Optional[_Iterable[_Union[InputTensorMapping, _Mapping]]] = ...
+    ) -> None: ...
 
 class OutputTensorMappings(_message.Message):
     __slots__ = ("items",)
     ITEMS_FIELD_NUMBER: _ClassVar[int]
     items: _containers.RepeatedCompositeFieldContainer[OutputTensorMapping]
-    def __init__(self, items: _Optional[_Iterable[_Union[OutputTensorMapping, _Mapping]]] = ...) -> None: ...
+    def __init__(
+        self, items: _Optional[_Iterable[_Union[OutputTensorMapping, _Mapping]]] = ...
+    ) -> None: ...
 
 class ThreadIOMapping(_message.Message):
     __slots__ = ("thread_id", "root_core_offset", "input_mappings", "output_mappings")
@@ -111,27 +154,41 @@ class ThreadIOMapping(_message.Message):
     root_core_offset: CoreOffset
     input_mappings: InputTensorMappings
     output_mappings: OutputTensorMappings
-    def __init__(self, thread_id: _Optional[int] = ..., root_core_offset: _Optional[_Union[CoreOffset, _Mapping]] = ..., input_mappings: _Optional[_Union[InputTensorMappings, _Mapping]] = ..., output_mappings: _Optional[_Union[OutputTensorMappings, _Mapping]] = ...) -> None: ...
+    def __init__(
+        self,
+        thread_id: _Optional[int] = ...,
+        root_core_offset: _Optional[_Union[CoreOffset, _Mapping]] = ...,
+        input_mappings: _Optional[_Union[InputTensorMappings, _Mapping]] = ...,
+        output_mappings: _Optional[_Union[OutputTensorMappings, _Mapping]] = ...,
+    ) -> None: ...
 
 class IOMapping(_message.Message):
     __slots__ = ("threads",)
     THREADS_FIELD_NUMBER: _ClassVar[int]
     threads: _containers.RepeatedCompositeFieldContainer[ThreadIOMapping]
-    def __init__(self, threads: _Optional[_Iterable[_Union[ThreadIOMapping, _Mapping]]] = ...) -> None: ...
+    def __init__(
+        self, threads: _Optional[_Iterable[_Union[ThreadIOMapping, _Mapping]]] = ...
+    ) -> None: ...
 
 class ConfigFrames(_message.Message):
     __slots__ = ("words", "word_order")
+
     class WordOrder(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
         __slots__ = ()
         HIGH_FIRST: _ClassVar[ConfigFrames.WordOrder]
         LOW_FIRST: _ClassVar[ConfigFrames.WordOrder]
+
     HIGH_FIRST: ConfigFrames.WordOrder
     LOW_FIRST: ConfigFrames.WordOrder
     WORDS_FIELD_NUMBER: _ClassVar[int]
     WORD_ORDER_FIELD_NUMBER: _ClassVar[int]
     words: _containers.RepeatedScalarFieldContainer[int]
     word_order: ConfigFrames.WordOrder
-    def __init__(self, words: _Optional[_Iterable[int]] = ..., word_order: _Optional[_Union[ConfigFrames.WordOrder, str]] = ...) -> None: ...
+    def __init__(
+        self,
+        words: _Optional[_Iterable[int]] = ...,
+        word_order: _Optional[_Union[ConfigFrames.WordOrder, str]] = ...,
+    ) -> None: ...
 
 class CompileArtifacts(_message.Message):
     __slots__ = ("schema_version", "io_mapping", "config_frames")
@@ -141,4 +198,9 @@ class CompileArtifacts(_message.Message):
     schema_version: int
     io_mapping: IOMapping
     config_frames: ConfigFrames
-    def __init__(self, schema_version: _Optional[int] = ..., io_mapping: _Optional[_Union[IOMapping, _Mapping]] = ..., config_frames: _Optional[_Union[ConfigFrames, _Mapping]] = ...) -> None: ...
+    def __init__(
+        self,
+        schema_version: _Optional[int] = ...,
+        io_mapping: _Optional[_Union[IOMapping, _Mapping]] = ...,
+        config_frames: _Optional[_Union[ConfigFrames, _Mapping]] = ...,
+    ) -> None: ...

--- a/paibox/paiir/__init__.py
+++ b/paibox/paiir/__init__.py
@@ -47,7 +47,7 @@ from .ir import (
 from .pipeline import CompileConfig, compile_to_paiir
 
 # Conversion entrypoints
-from .lowering import register_neuron, torch_to_paiir
+from .lowering import register_module, register_neuron, torch_to_paiir
 
 __all__ = [
     # Chip-accurate operators
@@ -69,6 +69,7 @@ __all__ = [
     # Graph
     "PAIIRGraph",
     # Conversion and passes
+    "register_module",
     "register_neuron",
     "torch_to_paiir",
     "compile_to_paiir",

--- a/paibox/paiir/ir/op_node.py
+++ b/paibox/paiir/ir/op_node.py
@@ -113,16 +113,14 @@ def _get_bias(comp: nn.Module) -> Tensor | None:
 def _get_weight_tensor(comp: nn.Module) -> Tensor | None:
     """Extract the graph-side weight tensor from a compute module.
 
-    Prefer a raw exported weight tensor when a converter preserved one
-    explicitly. Fall back to the runtime ``weight`` parameter for standard
-    PyTorch modules. For function-form conv2d lowering, ``raw_weight`` carries
-    the original FX-exported weight expression, while ``weight`` may only exist
-    as an ``nn.Conv2d`` compatibility surface.
+    The PAIIR conv lowering contract now relies on canonical PyTorch module
+    parameters only. Function-form convs are materialized into standard
+    ``nn.Conv1d`` / ``nn.Conv2d`` modules before they reach graph-side weight
+    queries, so ``weight`` is the only supported source here.
     """
-    for attr in ("raw_weight", "weight_int8", "weight"):
-        weight = getattr(comp, attr, None)
-        if torch.is_tensor(weight):
-            return weight.data
+    weight = getattr(comp, "weight", None)
+    if torch.is_tensor(weight):
+        return weight.data
     return None
 
 

--- a/paibox/paiir/lowering/__init__.py
+++ b/paibox/paiir/lowering/__init__.py
@@ -1,6 +1,12 @@
 """PAIIR front-end lowering from PyTorch/FX graphs."""
 
-from .converter import register_neuron, torch_to_paiir
+from .converter import register_module, register_neuron, torch_to_paiir
 from .dims_prop import DimsProp, DimsType
 
-__all__ = ["DimsProp", "DimsType", "register_neuron", "torch_to_paiir"]
+__all__ = [
+    "DimsProp",
+    "DimsType",
+    "register_module",
+    "register_neuron",
+    "torch_to_paiir",
+]

--- a/paibox/paiir/lowering/conv_lowering.py
+++ b/paibox/paiir/lowering/conv_lowering.py
@@ -106,7 +106,9 @@ def _resolve_supported_to_call(
         isinstance(arg, fx.Node) for arg in node.kwargs.values()
     ):
         if torch.is_tensor(resolved):
-            converted = resolved.to(*to_args, **node.kwargs)  # pyright: ignore[reportCallIssue, reportArgumentType]
+            converted = resolved.to(
+                *to_args, **node.kwargs
+            )  # pyright: ignore[reportCallIssue, reportArgumentType]
             return converted, aux_nodes | {node}
         return resolved, aux_nodes | {node}
 

--- a/paibox/paiir/lowering/conv_lowering.py
+++ b/paibox/paiir/lowering/conv_lowering.py
@@ -1,13 +1,11 @@
 """Conv-family lowering helpers for both module-form and function-form convs."""
 
-from __future__ import annotations
-
-import operator
 from dataclasses import dataclass, field
 from typing import Any
 
 import torch
 from torch import Tensor, fx, nn
+from torch.nn.modules.utils import _pair, _single
 
 from ..ir.op_node import StandaloneCompOp
 from .fx_utils import get_call_arg
@@ -53,15 +51,6 @@ def extract_module_conv_spec(node: fx.Node, module: nn.Module) -> ConvSpec | Non
     return ConvSpec(node.args[0], module)
 
 
-def _is_dtype_getattr(node: fx.Node) -> bool:
-    return (
-        node.op == "call_function"
-        and node.target is getattr
-        and len(node.args) >= 2
-        and node.args[1] == "dtype"
-    )
-
-
 def _resolve_attr_value(gm: fx.GraphModule, target: str) -> Any:
     value: Any = gm
     for atom in target.split("."):
@@ -96,118 +85,103 @@ def _get_normalized_call_kwargs(
     return dict(normalized.kwargs)
 
 
-def _resolve_to_aux_nodes(
+def _is_dtype_getattr(node: fx.Node) -> bool:
+    return (
+        node.op == "call_function"
+        and node.target is getattr
+        and len(node.args) >= 2
+        and node.args[1] == "dtype"
+    )
+
+
+def _resolve_supported_to_call(
     gm: fx.GraphModule, node: fx.Node
-) -> tuple[set[fx.Node] | None, bool]:
-    extra_nodes = {node}
-    for arg in (*node.args[1:], *node.kwargs.values()):
-        if isinstance(arg, fx.Node) and _is_dtype_getattr(arg):
-            extra_nodes.add(arg)
-            continue
-        if isinstance(arg, fx.Node):
-            resolved, extra = _resolve_constant_value(gm, arg)
-            if resolved is None:
-                return None, False
-            extra_nodes |= extra
-    return extra_nodes, True
+) -> tuple[Any | None, set[fx.Node]]:
+    resolved, aux_nodes = _resolve_static_value(gm, node.args[0])
+    if resolved is None:
+        return None, set()
+
+    to_args = node.args[1:]
+    if not any(isinstance(arg, fx.Node) for arg in to_args) and not any(
+        isinstance(arg, fx.Node) for arg in node.kwargs.values()
+    ):
+        if torch.is_tensor(resolved):
+            converted = resolved.to(*to_args, **node.kwargs)  # pyright: ignore[reportCallIssue, reportArgumentType]
+            return converted, aux_nodes | {node}
+        return resolved, aux_nodes | {node}
+
+    # Keep function-form conv lowering intentionally narrow. We support only the
+    # common deploy wrapper pattern `tensor.to(x.dtype)`, and reject mixed
+    # static/dynamic `.to(...)` forms rather than trying to partially emulate
+    # every PyTorch cast combination.
+    if (
+        torch.is_tensor(resolved)
+        and len(to_args) == 1
+        and not node.kwargs
+        and isinstance(to_args[0], fx.Node)
+        and _is_dtype_getattr(to_args[0])
+    ):
+        return resolved, aux_nodes | {node, to_args[0]}
+
+    return None, set()
 
 
-def _resolve_constant_value(
+def _resolve_static_value(
     gm: fx.GraphModule, value: Any
 ) -> tuple[Any | None, set[fx.Node]]:
+    # Keep this helper narrow: function-form conv lowering accepts directly
+    # resolvable tensor values plus simple canonical tensor reshaping/casting.
+    # Quantization or custom weight expressions belong in register_module(...)
+    # converters, where the user states the intended canonical module.
     if isinstance(value, fx.Node):
         if value.op == "get_attr":
-            return _resolve_attr_value(gm, str(value.target)), {value}
+            resolved = _resolve_attr_value(gm, str(value.target))
+            if torch.is_tensor(resolved):
+                return resolved.detach().clone(), {value}
+            return resolved, {value}
         if value.op == "call_method" and value.target == "to" and value.args:
-            resolved, nodes = _resolve_constant_value(gm, value.args[0])
-            if resolved is None:
+            return _resolve_supported_to_call(gm, value)
+        if (
+            value.op == "call_method"
+            and value.target in {"view", "reshape"}
+            and value.args
+        ):
+            resolved, aux_nodes = _resolve_static_value(gm, value.args[0])
+            if resolved is None or not torch.is_tensor(resolved):
+                return None, set()
+            if any(isinstance(arg, fx.Node) for arg in value.args[1:]) or any(
+                isinstance(arg, fx.Node) for arg in value.kwargs.values()
+            ):
                 return None, set()
 
-            extra_nodes, ok = _resolve_to_aux_nodes(gm, value)
-            if not ok or extra_nodes is None:
-                return None, set()
-            return resolved, nodes | extra_nodes
-        if value.op == "call_function" and value.target in (operator.mul, torch.mul):
-            lhs, lhs_nodes = _resolve_constant_value(gm, value.args[0])
-            rhs, rhs_nodes = _resolve_constant_value(gm, value.args[1])
-            if lhs is None or rhs is None:
-                return None, set()
-            return lhs * rhs, lhs_nodes | rhs_nodes | {value}
+            tensor_method = getattr(resolved, str(value.target))
+            return (
+                tensor_method(*value.args[1:], **value.kwargs),
+                aux_nodes | {value},
+            )
         return None, set()
 
     if isinstance(value, (Tensor, int, float)):
+        if torch.is_tensor(value):
+            return value.detach().clone(), set()
         return value, set()
 
     return None, set()
 
 
-def _match_quantized_functional_conv_weight_expr(
+def _resolve_static_tensor_value(
     gm: fx.GraphModule, value: Any
-) -> tuple[Tensor, Tensor | float | int | None, set[fx.Node]] | None:
-    """Match the quantized-weight expression used by customer functional convs."""
-    if isinstance(value, fx.Node):
-        if value.op == "get_attr":
-            resolved = _resolve_attr_value(gm, str(value.target))
-            if torch.is_tensor(resolved):
-                return resolved.detach().clone(), None, {value}
-            return None
-
-        if value.op == "call_method" and value.target == "to" and value.args:
-            extracted = _match_quantized_functional_conv_weight_expr(gm, value.args[0])
-            if extracted is None:
-                return None
-            weight, scale, nodes = extracted
-            extra_nodes, ok = _resolve_to_aux_nodes(gm, value)
-            if not ok or extra_nodes is None:
-                return None
-            return weight, scale, nodes | extra_nodes
-
-        if value.op == "call_function" and value.target in (operator.mul, torch.mul):
-            lhs = _match_quantized_functional_conv_weight_expr(gm, value.args[0])
-            rhs = _match_quantized_functional_conv_weight_expr(gm, value.args[1])
-            lhs_const, lhs_nodes = _resolve_constant_value(gm, value.args[0])
-            rhs_const, rhs_nodes = _resolve_constant_value(gm, value.args[1])
-
-            if lhs is not None and rhs_const is not None:
-                weight, scale, nodes = lhs
-                merged_scale = rhs_const if scale is None else scale * rhs_const
-                return weight, merged_scale, nodes | rhs_nodes | {value}
-
-            if rhs is not None and lhs_const is not None:
-                weight, scale, nodes = rhs
-                merged_scale = lhs_const if scale is None else scale * lhs_const
-                return weight, merged_scale, nodes | lhs_nodes | {value}
-
+) -> tuple[Tensor, set[fx.Node]] | None:
+    resolved, aux_nodes = _resolve_static_value(gm, value)
+    if torch.is_tensor(resolved):
+        return resolved.detach().clone(), aux_nodes
     return None
 
 
-def _infer_functional_conv_channels_and_kernel(
-    weight: Tensor, groups: int, spatial_ndim: int
-) -> tuple[int, int, tuple[int, ...]]:
-    raw_weight = weight.detach()
-    kernel_size = tuple(int(v) for v in raw_weight.shape[-spatial_ndim:])
-    in_channels = int(raw_weight.shape[1]) * groups
-    out_channels = int(raw_weight.shape[0])
-    return in_channels, out_channels, kernel_size
-
-
-def _attach_functional_conv_metadata(
-    conv: nn.Conv1d | nn.Conv2d,
-    weight: Tensor,
-    weight_scale: Tensor | float | int | None,
-    weight_zero_point: Tensor | int | None,
-) -> None:
-    raw_weight = weight.detach().clone()
-    scale = torch.as_tensor(
-        1.0 if weight_scale is None else weight_scale, dtype=torch.float32
-    ).detach()
-    zero_point = torch.as_tensor(
-        0 if weight_zero_point is None else weight_zero_point, dtype=torch.int32
-    ).detach()
-
-    conv.register_buffer("raw_weight", raw_weight)
-    conv.register_buffer("scale", scale)
-    conv.register_buffer("zero_point", zero_point)
+def _infer_functional_conv_channels(weight: Tensor, groups: int) -> tuple[int, int]:
+    in_channels = int(weight.shape[1]) * groups
+    out_channels = int(weight.shape[0])
+    return in_channels, out_channels
 
 
 def _build_functional_conv_module(
@@ -218,33 +192,38 @@ def _build_functional_conv_module(
     padding: int | tuple[int, ...] = 0,
     dilation: int | tuple[int, ...] = 1,
     groups: int = 1,
-    weight_scale: Tensor | float | int | None = None,
-    weight_zero_point: Tensor | int | None = None,
-) -> nn.Conv1d | nn.Conv2d:
-    in_channels, out_channels, kernel_size = _infer_functional_conv_channels_and_kernel(
-        weight, groups, spatial_ndim=spec.spatial_ndim
-    )
+) -> nn.Conv1d | nn.Conv2d | None:
+    in_channels, out_channels = _infer_functional_conv_channels(weight, groups)
 
-    module_cls = nn.Conv1d if spec.spatial_ndim == 1 else nn.Conv2d
-    conv = module_cls(
-        in_channels=in_channels,
-        out_channels=out_channels,
-        kernel_size=kernel_size,
-        stride=stride,
-        padding=padding,
-        dilation=dilation,
-        groups=groups,
-        bias=bias is not None,
-    )
+    if spec.spatial_ndim == 1:
+        conv = nn.Conv1d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=int(weight.shape[-1]),
+            stride=_single(stride),
+            padding=_single(padding),
+            dilation=_single(dilation),
+            groups=groups,
+            bias=bias is not None,
+        )
+    elif spec.spatial_ndim == 2:
+        conv = nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=(int(weight.shape[-2]), int(weight.shape[-1])),
+            stride=_pair(stride),
+            padding=_pair(padding),
+            dilation=_pair(dilation),
+            groups=groups,
+            bias=bias is not None,
+        )
+    else:
+        return None
 
     with torch.no_grad():
-        conv.weight.copy_(weight.detach().to(conv.weight.dtype))
-        conv.weight.requires_grad_(False)
+        _ = conv.weight.copy_(weight.detach().to(conv.weight.dtype))
         if bias is not None and conv.bias is not None:
-            conv.bias.copy_(bias.detach().to(conv.bias.dtype))
-            conv.bias.requires_grad_(False)
-
-    _attach_functional_conv_metadata(conv, weight, weight_scale, weight_zero_point)
+            _ = conv.bias.copy_(bias.detach().to(conv.bias.dtype))
     return conv
 
 
@@ -275,25 +254,24 @@ def extract_functional_conv_spec(gm: fx.GraphModule, node: fx.Node) -> ConvSpec 
     if not isinstance(input_arg, fx.Node) or not isinstance(groups, int):
         return None
 
-    weight_spec = _match_quantized_functional_conv_weight_expr(gm, weight_arg)
+    weight_spec = _resolve_static_tensor_value(gm, weight_arg)
     if weight_spec is None:
         return None
 
-    weight, weight_scale, aux_nodes = weight_spec
-    bias_value, bias_nodes = _resolve_constant_value(gm, bias_arg)
-    if bias_value is not None and not torch.is_tensor(bias_value):
-        return None
+    weight, aux_nodes = weight_spec
+    bias_value: Tensor | None = None
+    bias_nodes: set[fx.Node] = set()
+    if bias_arg is not None:
+        bias_spec = _resolve_static_tensor_value(gm, bias_arg)
+        if bias_spec is None:
+            return None
+        bias_value, bias_nodes = bias_spec
 
     module = _build_functional_conv_module(
-        spec,
-        weight,
-        bias_value,
-        stride,
-        padding,
-        dilation,
-        groups,
-        weight_scale,
+        spec, weight, bias_value, stride, padding, dilation, groups
     )
+    if module is None:
+        return None
     return ConvSpec(input_arg, module, frozenset(aux_nodes | bias_nodes))
 
 

--- a/paibox/paiir/lowering/converter.py
+++ b/paibox/paiir/lowering/converter.py
@@ -43,7 +43,7 @@ import warnings
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 
 import torch
 from spikingjelly.activation_based import neuron

--- a/paibox/paiir/lowering/converter.py
+++ b/paibox/paiir/lowering/converter.py
@@ -10,13 +10,23 @@ Pipeline:
 
 Example::
 
-    from paibox.paiir import torch_to_paiir, register_neuron, ANNNodeV25
+    from paibox.paiir import (
+        ANNNodeV25,
+        register_module,
+        register_neuron,
+        torch_to_paiir,
+    )
 
-    # Register a custom neuron type before conversion
+    # Register a custom neuron type before conversion. The converter may
+    # return a CoreNeuronV25 directly, or a LUT activation that is wrapped as
+    # ANNNodeV25 for deployment.
     register_neuron(
         MyNeuron,
         converter=lambda m: ANNNodeV25(LutCustom(...)),
     )
+
+    # Register a custom compute module by converting it into a canonical module
+    register_module(MyCustomConv, converter=lambda m: nn.Conv2d(...))
 
     # With shape inference
     graph = torch_to_paiir(model, torch.randn(1, 3, 32, 32))
@@ -33,7 +43,7 @@ import warnings
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 import torch
 from spikingjelly.activation_based import neuron
@@ -94,7 +104,7 @@ else:
     from typing_extensions import deprecated
 
 
-__all__ = ["torch_to_paiir", "register_neuron"]
+__all__ = ["torch_to_paiir", "register_module", "register_neuron"]
 
 _M = TypeVar("_M", bound=nn.Module)
 
@@ -137,7 +147,7 @@ def _has_nonzero_padding(padding: Any) -> bool:
     return int(padding) != 0
 
 
-def _unsupported_avgpool_description(m: nn.Module) -> str | None:
+def _describe_avgpool_lowering_issue(m: nn.Module) -> str | None:
     if not isinstance(m, (nn.AvgPool1d, nn.AvgPool2d)):
         return None
 
@@ -175,11 +185,82 @@ def _map_sj_lifnode(m: neuron.LIFNode, **kwargs) -> StandaloneActOp:
     )
 
 
+NeuronConverterResult = CoreNeuronV25 | LutActivation
+
+
+def _normalize_neuron_converter_result(
+    module_type: type[nn.Module], converted: NeuronConverterResult
+) -> CoreNeuronV25:
+    if isinstance(converted, CoreNeuronV25):
+        return converted.clone()
+
+    if isinstance(converted, LutActivation):
+        return ANNNodeV25(copy.deepcopy(converted))
+
+    raise TypeError(
+        "register_neuron converter must return a CoreNeuronV25 or "
+        f"LutActivation, got {type(converted).__name__} for {module_type.__name__}"
+    )
+
+
 def _build_standalone_act_mapper(
-    _: type[_M], cvt: Callable[[_M], CoreNeuronV25]
-) -> Callable[[_M], OpNode]:
-    def wrapper(m: _M) -> OpNode:
-        return StandaloneActOp(cvt(m))
+    module_type: type[_M], cvt: Callable[[_M], NeuronConverterResult]
+) -> Callable[[nn.Module], OpNode]:
+    def wrapper(m: nn.Module) -> OpNode:
+        if not isinstance(m, module_type):
+            raise TypeError(f"expected {module_type.__name__}, got {type(m).__name__}")
+        return StandaloneActOp(_normalize_neuron_converter_result(module_type, cvt(m)))
+
+    return wrapper
+
+
+def _ensure_supported_canonical_module(
+    module_type: type[nn.Module], canonical: nn.Module
+) -> nn.Module:
+    if not isinstance(canonical, nn.Module):
+        raise TypeError(
+            "register_module converter must return an nn.Module, "
+            f"got {type(canonical).__name__} for {module_type.__name__}"
+        )
+
+    if (
+        _is_lowering_bypass_module(canonical)
+        or type(canonical) not in _DEFAULT_MODULE_MAP
+    ):
+        raise TypeError(
+            "register_module converter must return a builtin canonical module "
+            "supported by PAIIR lowering, "
+            f"got unsupported {type(canonical).__name__}"
+        )
+
+    if (avgpool_issue := _describe_avgpool_lowering_issue(canonical)) is not None:
+        raise TypeError(
+            "register_module converter returned an unsupported "
+            f"canonical module: {avgpool_issue}"
+        )
+
+    return canonical
+
+
+def _map_supported_canonical_module(canonical: nn.Module) -> OpNode:
+    mapper = _DEFAULT_MODULE_MAP[type(canonical)]
+    ir_node = mapper(canonical)
+    if not isinstance(ir_node, OpNode):
+        raise TypeError(
+            "register_module converter returned a canonical module that lowers "
+            "as a bypass, which is not allowed"
+        )
+    return ir_node
+
+
+def _build_module_mapper(
+    module_type: type[_M], cvt: Callable[[_M], nn.Module]
+) -> Callable[[nn.Module], OpNode]:
+    def wrapper(m: nn.Module) -> OpNode:
+        if not isinstance(m, module_type):
+            raise TypeError(f"expected {module_type.__name__}, got {type(m).__name__}")
+        canonical = _ensure_supported_canonical_module(module_type, cvt(m))
+        return _map_supported_canonical_module(canonical)
 
     return wrapper
 
@@ -765,12 +846,14 @@ class _EraseModuleTransformer(fx.Transformer):
 
 
 def register_neuron(
-    module_type: type[_M], converter: Callable[[_M], CoreNeuronV25]
+    module_type: type[_M], converter: Callable[[_M], NeuronConverterResult]
 ) -> None:
-    """Register a custom neuron type for PAIIR conversion.
+    """Register a custom neuron/activation type for PAIIR conversion.
 
-    The converter receives the PyTorch module and must return a
-    :class:`CoreNeuronV25` with appropriate chip parameters.
+    This is the compatibility layer for deploy-facing neuron operators. The
+    converter receives the PyTorch module and must return either a
+    :class:`CoreNeuronV25` with appropriate chip parameters, or a
+    :class:`LutActivation` that will be wrapped as ``ANNNodeV25(lut)``.
     """
     if module_type in _USER_MODULE_MAP:
         raise ValueError(
@@ -779,6 +862,26 @@ def register_neuron(
         )
 
     _USER_MODULE_MAP[module_type] = _build_standalone_act_mapper(module_type, converter)
+
+
+def register_module(
+    module_type: type[_M], converter: Callable[[_M], nn.Module]
+) -> None:
+    """Register a custom module by converting it to a canonical module.
+
+    The converter receives the user module instance and must return a canonical
+    module already supported by PAIIR lowering, such as ``nn.Conv1d``,
+    ``nn.Conv2d``, ``nn.Linear``, pool modules, builtin activations, or PAIIR
+    neuron/LUT modules. This API intentionally does not guess field names or
+    quantization expressions from custom modules.
+    """
+    if module_type in _USER_MODULE_MAP:
+        raise ValueError(
+            f"Module type {module_type} is already registered. "
+            f"Overriding existing registrations is not allowed."
+        )
+
+    _USER_MODULE_MAP[module_type] = _build_module_mapper(module_type, converter)
 
 
 def torch_to_paiir(
@@ -1025,10 +1128,8 @@ def _apply_module_lowering_rule(
         ctx.bypass_nodes.add(node)
         return True
 
-    if (
-        unsupported_avgpool := _unsupported_avgpool_description(torch_module)
-    ) is not None:
-        _mark_unsupported(ctx, node, unsupported_avgpool, strict)
+    if (avgpool_issue := _describe_avgpool_lowering_issue(torch_module)) is not None:
+        _mark_unsupported(ctx, node, avgpool_issue, strict)
         return True
 
     if (mod_type := type(torch_module)) in module_map:

--- a/tests/paiir/conftest.py
+++ b/tests/paiir/conftest.py
@@ -36,9 +36,9 @@ def restore_default_module_map():
     """Restore the global neuron/module registry after each test.
 
     Built-in lowering rules live in ``_DEFAULT_MODULE_MAP`` while
-    ``register_neuron(...)`` writes test/user overrides into
-    ``_USER_MODULE_MAP``. Tests that register custom neurons should not leak
-    those overrides into later tests.
+    ``register_neuron(...)`` and ``register_module(...)`` write
+    test/user overrides into ``_USER_MODULE_MAP``. Tests that register custom
+    lowering hooks should not leak those overrides into later tests.
     """
     original_default = dict(_DEFAULT_MODULE_MAP)
     original_user = dict(_USER_MODULE_MAP)

--- a/tests/paiir/lowering/test_converter.py
+++ b/tests/paiir/lowering/test_converter.py
@@ -4,8 +4,9 @@ import warnings
 
 import pytest
 import torch
+import torch.nn.functional as F
 from spikingjelly.activation_based import neuron as sj
-from torch import nn
+from torch import Tensor, nn
 
 from paibox.paiir.exceptions import UnsupportedOpError, UnsupportedOpWarning
 from paibox.paiir.ir.core_neuron import ANNNodeV25, IFNodeV25, LIFNodeV25
@@ -16,7 +17,11 @@ from paibox.paiir.ir.op_node import (
     StandaloneActOp,
     StandaloneCompOp,
 )
-from paibox.paiir.lowering.converter import register_neuron, torch_to_paiir
+from paibox.paiir.lowering.converter import (
+    register_module,
+    register_neuron,
+    torch_to_paiir,
+)
 from tests.paiir.conftest import (
     MultiSpike4,
     UnsupportedSinModel,
@@ -135,9 +140,9 @@ class TestRegisterNeuron:
         test_inputs = torch.tensor([-100, -2, -1, 0, 1, 2, 3, 4, 5, 20, 100])
         ref_outputs = torch.round(torch.clamp(test_inputs, 0, 4))
         lut_outputs = seq_nodes[0].act(test_inputs)
-        assert torch.equal(
-            lut_outputs, ref_outputs
-        ), f"LUT mismatch: expected {ref_outputs.tolist()}, got {lut_outputs.tolist()}"
+        assert torch.equal(lut_outputs, ref_outputs), (
+            f"LUT mismatch: expected {ref_outputs.tolist()}, got {lut_outputs.tolist()}"
+        )
 
     def test_exact_registration_overrides_builtin_core_neuron_fallback(self):
         register_neuron(
@@ -157,6 +162,139 @@ class TestRegisterNeuron:
 
         lowered = _find_single_act(graph, ANNNodeV25)
         assert isinstance(lowered.lut, LutCustom)
+
+    def test_register_custom_lut_activation_as_neuron_compat_layer(self):
+        lut = make_multispike4_lut()
+        register_neuron(MultiSpike4, converter=lambda _: lut)
+
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(8, 4)
+                self.act = MultiSpike4()
+
+            def forward(self, x):
+                return self.act(self.linear(x))
+
+        graph = torch_to_paiir(Model().eval(), make_vec_8d())
+
+        lowered = _find_single_act(graph, ANNNodeV25)
+        assert lowered.lut is not None
+        assert isinstance(lowered.lut, LutCustom)
+        assert lowered.lut is not lut
+        assert torch.equal(lowered.lut.thresholds, lut.thresholds)
+        assert torch.equal(lowered.lut.lut_values, lut.lut_values)
+        assert lowered.lut.thresholds is not lut.thresholds
+        assert lowered.lut.lut_values is not lut.lut_values
+
+    def test_register_custom_core_neuron_converter_result_is_cloned(self):
+        neuron = IFNodeV25(v_threshold=2.0)
+        neuron(torch.full((1, 4), 1.0))
+        register_neuron(MultiSpike4, converter=lambda _: neuron)
+
+        graph = torch_to_paiir(MultiSpike4().eval(), make_vec_8d())
+
+        lowered = _find_single_act(graph, IFNodeV25)
+        assert lowered is not neuron
+        assert lowered.thres_pos == neuron.thres_pos
+        assert lowered.v == lowered.init_v
+
+
+class ExplicitQuantConv(nn.Module):
+    """Custom deploy module that requires register_module(...) to canonicalize it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        weight = torch.randint(-8, 8, (4, 3, 3, 3), dtype=torch.int8)
+        bias = torch.randint(-16, 16, (4,), dtype=torch.int32)
+        scale = torch.tensor([0.25, 0.5, 0.75, 1.0], dtype=torch.float32)
+        self.register_buffer("weight_int8", weight)
+        self.register_buffer("bias_int32", bias)
+        self.register_buffer("weight_scale", scale)
+        self.stride = (1, 1)
+        self.padding = (1, 1)
+        self.dilation = (1, 1)
+        self.groups = 1
+
+    def forward(self, x: Tensor) -> Tensor:
+        weight = self.weight_int8.to(torch.float32) * self.weight_scale.view(
+            -1, 1, 1, 1
+        )  # type: ignore
+        bias = self.bias_int32.to(torch.float32)
+        return F.conv2d(
+            x,
+            weight,
+            bias,  # type: ignore
+            self.stride,
+            self.padding,
+            self.dilation,
+            self.groups,
+        )
+
+
+def _to_canonical_conv2d(m: nn.Module) -> nn.Module:
+    """Materialize a canonical Conv2d from ExplicitQuantConv's deploy buffers."""
+    assert isinstance(m, ExplicitQuantConv)
+    conv = nn.Conv2d(
+        in_channels=3,
+        out_channels=4,
+        kernel_size=3,
+        stride=m.stride,
+        padding=m.padding,
+        dilation=m.dilation,
+        groups=m.groups,
+        bias=True,
+    )
+    with torch.no_grad():
+        conv.weight.copy_(
+            m.weight_int8.to(conv.weight.dtype) * m.weight_scale.view(-1, 1, 1, 1)  # type: ignore
+        )
+        assert conv.bias is not None
+        conv.bias.copy_(m.bias_int32.to(conv.bias.dtype))  # type: ignore
+    return conv
+
+
+class TestRegisterCanonicalModule:
+    def test_register_custom_module_to_canonical_conv(self):
+        register_module(ExplicitQuantConv, _to_canonical_conv2d)
+
+        model = ExplicitQuantConv().eval()
+        graph = torch_to_paiir(model, make_img_3ch_8x8(), strict=True)
+
+        comp_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.Conv2d)
+        ]
+        assert len(comp_nodes) == 1
+        comp = comp_nodes[0].comp
+        assert isinstance(comp, nn.Conv2d)
+        expected_weight = model.weight_int8.to(
+            comp.weight.dtype
+        ) * model.weight_scale.view(-1, 1, 1, 1)  # type: ignore
+        assert comp.weight.detach().equal(expected_weight)
+        assert comp.bias is not None
+        assert comp.bias.detach().equal(model.bias_int32.to(comp.bias.dtype))  # type: ignore
+        assert graph.predecessors(comp_nodes[0].name) == ["InputNode_0"]
+
+    def test_register_canonical_module_accepts_neuron_target(self):
+        register_module(MultiSpike4, lambda _: ANNNodeV25(make_multispike4_lut()))
+        graph = torch_to_paiir(MultiSpike4().eval(), make_vec_8d(), strict=True)
+
+        lowered = _find_single_act(graph, ANNNodeV25)
+        assert isinstance(lowered.lut, LutCustom)
+
+    def test_register_canonical_module_accepts_activation_target(self):
+        register_module(MultiSpike4, lambda _: nn.ReLU())
+        graph = torch_to_paiir(MultiSpike4().eval(), make_vec_8d(), strict=True)
+
+        lowered = _find_single_act(graph, ANNNodeV25)
+        assert isinstance(lowered.lut, LutReLU)
+
+    def test_register_canonical_module_rejects_duplicate_registration(self):
+        register_module(ExplicitQuantConv, _to_canonical_conv2d)
+        with pytest.raises(ValueError, match="already registered"):
+            register_module(ExplicitQuantConv, _to_canonical_conv2d)
 
 
 class TestCoreNeuronV25Lowering:

--- a/tests/paiir/lowering/test_converter.py
+++ b/tests/paiir/lowering/test_converter.py
@@ -140,9 +140,9 @@ class TestRegisterNeuron:
         test_inputs = torch.tensor([-100, -2, -1, 0, 1, 2, 3, 4, 5, 20, 100])
         ref_outputs = torch.round(torch.clamp(test_inputs, 0, 4))
         lut_outputs = seq_nodes[0].act(test_inputs)
-        assert torch.equal(lut_outputs, ref_outputs), (
-            f"LUT mismatch: expected {ref_outputs.tolist()}, got {lut_outputs.tolist()}"
-        )
+        assert torch.equal(
+            lut_outputs, ref_outputs
+        ), f"LUT mismatch: expected {ref_outputs.tolist()}, got {lut_outputs.tolist()}"
 
     def test_exact_registration_overrides_builtin_core_neuron_fallback(self):
         register_neuron(
@@ -271,7 +271,9 @@ class TestRegisterCanonicalModule:
         assert isinstance(comp, nn.Conv2d)
         expected_weight = model.weight_int8.to(
             comp.weight.dtype
-        ) * model.weight_scale.view(-1, 1, 1, 1)  # type: ignore
+        ) * model.weight_scale.view(
+            -1, 1, 1, 1
+        )  # type: ignore
         assert comp.weight.detach().equal(expected_weight)
         assert comp.bias is not None
         assert comp.bias.detach().equal(model.bias_int32.to(comp.bias.dtype))  # type: ignore

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -6,11 +6,17 @@ import torch
 import torch.nn.functional as F
 from paicorelib import DataSign, DataWidth
 from spikingjelly.activation_based import neuron as sj
-from torch import nn
+from torch import Tensor, nn
 
 import paibox.paiir.pipeline.avgpool.fusion as avgpool_fusion
 import paibox.paiir.pipeline.compile as compile_mod
-from paibox.paiir import CompileConfig, LIFNodeV25, compile_to_paiir, torch_to_paiir
+from paibox.paiir import (
+    CompileConfig,
+    LIFNodeV25,
+    compile_to_paiir,
+    register_module,
+    torch_to_paiir,
+)
 from paibox.paiir.exceptions import (
     GraphValidationError,
     UnsupportedOpError,
@@ -92,49 +98,42 @@ class PoolAfterReshape(nn.Module):
         return self.pool(x)
 
 
-class UnsupportedCountIncludePadAvgPool2d(nn.Module):
-    def __init__(self):
+class AvgPool2dWrapper(nn.Module):
+    def __init__(self, *, padding: int, count_include_pad: bool) -> None:
         super().__init__()
-        self.pool = nn.AvgPool2d(
-            kernel_size=3,
-            stride=1,
-            padding=1,
-            count_include_pad=False,
-        )
+        self.pool = nn.AvgPool2d(3, 1, padding, count_include_pad=count_include_pad)
 
-    def forward(self, x):
+    def forward(self, x: Tensor) -> Tensor:
         return self.pool(x)
 
 
-class SupportedNoPaddingCountIncludePadAvgPool2d(nn.Module):
-    def __init__(self):
+class TransformThenLinear(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        transform_fn: Callable[[Tensor], Tensor],
+        *,
+        out_features: int = 4,
+    ) -> None:
         super().__init__()
-        self.pool = nn.AvgPool2d(
-            kernel_size=3,
-            stride=1,
-            padding=0,
-            count_include_pad=False,
-        )
+        self.linear = nn.Linear(in_features, out_features, bias=False)
+        self.transform_fn = transform_fn
 
-    def forward(self, x):
-        return self.pool(x)
+    def forward(self, x: Tensor) -> Tensor:
+        return self.linear(self.transform_fn(x))
 
 
 def _make_linear_after_transform_model(
     in_features: int,
-    transform_fn: Callable[[torch.Tensor], torch.Tensor],
+    transform_fn: Callable[[Tensor], Tensor],
     *,
     out_features: int = 4,
 ) -> nn.Module:
-    class LinearAfterTransform(nn.Module):
-        def __init__(self) -> None:
-            super().__init__()
-            self.linear = nn.Linear(in_features, out_features, bias=False)
-
-        def forward(self, x):
-            return self.linear(transform_fn(x))
-
-    return LinearAfterTransform()
+    return TransformThenLinear(
+        in_features,
+        transform_fn,
+        out_features=out_features,
+    )
 
 
 def _assert_single_transform_before_linear(
@@ -155,6 +154,18 @@ def _assert_single_transform_before_linear(
         tuple(type(stage) for stage in transform_nodes[0].stages)
         == expected_stage_types
     )
+
+
+def _find_single_conv_comp(graph, conv_type: type[nn.Conv1d] | type[nn.Conv2d]):
+    comp_nodes = [
+        node
+        for node in graph.nodes.values()
+        if isinstance(node, StandaloneCompOp) and isinstance(node.comp, conv_type)
+    ]
+    assert len(comp_nodes) == 1
+    comp = comp_nodes[0].comp
+    assert isinstance(comp, conv_type)
+    return comp_nodes[0], comp
 
 
 TRANSFORM_BEFORE_LINEAR_CASES = (
@@ -573,14 +584,14 @@ class TestStrictMode:
     def test_strict_raises_for_count_include_pad_false_with_padding(self):
         with pytest.raises(UnsupportedOpError, match="count_include_pad=False"):
             compile_to_paiir(
-                UnsupportedCountIncludePadAvgPool2d(),
+                AvgPool2dWrapper(padding=1, count_include_pad=False),
                 make_img_3ch_8x8(),
                 strict=True,
             )
 
     def test_padding_free_count_include_pad_false_still_compiles(self):
         graph = compile_to_paiir(
-            SupportedNoPaddingCountIncludePadAvgPool2d(),
+            AvgPool2dWrapper(padding=0, count_include_pad=False),
             make_img_3ch_8x8(),
             strict=True,
         )
@@ -594,96 +605,229 @@ class TestStrictMode:
         assert len(pool_nodes) == 1
 
 
-class FunctionalQuantizedConv(nn.Module):
+class FunctionalDirectConv(nn.Module):
+    def __init__(self):
+        super().__init__()
+        weight = torch.randn(4, 3, 3, 3)
+        bias = torch.randn(4)
+        self.register_buffer("weight_buf", weight)
+        self.register_buffer("bias_buf", bias)
+
+    def forward(self, x):
+        return F.conv2d(
+            x,
+            self.weight_buf,  # type: ignore
+            self.bias_buf,  # type: ignore
+            stride=1,
+            padding=1,
+            dilation=1,
+            groups=1,
+        )
+
+
+class FunctionalDirectConv1d(nn.Module):
+    def __init__(self):
+        super().__init__()
+        weight = torch.randn(4, 3, 3)
+        bias = torch.randn(4)
+        self.register_buffer("weight_buf", weight)
+        self.register_buffer("bias_buf", bias)
+
+    def forward(self, x):
+        return F.conv1d(
+            x,
+            self.weight_buf,  # type: ignore
+            self.bias_buf,  # type: ignore
+            stride=1,
+            padding=1,
+            dilation=1,
+            groups=1,
+        )
+
+
+class FunctionalQuantizedConvExpression(nn.Module):
+    weight_int8_buf: Tensor
+    weight_scale_buf: Tensor
+    bias_buf: Tensor
+
     def __init__(self):
         super().__init__()
         weight = torch.randint(-8, 8, (4, 3, 3, 3), dtype=torch.int8)
         bias = torch.randn(4)
         scale = torch.tensor(0.125)
-        self.register_buffer("weight_int8", weight)
-        self.register_buffer("weight_scale", scale)
-        self.register_buffer("bias", bias)
+        self.register_buffer("weight_int8_buf", weight)
+        self.register_buffer("weight_scale_buf", scale)
+        self.register_buffer("bias_buf", bias)
+        self.weight_int8_buf = weight
+        self.weight_scale_buf = scale
+        self.bias_buf = bias
 
     def forward(self, x):
-        w = self.weight_int8.to(x.dtype) * self.weight_scale
-        return F.conv2d(x, w, self.bias, stride=1, padding=1, dilation=1, groups=1)
+        w = self.weight_int8_buf.to(x.dtype) * self.weight_scale_buf
+        return F.conv2d(x, w, self.bias_buf, stride=1, padding=1, dilation=1, groups=1)
 
 
-class FunctionalQuantizedConv1d(nn.Module):
-    def __init__(self):
-        super().__init__()
-        weight = torch.randint(-8, 8, (4, 3, 3), dtype=torch.int8)
-        bias = torch.randn(4)
-        scale = torch.tensor(0.125)
-        self.register_buffer("weight_int8", weight)
-        self.register_buffer("weight_scale", scale)
-        self.register_buffer("bias", bias)
+class FunctionalMixedDynamicToConvExpression(nn.Module):
+    weight_int8_buf: Tensor
+    bias_buf: Tensor
 
-    def forward(self, x):
-        w = self.weight_int8.to(x.dtype) * self.weight_scale
-        return F.conv1d(x, w, self.bias, stride=1, padding=1, dilation=1, groups=1)
-
-
-class FunctionalQuantizedConvWithShapeReshape(nn.Module):
     def __init__(self):
         super().__init__()
         weight = torch.randint(-8, 8, (4, 3, 3, 3), dtype=torch.int8)
         bias = torch.randn(4)
-        scale = torch.tensor(0.125)
-        self.register_buffer("weight_int8", weight)
-        self.register_buffer("weight_scale", scale)
-        self.register_buffer("bias", bias)
+        self.register_buffer("weight_int8_buf", weight)
+        self.register_buffer("bias_buf", bias)
+        self.weight_int8_buf = weight
+        self.bias_buf = bias
+
+    def forward(self, x):
+        w = self.weight_int8_buf.to(x.dtype, copy=False)
+        return F.conv2d(x, w, self.bias_buf, stride=1, padding=1, dilation=1, groups=1)
+
+
+class FunctionalDirectConvWithShapeReshape(nn.Module):
+    def __init__(self):
+        super().__init__()
+        weight = torch.randn(4, 3, 3, 3)
+        bias = torch.randn(4)
+        self.register_buffer("weight_buf", weight)
+        self.register_buffer("bias_buf", bias)
         self.relu = nn.ReLU()
 
     def forward(self, x):
         expanded = x.unsqueeze(0).repeat(1, 1, 1, 1, 1)
         flat = expanded.flatten(0, 1)
-        w = self.weight_int8.to(flat.dtype) * self.weight_scale
-        y = F.conv2d(flat, w, self.bias, stride=1, padding=1, dilation=1, groups=1)
+        y = F.conv2d(
+            flat,
+            self.weight_buf,  # type: ignore
+            self.bias_buf,  # type: ignore
+            stride=1,
+            padding=1,
+            dilation=1,
+            groups=1,
+        )
         y = y.reshape(
             expanded.shape[0], expanded.shape[1], -1, y.shape[-2], y.shape[-1]
         )
         return self.relu(y)
 
 
+class ExplicitQuantizedConvModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        weight_int8 = torch.randint(-8, 8, (4, 3, 3, 3), dtype=torch.int8)
+        bias_int32 = torch.randint(-16, 16, (4,), dtype=torch.int32)
+        weight_scale = torch.tensor([0.25, 0.5, 0.75, 1.0], dtype=torch.float32)
+        self.register_buffer("weight_int8_buf", weight_int8)
+        self.register_buffer("bias_int32_buf", bias_int32)
+        self.register_buffer("weight_scale_buf", weight_scale)
+        self.stride = (1, 1)
+        self.padding = (1, 1)
+        self.dilation = (1, 1)
+        self.groups = 1
+
+    def forward(self, x):
+        weight = self.weight_int8_buf.to(x.dtype) * self.weight_scale_buf.view(
+            -1, 1, 1, 1
+        )  # type: ignore
+        bias = self.bias_int32_buf.to(x.dtype)
+        return F.conv2d(
+            x,
+            weight,
+            bias,  # type: ignore
+            self.stride,
+            self.padding,
+            self.dilation,
+            self.groups,
+        )
+
+
+def _canonicalize_explicit_quantized_conv(module: nn.Module) -> nn.Module:
+    assert isinstance(module, ExplicitQuantizedConvModule)
+    conv = nn.Conv2d(
+        in_channels=3,
+        out_channels=4,
+        kernel_size=3,
+        stride=module.stride,
+        padding=module.padding,
+        dilation=module.dilation,
+        groups=module.groups,
+        bias=True,
+    )
+    with torch.no_grad():
+        conv.weight.copy_(
+            module.weight_int8_buf.to(conv.weight.dtype)
+            * module.weight_scale_buf.view(-1, 1, 1, 1)
+        )  # type: ignore
+        assert conv.bias is not None
+        conv.bias.copy_(module.bias_int32_buf.to(conv.bias.dtype))  # type: ignore
+        conv.weight.requires_grad_(False)
+        conv.bias.requires_grad_(False)
+    return conv
+
+
 class TestFunctionalConv:
-    def test_quantized_functional_conv2d_supported_in_strict_mode(self):
-        model = FunctionalQuantizedConv()
+    def test_direct_functional_conv2d_supported_in_strict_mode(self):
+        model = FunctionalDirectConv()
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             graph = compile_to_paiir(model, torch.randn(1, 3, 8, 8), strict=True)
 
-        comp_nodes = [
-            node
-            for node in graph.nodes.values()
-            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.Conv2d)
-        ]
-        assert len(comp_nodes) == 1
-        assert isinstance(comp_nodes[0].comp, nn.Conv2d)
-        assert torch.equal(comp_nodes[0].comp.raw_weight, model.weight_int8)
-        assert graph.predecessors(comp_nodes[0].name) == ["InputNode_0"]
+        comp_node, comp = _find_single_conv_comp(graph, nn.Conv2d)
+        assert comp.weight.detach().equal(model.weight_buf)  # type: ignore
+        assert comp.bias is not None
+        assert comp.bias.detach().equal(model.bias_buf)  # type: ignore
+        assert graph.predecessors(comp_node.name) == ["InputNode_0"]
         assert not any("conv2d" in str(w.message) for w in caught)
 
-    def test_quantized_functional_conv1d_supported_in_strict_mode(self):
-        model = FunctionalQuantizedConv1d()
+    def test_direct_functional_conv1d_supported_in_strict_mode(self):
+        model = FunctionalDirectConv1d()
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             graph = compile_to_paiir(model, torch.randn(1, 3, 16), strict=True)
 
-        comp_nodes = [
-            node
-            for node in graph.nodes.values()
-            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.Conv1d)
-        ]
-        assert len(comp_nodes) == 1
-        assert isinstance(comp_nodes[0].comp, nn.Conv1d)
-        assert torch.equal(comp_nodes[0].comp.raw_weight, model.weight_int8)
-        assert graph.predecessors(comp_nodes[0].name) == ["InputNode_0"]
+        comp_node, comp = _find_single_conv_comp(graph, nn.Conv1d)
+        assert comp.weight.detach().equal(model.weight_buf)  # type: ignore
+        assert comp.bias is not None
+        assert comp.bias.detach().equal(model.bias_buf)  # type: ignore
+        assert graph.predecessors(comp_node.name) == ["InputNode_0"]
         assert not any("conv1d" in str(w.message) for w in caught)
+
+    def test_functional_conv_quantized_weight_expression_is_unsupported(self):
+        model = FunctionalQuantizedConvExpression()
+
+        with pytest.raises(UnsupportedOpError):
+            compile_to_paiir(model, torch.randn(1, 3, 8, 8), strict=True)
+
+    def test_functional_conv_mixed_dynamic_to_is_unsupported(self):
+        model = FunctionalMixedDynamicToConvExpression()
+
+        with pytest.raises(UnsupportedOpError):
+            compile_to_paiir(model, torch.randn(1, 3, 8, 8), strict=True)
+
+    def test_registered_custom_conv_module_compiles_via_explicit_canonical_mapping(
+        self,
+    ):
+        register_module(
+            ExplicitQuantizedConvModule, _canonicalize_explicit_quantized_conv
+        )
+
+        model = ExplicitQuantizedConvModule().eval()
+        graph = compile_to_paiir(model, torch.randn(1, 3, 8, 8), strict=True)
+
+        _, comp = _find_single_conv_comp(graph, nn.Conv2d)
+        expected_weight = model.weight_int8_buf.to(
+            comp.weight.dtype
+        ) * model.weight_scale_buf.view(-1, 1, 1, 1)  # type: ignore
+        assert comp.weight.detach().equal(expected_weight)
+        assert comp.bias is not None
+        assert comp.bias.detach().equal(
+            model.bias_int32_buf.to(comp.bias.dtype)  # type: ignore
+        )
 
     def test_shape_only_reshape_args_do_not_become_data_predecessors(self):
         graph = torch_to_paiir(
-            FunctionalQuantizedConvWithShapeReshape(),
+            FunctionalDirectConvWithShapeReshape(),
             torch.randn(1, 3, 8, 8),
             strict=False,
         )
@@ -709,7 +853,7 @@ class TestFunctionalConv:
 
     def test_unsqueeze_repeat_all_ones_compile_path_succeeds(self):
         graph = compile_to_paiir(
-            FunctionalQuantizedConvWithShapeReshape(),
+            FunctionalDirectConvWithShapeReshape(),
             torch.randn(1, 3, 8, 8),
             strict=True,
         )
@@ -756,7 +900,7 @@ class TestFunctionalConv:
 
     def test_analysis_prebuilds_functional_conv_and_marks_shape_aux_nodes(self):
         sample = torch.randn(1, 3, 8, 8)
-        gm = trace_for_lowering(FunctionalQuantizedConvWithShapeReshape(), sample)
+        gm = trace_for_lowering(FunctionalDirectConvWithShapeReshape(), sample)
         ctx = _LoweringContext()
 
         _analyze_graph(gm, ctx)
@@ -790,7 +934,7 @@ class TestFunctionalConv:
 
     def test_analysis_prebuilds_functional_conv1d_node(self):
         sample = torch.randn(1, 3, 16)
-        gm = trace_for_lowering(FunctionalQuantizedConv1d(), sample)
+        gm = trace_for_lowering(FunctionalDirectConv1d(), sample)
         ctx = _LoweringContext()
 
         _analyze_graph(gm, ctx)

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -818,7 +818,9 @@ class TestFunctionalConv:
         _, comp = _find_single_conv_comp(graph, nn.Conv2d)
         expected_weight = model.weight_int8_buf.to(
             comp.weight.dtype
-        ) * model.weight_scale_buf.view(-1, 1, 1, 1)  # type: ignore
+        ) * model.weight_scale_buf.view(
+            -1, 1, 1, 1
+        )  # type: ignore
         assert comp.weight.detach().equal(expected_weight)
         assert comp.bias is not None
         assert comp.bias.detach().equal(


### PR DESCRIPTION
## Summary
- add `register_module(...)` for explicit custom-module to canonical `nn.Module` lowering
- narrow function-form conv lowering to directly resolvable static tensor weights/biases
- remove implicit `raw_weight` / `weight_int8` graph-side weight fallback
- document PAIIR lowering extension hooks and update coverage for custom conv wrappers