### PR TITLE
Feat(paiir): support per-channel threshold neurons

### DIFF
--- a/docs/paiir_backend_guide.md
+++ b/docs/paiir_backend_guide.md
@@ -491,23 +491,23 @@ params: NeuronParams = op.neuron_params
 
 关键字段：
 
-| 字段                  | 类型                       | 说明                                             |
-| --------------------- | -------------------------- | ------------------------------------------------ |
-| `reset_mode`          | `RM`                       | `MODE_NORMAL`（硬复位）/ `MODE_LINEAR`（软复位） |
-| `reset_v`             | `float`                    | 复位电压                                         |
-| `thres_pos`           | `float \| Tensor`         | 正阈值；tensor 时表示 1D per-channel 阈值        |
-| `thres_neg`           | `float`                    | 负阈值                                           |
-| `thres_pos_mode`      | `ThresholdPosMode`         | `FIRE`（触发）/ `CEILING`（截断）                |
-| `thres_neg_mode`      | `ThresholdNegMode`         | `FIRE`（触发）/ `FLOOR`（截断）                  |
-| `leak_tau`            | `int`                      | 移位指数（正 = 左移放大，负 = 右移衰减）         |
-| `leak_v`              | `float \| Tensor`         | 加性漏电压（含融合后的 bias）；tensor 时为 1D per-channel |
-| `init_v`              | `float`                    | 初始膜电位                                       |
-| `output_type`         | `OutputType`               | 输出类型                                         |
-| `lateral_inhi`        | `LateralInhibitionMode`    | 侧抑制                                           |
-| `leak_multi_sequence` | `LeakMultiComparisonOrder` | 乘性漏执行顺序                                   |
-| `leak_multi_input`    | `LeakMultiInputMode`       | 输入是否参与乘性漏                               |
-| `leak_multi_mode`     | `LeakMultiMode`            | 乘性漏模式                                       |
-| `leak_add_mode`       | `LeakAddMode`              | 加性漏方向                                       |
+| 字段                  | 类型                       | 说明                                                      |
+| --------------------- | -------------------------- | --------------------------------------------------------- |
+| `reset_mode`          | `RM`                       | `MODE_NORMAL`（硬复位）/ `MODE_LINEAR`（软复位）          |
+| `reset_v`             | `float`                    | 复位电压                                                  |
+| `thres_pos`           | `float \| Tensor`          | 正阈值；tensor 时表示 1D per-channel 阈值                 |
+| `thres_neg`           | `float`                    | 负阈值                                                    |
+| `thres_pos_mode`      | `ThresholdPosMode`         | `FIRE`（触发）/ `CEILING`（截断）                         |
+| `thres_neg_mode`      | `ThresholdNegMode`         | `FIRE`（触发）/ `FLOOR`（截断）                           |
+| `leak_tau`            | `int`                      | 移位指数（正 = 左移放大，负 = 右移衰减）                  |
+| `leak_v`              | `float \| Tensor`          | 加性漏电压（含融合后的 bias）；tensor 时为 1D per-channel |
+| `init_v`              | `float`                    | 初始膜电位                                                |
+| `output_type`         | `OutputType`               | 输出类型                                                  |
+| `lateral_inhi`        | `LateralInhibitionMode`    | 侧抑制                                                    |
+| `leak_multi_sequence` | `LeakMultiComparisonOrder` | 乘性漏执行顺序                                            |
+| `leak_multi_input`    | `LeakMultiInputMode`       | 输入是否参与乘性漏                                        |
+| `leak_multi_mode`     | `LeakMultiMode`            | 乘性漏模式                                                |
+| `leak_add_mode`       | `LeakAddMode`              | 加性漏方向                                                |
 
 > **bias 融合**：`SequentialOp` 和 `AccumulateOp` 的 `neuron_params` 已将 Conv/Linear 的 bias 融合到 `leak_v` 中，后端无需额外处理。
 

--- a/docs/paiir_backend_guide.md
+++ b/docs/paiir_backend_guide.md
@@ -92,6 +92,20 @@ from paibox.paiir import ANNNodeV25, LutReLU, register_neuron
 register_neuron(MyActivation, lambda module: ANNNodeV25(LutReLU()))
 ```
 
+对于 SNN 神经元，converter 也可以直接返回 `IFNodeV25` / `LIFNodeV25`。当前
+`v_threshold` 已支持：
+
+- 标量 `float`：整层共享阈值
+- 1D `Tensor(shape=(C,))`：按输出 channel 的 per-channel 阈值
+
+后者会在 PAIIR 仿真中按 `N,C,...` 显式广播，并在 backend 导出时按输出
+channel 展开为每个 neuron 的标量 `threshold_pos`。当前导出契约限制为：
+
+- batch size 必须为 `1`
+- tensor 必须是 1D
+- `numel()` 必须等于输出 `shape[1]`
+- `lut` 与 tensor `thres_pos` 不可共存
+
 ### function-form conv 边界
 
 `F.conv1d` / `F.conv2d` 会在 lowering 分析阶段 materialize 为 canonical `nn.Conv1d` / `nn.Conv2d`，但只支持权重和 bias 能直接解析为静态 tensor 的形式，以及简单的 tensor `to` / `view` / `reshape` 辅助节点。形如 `weight_int8 * scale` 的用户量化表达式不在核心 functional conv lowering 中推断；应通过 `register_module(...)` 在用户 converter 中显式构造 canonical conv。
@@ -481,12 +495,12 @@ params: NeuronParams = op.neuron_params
 | --------------------- | -------------------------- | ------------------------------------------------ |
 | `reset_mode`          | `RM`                       | `MODE_NORMAL`（硬复位）/ `MODE_LINEAR`（软复位） |
 | `reset_v`             | `float`                    | 复位电压                                         |
-| `thres_pos`           | `float`                    | 正阈值                                           |
+| `thres_pos`           | `float \| Tensor`         | 正阈值；tensor 时表示 1D per-channel 阈值        |
 | `thres_neg`           | `float`                    | 负阈值                                           |
 | `thres_pos_mode`      | `ThresholdPosMode`         | `FIRE`（触发）/ `CEILING`（截断）                |
 | `thres_neg_mode`      | `ThresholdNegMode`         | `FIRE`（触发）/ `FLOOR`（截断）                  |
 | `leak_tau`            | `int`                      | 移位指数（正 = 左移放大，负 = 右移衰减）         |
-| `leak_v`              | `float`                    | 加性漏电压（含融合后的 bias）                    |
+| `leak_v`              | `float \| Tensor`         | 加性漏电压（含融合后的 bias）；tensor 时为 1D per-channel |
 | `init_v`              | `float`                    | 初始膜电位                                       |
 | `output_type`         | `OutputType`               | 输出类型                                         |
 | `lateral_inhi`        | `LateralInhibitionMode`    | 侧抑制                                           |
@@ -496,6 +510,10 @@ params: NeuronParams = op.neuron_params
 | `leak_add_mode`       | `LeakAddMode`              | 加性漏方向                                       |
 
 > **bias 融合**：`SequentialOp` 和 `AccumulateOp` 的 `neuron_params` 已将 Conv/Linear 的 bias 融合到 `leak_v` 中，后端无需额外处理。
+
+> **per-channel 参数导出约束**：当前 backend 只支持 1D per-channel `thres_pos`
+> / `leak_v`，并按输出 tensor 的 channel 轴 `shape[1]` 解释；不支持
+> per-spatial、per-group、per-element 或 batch-dependent tensor。
 
 #### 4. LUT 数据（ANN 模式）
 

--- a/paibox/backendv2/op_node.py
+++ b/paibox/backendv2/op_node.py
@@ -27,6 +27,29 @@ from ..paiir.ir.op_node import (
 from .core_config import Frontend_Core_Config
 
 
+def _resolve_channel_param(
+    value: float | Tensor, idx: int, shape: torch.Size, name: str
+) -> float:
+    if not torch.is_tensor(value):
+        return value
+    if len(shape) < 2:
+        raise ValueError(f"{name} tensor requires an output channel dimension")
+    if shape[0] != 1:
+        raise ValueError(f"Batch size > 1 not supported for tensor {name}")
+    if value.ndim != 1:
+        raise ValueError(f"{name} tensor must be 1D, got shape={tuple(value.shape)}")
+
+    out_channel = shape[1]
+    if value.numel() != out_channel:
+        raise ValueError(
+            f"{name} tensor size mismatch: got {value.numel()}, expected {out_channel}"
+        )
+
+    channel_stride = shape.numel() // out_channel
+    cur_channel = idx // channel_stride
+    return value[cur_channel].item()
+
+
 class CustomIndex:
     def __init__(self, idx: int, copy_id: int = 0):
         self.idx = idx
@@ -406,16 +429,10 @@ class CoreOpNode(BaseNode["OfflineCoreOp"]):
 
     def attrs_part2(self, idx: int = 0) -> "OfflineNeuFullAttrsV2Part2":
         neu_attrs = self.raw_node.neuron_params
-        if isinstance(neu_attrs.leak_v, torch.Tensor):
-            assert self.shape[0] == 1, "Batch size > 1 not supported for tensor leak_v"
-            out_channel = self.shape[1]
-            assert (
-                neu_attrs.leak_v.numel() == out_channel
-            ), "leak_v tensor size mismatch"
-            cur_channel = idx // (self.shape.numel() // self.shape[1])
-            leak_v = neu_attrs.leak_v[cur_channel].item()
-        else:
-            leak_v = neu_attrs.leak_v
+        leak_v = _resolve_channel_param(neu_attrs.leak_v, idx, self.shape, "leak_v")
+        thres_pos = _resolve_channel_param(
+            neu_attrs.thres_pos, idx, self.shape, "thres_pos"
+        )
 
         return OfflineNeuFullAttrsV2Part2(
             reset_mode=neu_attrs.reset_mode,
@@ -423,7 +440,7 @@ class CoreOpNode(BaseNode["OfflineCoreOp"]):
             threshold_neg_mode=neu_attrs.thres_neg_mode,
             threshold_pos_mode=neu_attrs.thres_pos_mode,
             threshold_neg=round(neu_attrs.thres_neg),
-            threshold_pos=round(neu_attrs.thres_pos),
+            threshold_pos=round(thres_pos),
             lateral_inhibition=neu_attrs.lateral_inhi,
             leak_multi_sequence=neu_attrs.leak_multi_sequence,
             leak_multi_input=neu_attrs.leak_multi_input,

--- a/paibox/backendv2/proto/README.md
+++ b/paibox/backendv2/proto/README.md
@@ -18,12 +18,12 @@ output/
     compile_artifacts_pb2.pyi
 ```
 
-| 文件 | 用途 |
-| --- | --- |
-| `config.pb` | 二进制 protobuf，应用程序应优先读取此文件。 |
-| `config.json` | `config.pb` 的 JSON 展开，供人工检查和调试。 |
-| `compile_artifacts.proto` | schema 文件。 |
-| `compile_artifacts_pb2.py` | Python 生成代码，仅在 x86 导出且开启 `export_proto_python` 时复制。 |
+| 文件                        | 用途                                                                    |
+| --------------------------- | ----------------------------------------------------------------------- |
+| `config.pb`                 | 二进制 protobuf，应用程序应优先读取此文件。                             |
+| `config.json`               | `config.pb` 的 JSON 展开，供人工检查和调试。                            |
+| `compile_artifacts.proto`   | schema 文件。                                                           |
+| `compile_artifacts_pb2.py`  | Python 生成代码，仅在 x86 导出且开启 `export_proto_python` 时复制。     |
 | `compile_artifacts_pb2.pyi` | Python 类型标注文件，仅在 x86 导出且开启 `export_proto_python` 时复制。 |
 
 正式程序不要把 `config.json` 作为机器接口；它只用于调试和人工核对。
@@ -76,11 +76,11 @@ message CompileArtifacts {
 }
 ```
 
-| 字段 | 含义 |
-| --- | --- |
+| 字段             | 含义                                                    |
+| ---------------- | ------------------------------------------------------- |
 | `schema_version` | schema 版本。应用侧可用它判断当前程序是否支持该 `.pb`。 |
-| `io_mapping` | 逻辑 I/O 张量与芯片工作帧地址之间的映射。 |
-| `config_frames` | 编译生成的配置帧，按 32-bit word 展平保存。 |
+| `io_mapping`     | 逻辑 I/O 张量与芯片工作帧地址之间的映射。               |
+| `config_frames`  | 编译生成的配置帧，按 32-bit word 展平保存。             |
 
 ## 4. 配置帧
 
@@ -98,10 +98,10 @@ message ConfigFrames {
 
 `words` 是由 64-bit 配置帧拆分得到的 32-bit word 序列。`word_order` 表示每个 64-bit 配置帧内部两个 word 的排列顺序：
 
-| `word_order` | `words` 排列 |
-| --- | --- |
+| `word_order` | `words` 排列                                                      |
+| ------------ | ----------------------------------------------------------------- |
 | `HIGH_FIRST` | `[frame0.high32, frame0.low32, frame1.high32, frame1.low32, ...]` |
-| `LOW_FIRST` | `[frame0.low32, frame0.high32, frame1.low32, frame1.high32, ...]` |
+| `LOW_FIRST`  | `[frame0.low32, frame0.high32, frame1.low32, frame1.high32, ...]` |
 
 如果应用侧需要从 `config.pb` 还原 64-bit 配置帧，可使用如下逻辑。该示例未经过板端流程验证，仅供实现参考：
 
@@ -139,12 +139,12 @@ message ThreadIOMapping {
 }
 ```
 
-| 字段 | 含义 |
-| --- | --- |
-| `thread_id` | 硬件线程编号。一次编译若包含多个网络或多个线程域，可导出多个 `ThreadIOMapping`。 |
-| `root_core_offset` | 该线程内全局信号 root core 的相对偏移。 |
-| `input_mappings` | 输入逻辑张量到输入工作帧地址的映射。 |
-| `output_mappings` | 输出工作帧地址到输出逻辑张量的映射。 |
+| 字段               | 含义                                                                             |
+| ------------------ | -------------------------------------------------------------------------------- |
+| `thread_id`        | 硬件线程编号。一次编译若包含多个网络或多个线程域，可导出多个 `ThreadIOMapping`。 |
+| `root_core_offset` | 该线程内全局信号 root core 的相对偏移。                                          |
+| `input_mappings`   | 输入逻辑张量到输入工作帧地址的映射。                                             |
+| `output_mappings`  | 输出工作帧地址到输出逻辑张量的映射。                                             |
 
 `CoreOffset` 和 `CopyCount` 都包含 `xy/x/y` 三个分量：
 
@@ -185,18 +185,18 @@ message InputEntry {
 }
 ```
 
-| 字段 | 含义 |
-| --- | --- |
-| `name` | PAIIR 输入节点名。 |
-| `shape.size` | 逻辑输入张量 shape。 |
-| `elem_idx` | 输入张量按 C-order 展平后的元素下标。 |
-| `core_offset` | 输入工作帧目标 core 的相对偏移。 |
-| `copy_count` | AER 多播复制数量。 |
-| `tick_relative` | 后端分配出的相对 tick 段。 |
-| `addr_axon` | 后端分配出的 axon 地址低段。 |
-| `target_lcn` | 目标 core 的 LCN 编号，对应 `paicorelib.LCN_EX` 枚举值。 |
-| `copy_id` | tiling/folding 产生的逻辑 copy 编号，不等同于 `CopyCount`。 |
-| `bit_width` | 该逻辑输入元素的位宽。 |
+| 字段            | 含义                                                        |
+| --------------- | ----------------------------------------------------------- |
+| `name`          | PAIIR 输入节点名。                                          |
+| `shape.size`    | 逻辑输入张量 shape。                                        |
+| `elem_idx`      | 输入张量按 C-order 展平后的元素下标。                       |
+| `core_offset`   | 输入工作帧目标 core 的相对偏移。                            |
+| `copy_count`    | AER 多播复制数量。                                          |
+| `tick_relative` | 后端分配出的相对 tick 段。                                  |
+| `addr_axon`     | 后端分配出的 axon 地址低段。                                |
+| `target_lcn`    | 目标 core 的 LCN 编号，对应 `paicorelib.LCN_EX` 枚举值。    |
+| `copy_id`       | tiling/folding 产生的逻辑 copy 编号，不等同于 `CopyCount`。 |
+| `bit_width`     | 该逻辑输入元素的位宽。                                      |
 
 应用侧编码输入工作帧时，应按 `shape.size` 准备输入张量，并以 C-order 展平后使用 `elem_idx` 取值。
 
@@ -312,13 +312,13 @@ message OutputEntry {
 }
 ```
 
-| 字段 | 含义 |
-| --- | --- |
-| `name` | PAIIR 输出节点名。 |
-| `shape.size` | 逻辑输出张量 shape。 |
-| `elem_idx` | 输出张量按 C-order 展平后的元素下标。 |
-| `copy_id` | tiling/folding 产生的逻辑 copy 编号。 |
-| `bit_width` | 输出元素位宽。 |
+| 字段           | 含义                                               |
+| -------------- | -------------------------------------------------- |
+| `name`         | PAIIR 输出节点名。                                 |
+| `shape.size`   | 逻辑输出张量 shape。                               |
+| `elem_idx`     | 输出张量按 C-order 展平后的元素下标。              |
+| `copy_id`      | tiling/folding 产生的逻辑 copy 编号。              |
+| `bit_width`    | 输出元素位宽。                                     |
 | `axon_bit_idx` | 后端为该输出元素分配的平坦 output axon bit index。 |
 
 当前 `OutputEntry` 只能表示普通输出数据帧的地址标注与解码，即应用侧可通过 `axon_bit_idx` 把芯片返回的工作帧 payload 放回逻辑输出张量。它不能表示膜电平帧的地址信息，也不能描述膜电平帧的 4 帧基地址。因此，基于当前 schema，应用侧无法仅依赖 `config.pb` 完成膜电平帧定位或解码。
@@ -406,14 +406,14 @@ def collect_u32_le(decoded_by_axon: dict[int, int], base_axon_bit_idx: int) -> i
 
 `config.json` 使用 protobuf JSON 命名规则，会把 snake_case 字段转成 lowerCamelCase：
 
-| proto 字段 | JSON 字段 |
-| --- | --- |
-| `schema_version` | `schemaVersion` |
-| `io_mapping` | `ioMapping` |
-| `config_frames` | `configFrames` |
+| proto 字段         | JSON 字段        |
+| ------------------ | ---------------- |
+| `schema_version`   | `schemaVersion`  |
+| `io_mapping`       | `ioMapping`      |
+| `config_frames`    | `configFrames`   |
 | `root_core_offset` | `rootCoreOffset` |
-| `elem_idx` | `elemIdx` |
-| `addr_axon` | `addrAxon` |
-| `axon_bit_idx` | `axonBitIdx` |
+| `elem_idx`         | `elemIdx`        |
+| `addr_axon`        | `addrAxon`       |
+| `axon_bit_idx`     | `axonBitIdx`     |
 
 应用程序读取 `config.pb` 时使用 proto 字段名；人工查看 `config.json` 时使用 JSON 字段名。

--- a/paibox/paiir/ir/__init__.py
+++ b/paibox/paiir/ir/__init__.py
@@ -11,7 +11,12 @@ and backend deployment:
 """
 
 from .calc_params import LutData, NeuronParams, OfflineCoreParams, OnlineCoreParams
-from .core_neuron import ANNNodeV25, CoreNeuronV25, IFNodeV25, LIFNodeV25
+from .core_neuron import (
+    ANNNodeV25,
+    CoreNeuronV25,
+    IFNodeV25,
+    LIFNodeV25,
+)
 from .graph import Edge, PAIIRGraph
 from .ir_base import InputNode, OutputNode, PAIIRNode, TensorLayout
 from .signal_domain import SignalDomain, SignalSemantics

--- a/paibox/paiir/ir/add_ops.py
+++ b/paibox/paiir/ir/add_ops.py
@@ -95,7 +95,7 @@ class GeneralAddOp(OpNode):
     :class:`PotentialAddOp`.
     """
 
-    deploy: ClassVar[bool] = False
+    __deploy__: ClassVar[bool] = False
 
     def __init__(self, operands: Sequence[AddOperandSpec]) -> None:
         super().__init__()

--- a/paibox/paiir/ir/calc_params.py
+++ b/paibox/paiir/ir/calc_params.py
@@ -209,7 +209,7 @@ class NeuronParams:
     thres_neg_mode: ThresholdNegMode = ThresholdNegMode.FLOOR
     thres_pos_mode: ThresholdPosMode = ThresholdPosMode.FIRE
     thres_neg: float = DEFAULT_NEG_THRESHOLD
-    thres_pos: float = 0.0
+    thres_pos: float | Tensor = 0.0
     lateral_inhi: LateralInhibitionMode = LateralInhibitionMode.DISABLE
     leak_multi_sequence: LeakMultiComparisonOrder = (
         LeakMultiComparisonOrder.AFTER_COMPARE

--- a/paibox/paiir/ir/core_neuron.py
+++ b/paibox/paiir/ir/core_neuron.py
@@ -54,7 +54,12 @@ from ...exceptions import AutoOptimizationWarning
 from .calc_params import DEFAULT_NEG_THRESHOLD, LutData, NeuronParams
 from .lut_activation import LutActivation
 
-__all__ = ["CoreNeuronV25", "ANNNodeV25", "IFNodeV25", "LIFNodeV25"]
+__all__ = [
+    "CoreNeuronV25",
+    "ANNNodeV25",
+    "IFNodeV25",
+    "LIFNodeV25",
+]
 
 _T = TypeVar("_T", bound="CoreNeuronV25")
 
@@ -83,7 +88,7 @@ class CoreNeuronV25(MemoryModule):
         reset_v: float = 0,
         thres_pos_mode: ThresholdPosMode = ThresholdPosMode.FIRE,
         thres_neg_mode: ThresholdNegMode | None = None,
-        thres_pos: float = 0,
+        thres_pos: float | Tensor = 0,
         thres_neg: float | None = None,
         lateral_inhi: LateralInhibitionMode | bool = LateralInhibitionMode.DISABLE,
         leak_multi_sequence: LeakMultiComparisonOrder = LeakMultiComparisonOrder.AFTER_COMPARE,
@@ -114,7 +119,9 @@ class CoreNeuronV25(MemoryModule):
             reset_v: Hard-reset voltage.
             thres_pos_mode: Positive threshold mode.
             thres_neg_mode: Negative threshold mode.
-            thres_pos: Positive threshold.
+            thres_pos: Positive threshold. A scalar applies to the whole neuron
+                instance; a 1D tensor is interpreted as per-output-channel
+                threshold and is explicitly broadcast against ``N,C,...`` state.
             thres_neg: Negative threshold. ``None`` uses a very small default.
             lateral_inhi: Lateral inhibition mode.
             leak_multi_sequence: Order of multiplicative leak relative to
@@ -143,18 +150,16 @@ class CoreNeuronV25(MemoryModule):
         else:
             self.thres_neg_mode = ThresholdNegMode.FLOOR
 
-        self.thres_pos = thres_pos
+        self.thres_pos = _normalize_thres_pos(thres_pos)
         self.thres_neg = thres_neg if thres_neg is not None else DEFAULT_NEG_THRESHOLD
+        self.lut = lut
         self.lateral_inhi = LateralInhibitionMode(lateral_inhi)
         self.leak_multi_sequence = leak_multi_sequence
         self.leak_multi_input = LeakMultiInputMode(leak_multi_input)
         self.leak_multi_mode = LeakMultiMode(leak_multi_mode)
         self.leak_add_mode = leak_add_mode
 
-        if self.thres_pos < self.thres_neg:
-            raise ValueError(
-                f"'thres_pos' ({self.thres_pos}) must be >= 'thres_neg' ({self.thres_neg})"
-            )
+        self._validate_threshold_bounds()
 
         # tau -> leak_tau (right-shift exponent)
         # Keep the original tau for compensation passes that need the
@@ -170,9 +175,6 @@ class CoreNeuronV25(MemoryModule):
 
         self.surrogate_function = surrogate_function
         self.detach_reset = detach_reset
-
-        # LUT activation for ANN mode (stored as sub-module)
-        self.lut = lut
 
         self.register_memory("v", init_v)
         self._any_pos_spike_at_last_ts = False
@@ -295,10 +297,11 @@ class CoreNeuronV25(MemoryModule):
 
             # Fire: compare V against threshold (only for FIRE sides)
             if self.thres_pos_mode == ThresholdPosMode.FIRE:
+                pos_thres = self._thres_pos_for_v()
                 if self.training:
-                    pos_spike = self.surrogate_function(self.v - self.thres_pos)
+                    pos_spike = self.surrogate_function(self.v - pos_thres)
                 else:
-                    pos_spike = (self.v >= self.thres_pos).to(torch.int8)
+                    pos_spike = (self.v >= pos_thres).to(torch.int8)
                 output = output + pos_spike
                 pos_mask = (
                     pos_spike.detach().bool()
@@ -320,7 +323,14 @@ class CoreNeuronV25(MemoryModule):
 
             # Build per-element threshold for soft reset (only fired elements matter)
             thres = torch.zeros_like(self.v)
-            thres[pos_mask] = self.thres_pos
+            if self.thres_pos_mode == ThresholdPosMode.FIRE:
+                pos_thres = self._thres_pos_for_v()
+                if torch.is_tensor(pos_thres):
+                    thres = torch.where(
+                        pos_mask, pos_thres.expand_as(self.v), thres
+                    )
+                else:
+                    thres[pos_mask] = pos_thres
             thres[neg_mask] = self.thres_neg
             self.v = self._reset_v(self.v, pos_mask, neg_mask, thres)
 
@@ -345,7 +355,11 @@ class CoreNeuronV25(MemoryModule):
         LUT lookup step.
         """
         if self.thres_pos_mode == ThresholdPosMode.CEILING:
-            self.v.clamp_max_(self.thres_pos)
+            pos_thres = self._thres_pos_for_v()
+            if torch.is_tensor(pos_thres):
+                self.v = torch.minimum(self.v, pos_thres.expand_as(self.v))
+            else:
+                self.v.clamp_max_(pos_thres)
         if self.thres_neg_mode == ThresholdNegMode.FLOOR:
             self.v.clamp_min_(self.thres_neg)
 
@@ -432,6 +446,48 @@ class CoreNeuronV25(MemoryModule):
         else:
             return self.v - self._apply_tau_shift(self.v)
 
+    def _validate_threshold_bounds(self) -> None:
+        """Validate scalar/per-channel positive threshold configuration."""
+        if torch.is_tensor(self.thres_pos):
+            if self.lut is not None:
+                raise ValueError(
+                    "per-channel 'thres_pos' is only supported in SNN mode"
+                )
+            if torch.any(self.thres_pos < self.thres_neg).item():
+                raise ValueError(
+                    "all per-channel 'thres_pos' values "
+                    f"({self.thres_pos}) must be >= 'thres_neg' ({self.thres_neg})"
+                )
+            return
+
+        if self.thres_pos < self.thres_neg:
+            raise ValueError(
+                f"'thres_pos' ({self.thres_pos}) must be >= 'thres_neg' ({self.thres_neg})"
+            )
+
+    def _thres_pos_for_v(self) -> float | Tensor:
+        """Return scalar threshold or a channel-broadcast tensor for ``self.v``."""
+        if not torch.is_tensor(self.thres_pos):
+            return self.thres_pos
+        if not torch.is_tensor(self.v):
+            raise RuntimeError(
+                "per-channel 'thres_pos' requires tensor membrane state"
+            )
+        if self.v.ndim < 2:
+            raise ValueError(
+                "per-channel 'thres_pos' requires neuron state with a channel dimension"
+            )
+        if self.v.shape[1] != self.thres_pos.numel():
+            raise ValueError(
+                f"per-channel 'thres_pos' has {self.thres_pos.numel()} element(s) "
+                f"but neuron state channel count is {self.v.shape[1]}"
+            )
+
+        threshold = self.thres_pos.to(device=self.v.device)
+        return threshold.reshape(
+            _channel_broadcast_shape(self.v.ndim, threshold.numel())
+        )
+
     def _tau_to_shift(self, tau: float) -> int:
         """Convert time constant *tau* to a right-shift exponent."""
         if tau <= 1:
@@ -494,10 +550,35 @@ def _resolve_reset(v_reset: float | None) -> tuple[float, RM]:
     return v_reset, RM.MODE_NORMAL  # hard reset
 
 
+def _normalize_thres_pos(thres_pos: float | Tensor) -> float | Tensor:
+    if not torch.is_tensor(thres_pos):
+        return thres_pos
+    if thres_pos.ndim == 0:
+        return thres_pos.item()
+    return _validate_per_channel_threshold(thres_pos, name="thres_pos")
+
+
+def _channel_broadcast_shape(ndim: int, channel_count: int) -> tuple[int, ...]:
+    """Broadcast shape for applying a `(C,)` tensor across an `N,C,...` state."""
+    return (1, channel_count, *(1 for _ in range(ndim - 2)))
+
+
+def _validate_per_channel_threshold(v_threshold: Tensor, *, name: str) -> Tensor:
+    if not torch.is_tensor(v_threshold):
+        raise ValueError(f"{name} must be a 1D Tensor")
+    if v_threshold.ndim != 1:
+        raise ValueError(
+            f"{name} must be a 1D Tensor, got shape={tuple(v_threshold.shape)}"
+        )
+    if v_threshold.numel() == 0:
+        raise ValueError(f"{name} must not be empty")
+    return v_threshold.detach().clone()
+
+
 class IFNodeV25(CoreNeuronV25):
     def __init__(
         self,
-        v_threshold: float = 1.0,
+        v_threshold: float | Tensor = 1.0,
         v_reset: float | None = 0.0,
         surrogate_function: Callable = surrogate.Sigmoid(),
         detach_reset: bool = False,
@@ -531,7 +612,7 @@ class LIFNodeV25(CoreNeuronV25):
         self,
         tau: float = 2.0,
         decay_input: bool = True,
-        v_threshold: float = 1.0,
+        v_threshold: float | Tensor = 1.0,
         v_reset: float | None = 0.0,
         surrogate_function: Callable = surrogate.Sigmoid(),
         detach_reset: bool = False,

--- a/paibox/paiir/ir/core_neuron.py
+++ b/paibox/paiir/ir/core_neuron.py
@@ -326,9 +326,7 @@ class CoreNeuronV25(MemoryModule):
             if self.thres_pos_mode == ThresholdPosMode.FIRE:
                 pos_thres = self._thres_pos_for_v()
                 if torch.is_tensor(pos_thres):
-                    thres = torch.where(
-                        pos_mask, pos_thres.expand_as(self.v), thres
-                    )
+                    thres = torch.where(pos_mask, pos_thres.expand_as(self.v), thres)
                 else:
                     thres[pos_mask] = pos_thres
             thres[neg_mask] = self.thres_neg
@@ -470,9 +468,7 @@ class CoreNeuronV25(MemoryModule):
         if not torch.is_tensor(self.thres_pos):
             return self.thres_pos
         if not torch.is_tensor(self.v):
-            raise RuntimeError(
-                "per-channel 'thres_pos' requires tensor membrane state"
-            )
+            raise RuntimeError("per-channel 'thres_pos' requires tensor membrane state")
         if self.v.ndim < 2:
             raise ValueError(
                 "per-channel 'thres_pos' requires neuron state with a channel dimension"

--- a/paibox/paiir/ir/op_node.py
+++ b/paibox/paiir/ir/op_node.py
@@ -169,7 +169,7 @@ class OpNode(nn.Module, PAIIRNode):
     variants (offline core, online core, CPU fallback, etc.).
 
     Class attributes:
-        deploy: Whether this node should be deployed to a chip core.
+        __deploy__: Whether this node should be deployed to a chip core.
             Set to False for simulation-only routing transforms.
 
     Attributes:
@@ -177,7 +177,7 @@ class OpNode(nn.Module, PAIIRNode):
         output_layouts: Tensor layouts at each output port.
     """
 
-    deploy: ClassVar[bool] = True
+    __deploy__: ClassVar[bool] = True
     input_layouts: tuple[TensorLayout, ...]
     output_layouts: tuple[TensorLayout, ...]
 
@@ -219,7 +219,7 @@ class RoutingOp(OpNode):
     interpretation but require no actual computation.
 
     Class attributes:
-        deploy: False - routing ops are not deployed to any core.
+        __deploy__: False - routing ops are not deployed to any core.
 
     Subclasses:
     - :class:`TransformOp` - ordered layout / shape reinterpretation
@@ -227,7 +227,7 @@ class RoutingOp(OpNode):
     - :class:`SplitOp` - split branch selection
     """
 
-    deploy: ClassVar[bool] = False
+    __deploy__: ClassVar[bool] = False
 
 
 class TransformOp(RoutingOp):

--- a/paibox/paiir/lowering/converter.py
+++ b/paibox/paiir/lowering/converter.py
@@ -53,7 +53,12 @@ from torch.fx.passes.shape_prop import ShapeProp
 
 from ..exceptions import UnsupportedOpError, UnsupportedOpWarning
 from ..ir.add_ops import AddOperandKind, AddOperandSpec, GeneralAddOp
-from ..ir.core_neuron import ANNNodeV25, CoreNeuronV25, IFNodeV25, LIFNodeV25
+from ..ir.core_neuron import (
+    ANNNodeV25,
+    CoreNeuronV25,
+    IFNodeV25,
+    LIFNodeV25,
+)
 from ..ir.graph import PAIIRGraph
 from ..ir.ir_base import InputNode, OutputNode
 from ..ir.lut_activation import (
@@ -276,7 +281,12 @@ _BUILTIN_PAIIR_LUT_MODULES = (
     LutSoftsign,
 )
 
-_BUILTIN_PAIIR_NEURONS = (CoreNeuronV25, IFNodeV25, LIFNodeV25, ANNNodeV25)
+_BUILTIN_PAIIR_NEURONS = (
+    CoreNeuronV25,
+    IFNodeV25,
+    LIFNodeV25,
+    ANNNodeV25,
+)
 
 
 def _build_compute_module_map() -> ModuleMapper:

--- a/paibox/paiir/pipeline/avgpool/compensation.py
+++ b/paibox/paiir/pipeline/avgpool/compensation.py
@@ -2,6 +2,7 @@
 
 import math
 
+import torch
 from paicorelib import LeakMultiComparisonOrder, LeakMultiInputMode, LeakMultiMode
 
 from ...ir.calc_params import LutData, NeuronParams
@@ -23,6 +24,11 @@ __all__ = [
 def _is_power_of_two(n: int) -> bool:
     """Return True when AvgPool division can be represented by an exact shift."""
     return n > 0 and (n & (n - 1)) == 0
+
+
+def _reject_channelwise_threshold(thres_pos: float | torch.Tensor) -> None:
+    if isinstance(thres_pos, torch.Tensor):
+        raise ValueError("AvgPool compensation does not support per-channel thres_pos")
 
 
 def apply_avgpool_leak_params(
@@ -71,6 +77,7 @@ def compensate_avgpool_neuron(
     Thresholds are therefore moved into the same working domain while keeping
     the reset voltage fixed.
     """
+    _reject_channelwise_threshold(params.thres_pos)
     reset_v = params.reset_v
     factor = window_size if decay_input else window_size / tau
     params.thres_pos = reset_v + (params.thres_pos - reset_v) * factor
@@ -98,6 +105,7 @@ def compensate_sumpool_neuron(
     Core 1 emits ``sum = window_size * avg`` in the split-core LIF path, so Core
     2 must run the neuron in that same scaled voltage domain.
     """
+    _reject_channelwise_threshold(params.thres_pos)
     params.thres_pos *= window_size
     params.thres_neg *= window_size
     params.reset_v *= window_size
@@ -134,6 +142,7 @@ def apply_avgpool_snn_compensation(
     calibrated: bool = False,
 ) -> None:
     """Write shared-core LIF compensation back into the live neuron module."""
+    _reject_channelwise_threshold(neuron.thres_pos)
     if not calibrated:
         reset_v = neuron.reset_v
         # Shared-core LIF runs in the sum domain, so thresholds move there while
@@ -155,6 +164,7 @@ def apply_sumpool_snn_compensation(
     neuron: CoreNeuronV25, window_size: int, *, is_float: bool = False
 ) -> None:
     """Write split-core SumPool + LIF scaling back into the live neuron module."""
+    _reject_channelwise_threshold(neuron.thres_pos)
     neuron.thres_pos *= window_size
     neuron.thres_neg *= window_size
     neuron.reset_v *= window_size

--- a/paibox/paiir/pipeline/avgpool/delayed_division.py
+++ b/paibox/paiir/pipeline/avgpool/delayed_division.py
@@ -295,7 +295,9 @@ def _lut_thresholds_within_bounds(lut: LutActivation | None, factor: int) -> boo
 
 def _neuron_params_within_bounds(act: CoreNeuronV25, factor: int) -> bool:
     if isinstance(act.thres_pos, torch.Tensor):
-        raise ValueError("Delayed AvgPool division does not support per-channel thres_pos")
+        raise ValueError(
+            "Delayed AvgPool division does not support per-channel thres_pos"
+        )
 
     threshold_values = (
         torch.tensor([act.thres_pos, act.thres_neg], dtype=torch.float64) * factor
@@ -396,7 +398,9 @@ def _scale_lut_thresholds(act: CoreNeuronV25, factor: int) -> None:
 def _scale_neuron(act: CoreNeuronV25, factor: int) -> None:
     """Scale all neuron voltage-domain parameters by the pending divisor."""
     if isinstance(act.thres_pos, torch.Tensor):
-        raise ValueError("Delayed AvgPool division does not support per-channel thres_pos")
+        raise ValueError(
+            "Delayed AvgPool division does not support per-channel thres_pos"
+        )
 
     act.thres_pos *= factor
     act.thres_neg *= factor

--- a/paibox/paiir/pipeline/avgpool/delayed_division.py
+++ b/paibox/paiir/pipeline/avgpool/delayed_division.py
@@ -294,6 +294,9 @@ def _lut_thresholds_within_bounds(lut: LutActivation | None, factor: int) -> boo
 
 
 def _neuron_params_within_bounds(act: CoreNeuronV25, factor: int) -> bool:
+    if isinstance(act.thres_pos, torch.Tensor):
+        raise ValueError("Delayed AvgPool division does not support per-channel thres_pos")
+
     threshold_values = (
         torch.tensor([act.thres_pos, act.thres_neg], dtype=torch.float64) * factor
     )
@@ -392,6 +395,9 @@ def _scale_lut_thresholds(act: CoreNeuronV25, factor: int) -> None:
 
 def _scale_neuron(act: CoreNeuronV25, factor: int) -> None:
     """Scale all neuron voltage-domain parameters by the pending divisor."""
+    if isinstance(act.thres_pos, torch.Tensor):
+        raise ValueError("Delayed AvgPool division does not support per-channel thres_pos")
+
     act.thres_pos *= factor
     act.thres_neg *= factor
     act.reset_v *= factor

--- a/paibox/paiir/pipeline/avgpool/pass_ops.py
+++ b/paibox/paiir/pipeline/avgpool/pass_ops.py
@@ -1,5 +1,6 @@
 """AvgPool-related calibration pass operations."""
 
+import torch
 from paicorelib import LeakMultiInputMode
 
 from ...ir.graph import PAIIRGraph
@@ -28,6 +29,10 @@ def calibrate_avgpool_thresholds(
             continue
         if not node.act.has_lif_dynamics:
             continue
+        if isinstance(node.act.thres_pos, torch.Tensor):
+            raise ValueError(
+                "AvgPool threshold calibration does not support per-channel thres_pos"
+            )
 
         sum_window_size = get_pool_window_size(node.comp)
         avg_divisor = get_avgpool_divisor(node.comp)

--- a/paibox/paiir/pipeline/passes.py
+++ b/paibox/paiir/pipeline/passes.py
@@ -528,6 +528,12 @@ def validate_compiled_graph(graph: PAIIRGraph) -> None:
             continue
 
         _validate_lut_mode_consistency(errors, name, node)
+        _validate_per_channel_export_param_contract(
+            errors, name, node, node.neuron_params.thres_pos, "thres_pos"
+        )
+        _validate_per_channel_export_param_contract(
+            errors, name, node, node.neuron_params.leak_v, "leak_v"
+        )
         _validate_output_domain_consistency(errors, name, node)
         _validate_32bit_input_contract(errors, name, node)
 
@@ -561,6 +567,45 @@ def _validate_output_domain_consistency(
             f"neuron_params.output_type={output_type.name}"
         )
         return
+
+
+def _validate_per_channel_export_param_contract(
+    errors: list[str],
+    name: str,
+    node: OfflineCoreOp,
+    value: float | torch.Tensor,
+    param_name: str,
+) -> None:
+    if not torch.is_tensor(value):
+        return
+
+    output_shape = _single_output_shape(node)
+    if len(output_shape) < 2:
+        errors.append(
+            f"OfflineCoreOp '{name}' has per-channel {param_name} but "
+            f"output_shape={tuple(output_shape)} has no channel dimension"
+        )
+        return
+
+    if output_shape[0] != 1:
+        errors.append(
+            f"OfflineCoreOp '{name}' has per-channel {param_name} but "
+            f"batch size {output_shape[0]} is not supported"
+        )
+
+    if value.ndim != 1:
+        errors.append(
+            f"OfflineCoreOp '{name}' has per-channel {param_name} but "
+            f"shape={tuple(value.shape)} is not a 1D tensor"
+        )
+        return
+
+    channel_count = output_shape[1]
+    if value.numel() != channel_count:
+        errors.append(
+            f"OfflineCoreOp '{name}' {param_name} has {value.numel()} element(s) "
+            f"but output channel count is {channel_count}"
+        )
 
 
 def _validate_32bit_input_contract(

--- a/tests/paiir/ir/test_core_neuron.py
+++ b/tests/paiir/ir/test_core_neuron.py
@@ -6,7 +6,12 @@ from paicorelib import RM, ThresholdPosMode
 from spikingjelly.activation_based import functional
 from torch import nn
 
-from paibox.paiir.ir.core_neuron import ANNNodeV25, CoreNeuronV25, IFNodeV25, LIFNodeV25
+from paibox.paiir.ir.core_neuron import (
+    ANNNodeV25,
+    CoreNeuronV25,
+    IFNodeV25,
+    LIFNodeV25,
+)
 from paibox.paiir.ir.lut_activation import LutCustom, LutReLU
 
 
@@ -126,6 +131,64 @@ class TestLIFNodeV25:
         n3 = LIFNodeV25(tau=2, v_threshold=1.0, v_reset=None)
         assert n3.v == 0.0
         assert n3.init_v == 0.0
+
+
+class TestPerChannelThreshold:
+    def test_if_node_per_channel_forward_uses_channel_thresholds(self):
+        node = IFNodeV25(torch.tensor([1.0, 2.0, 3.0]))
+        assert torch.equal(node.thres_pos, torch.tensor([1.0, 2.0, 3.0]))
+
+        x = torch.tensor(
+            [[[[0.5, 1.0]], [[1.9, 2.0]], [[2.9, 3.0]]]],
+            dtype=torch.float32,
+        )
+        spike = node(x)
+
+        assert spike.tolist() == [[[[0, 1]], [[0, 1]], [[0, 1]]]]
+
+    def test_if_node_per_channel_soft_reset_uses_channel_thresholds(self):
+        node = IFNodeV25(torch.tensor([1.0, 2.0]), v_reset=None)
+        spike = node(torch.tensor([[[[1.5]], [[2.5]]]], dtype=torch.float32))
+
+        assert spike.tolist() == [[[[1]], [[1]]]]
+        assert torch.equal(node.v, torch.tensor([[[[0.5]], [[0.5]]]]))
+
+    def test_lif_node_per_channel_forward_uses_channel_thresholds(self):
+        node = LIFNodeV25(
+            tau=2.0,
+            decay_input=False,
+            v_threshold=torch.tensor([1.0, 3.0]),
+            v_reset=0.0,
+        )
+
+        spike = node(torch.tensor([[[[1.0]], [[2.0]]]], dtype=torch.float32))
+
+        assert spike.tolist() == [[[[1]], [[0]]]]
+        assert torch.equal(node.v, torch.tensor([[[[0.0]], [[1.0]]]]))
+
+    def test_per_channel_nodes_reject_non_1d_thresholds(self):
+        with pytest.raises(ValueError, match="1D Tensor"):
+            IFNodeV25(torch.ones(1, 3))
+
+        with pytest.raises(ValueError, match="1D Tensor"):
+            LIFNodeV25(v_threshold=torch.ones(1, 3))
+
+    def test_per_channel_threshold_is_rejected_for_lut_nodes(self):
+        with pytest.raises(ValueError, match="only supported in SNN mode"):
+            ANNNodeV25(LutReLU(), thres_pos=torch.tensor([1.0, 2.0, 3.0]))
+
+    def test_backend_attrs_part2_resolves_threshold_by_channel(self):
+        from paibox.backendv2.op_node import CoreOpNode
+        from paibox.paiir.ir.op_node import StandaloneActOp
+
+        raw_node = StandaloneActOp(IFNodeV25(torch.tensor([1.0, 2.0, 3.0])))
+        raw_node.core_params.tick_start = 0
+        backend_node = CoreOpNode("act", raw_node, (1, 3, 2, 2))
+
+        assert backend_node.attrs_part2(0).threshold_pos == 1
+        assert backend_node.attrs_part2(3).threshold_pos == 1
+        assert backend_node.attrs_part2(4).threshold_pos == 2
+        assert backend_node.attrs_part2(8).threshold_pos == 3
 
 
 class TestCoreNeuronCopying:

--- a/tests/paiir/lowering/test_converter.py
+++ b/tests/paiir/lowering/test_converter.py
@@ -9,7 +9,11 @@ from spikingjelly.activation_based import neuron as sj
 from torch import Tensor, nn
 
 from paibox.paiir.exceptions import UnsupportedOpError, UnsupportedOpWarning
-from paibox.paiir.ir.core_neuron import ANNNodeV25, IFNodeV25, LIFNodeV25
+from paibox.paiir.ir.core_neuron import (
+    ANNNodeV25,
+    IFNodeV25,
+    LIFNodeV25,
+)
 from paibox.paiir.ir.lut_activation import LutCustom, LutReLU
 from paibox.paiir.ir.op_node import (
     SequentialOp,
@@ -198,6 +202,60 @@ class TestRegisterNeuron:
         assert lowered is not neuron
         assert lowered.thres_pos == neuron.thres_pos
         assert lowered.v == lowered.init_v
+
+    def test_register_spikingjelly_per_channel_ifnode_lowers_to_deploy_only_act(self):
+        class _PerChannelThresholdMixin:
+            per_channel_threshold: Tensor
+
+            def _threshold_view(self) -> Tensor:
+                shape = [1] * self.v.ndim
+                shape[1] = self.per_channel_threshold.numel()
+                return self.per_channel_threshold.view(shape)
+
+            def neuronal_fire(self):
+                return self.surrogate_function(self.v - self._threshold_view())
+
+            def neuronal_reset(self, spike):
+                spike_d = spike.detach() if self.detach_reset else spike
+                if self.v_reset is None:
+                    self.v = self.v - spike_d * self._threshold_view()
+                else:
+                    self.v = spike_d * self.v_reset + (1.0 - spike_d) * self.v
+
+        class SpikingJellyPerChannelIFNode(_PerChannelThresholdMixin, sj.IFNode):
+            per_channel_threshold: Tensor
+
+            def __init__(self, thresholds: Tensor) -> None:
+                super().__init__(v_threshold=1.0, v_reset=0.0)
+                self.register_buffer("per_channel_threshold", thresholds)
+
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(8, 4)
+                self.act = SpikingJellyPerChannelIFNode(
+                    torch.tensor([1.0, 2.0, 3.0, 4.0])
+                )
+
+            def forward(self, x):
+                return self.act(self.linear(x))
+
+        register_neuron(
+            SpikingJellyPerChannelIFNode,
+            lambda m: IFNodeV25(
+                m.per_channel_threshold, m.v_reset, m.surrogate_function, m.detach_reset
+            ),
+        )
+
+        fused = convert_and_fuse(Model(), make_vec_8d())
+        seq_nodes = find_nodes(fused, SequentialOp)
+        assert len(seq_nodes) == 1
+        assert isinstance(seq_nodes[0].act, IFNodeV25)
+        assert isinstance(seq_nodes[0].act.thres_pos, torch.Tensor)
+        assert torch.equal(
+            seq_nodes[0].act.thres_pos, torch.tensor([1.0, 2.0, 3.0, 4.0])
+        )
+        assert isinstance(seq_nodes[0].neuron_params.thres_pos, torch.Tensor)
 
 
 class ExplicitQuantConv(nn.Module):


### PR DESCRIPTION
## Summary

- add `float | Tensor` `thres_pos` support to `CoreNeuronV25`
- support per-channel `(C,)` thresholds in `IFNodeV25` and `LIFNodeV25`
- export per-channel `thres_pos` to backendv2 with channel-wise scalarization
- reject unsupported AvgPool calibration / compensation paths for tensor thresholds
- document the current per-channel threshold contract in `docs/paiir_backend_guide.md`
