### PR TITLE
Feat(backendv2): export artifact contract & align developer guides

### DIFF
--- a/docs/user_quickstart.md
+++ b/docs/user_quickstart.md
@@ -211,7 +211,7 @@ graph = compile_to_paiir(raw_quantized_model, sample_input)
 
 更稳妥的通用做法是先做一层“部署态重建”：
 
-1. 从量化模型中提取部署参数  
+1. 从量化模型中提取部署参数
    例如 `int8` 权重、`int32` 偏置、输入/输出 scale、requant 规则。
 2. 用当前 lowering 能识别的模块重建一个部署态 `nn.Module`
 3. 对不能直接表达的激活或 requant，使用 LUT 激活或 `register_neuron(...)`
@@ -308,19 +308,19 @@ print("frame_dir:", output_dir)
 
 高频参数如下：
 
-| 参数 | 作用 |
-| --- | --- |
-| `*sample_inputs` | 示例输入，参与 shape/dims 推断，`batch_size` 必须为 `1` |
-| `tick_duration` | 全局工作时长，`0` 表示常开 |
-| `auto_reset` | 工作周期结束后是否自动复位 |
-| `tick_overrides` | 按节点名覆盖局部时序 |
-| `input_formats` | 按 `InputNode` 名称指定输入数据格式 |
-| `compile_config` | 统一承载默认配置 |
-| `concrete_args` | 固定 FX tracing 时的非 Tensor 参数 |
-| `strict` | 遇到 unsupported op 时是否直接报错 |
-| `enable_avgpool_calibration` | 共享核 `AvgPool + LIF` 阈值细化开关 |
-| `enable_split_avgpool_lif` | 条件式 `AvgPool + LIF` 分核部署开关 |
-| `enable_delayed_avgpool_division` | AvgPool 延迟除法改写开关，默认开启 |
+| 参数                              | 作用                                                    |
+| --------------------------------- | ------------------------------------------------------- |
+| `*sample_inputs`                  | 示例输入，参与 shape/dims 推断，`batch_size` 必须为 `1` |
+| `tick_duration`                   | 全局工作时长，`0` 表示常开                              |
+| `auto_reset`                      | 工作周期结束后是否自动复位                              |
+| `tick_overrides`                  | 按节点名覆盖局部时序                                    |
+| `input_formats`                   | 按 `InputNode` 名称指定输入数据格式                     |
+| `compile_config`                  | 统一承载默认配置                                        |
+| `concrete_args`                   | 固定 FX tracing 时的非 Tensor 参数                      |
+| `strict`                          | 遇到 unsupported op 时是否直接报错                      |
+| `enable_avgpool_calibration`      | 共享核 `AvgPool + LIF` 阈值细化开关                     |
+| `enable_split_avgpool_lif`        | 条件式 `AvgPool + LIF` 分核部署开关                     |
+| `enable_delayed_avgpool_division` | AvgPool 延迟除法改写开关，默认开启                      |
 
 优先级为：
 
@@ -640,13 +640,13 @@ work_frames_to_header(frames, output_header, array_name="work_frame1")
 
 对于“量化后网络模型”的通用部署，推荐按下面的顺序做：
 
-1. 完成量化，并拿到部署所需的整数参数  
+1. 完成量化，并拿到部署所需的整数参数
    例如输入 scale、每层权重、偏置、输出 scale、requant/LUT 规则。
-2. 重建一个“部署态 PyTorch 模型”  
+2. 重建一个“部署态 PyTorch 模型”
    保持当前 lowering 可识别的模块表面，不直接依赖原始量化执行图。
-3. 用 `compile_to_paiir(..., strict=True)` 编译  
+3. 用 `compile_to_paiir(..., strict=True)` 编译
    同时保存 `graph.summary()`。
-4. 用 `Mapper.compile(...)` 导出平台相关帧文件与 `proto/` 目录  
+4. 用 `Mapper.compile(...)` 导出平台相关帧文件与 `proto/` 目录
    同时保存 `backendv2.log` 与 `proto/config.pb`。
 5. 如果板端需要输入工作帧，再从 `cfg_frame1.txt` 生成 `work_frame1.h`
 6. 向板端交付至少这几类文件

--- a/docs/user_quickstart.md
+++ b/docs/user_quickstart.md
@@ -1,0 +1,738 @@
+# PAIIR + backendv2 用户快速上手
+
+本文档面向“已经拿到量化后模型，想在当前 PAIBox `dev` 分支上生成 2.5 芯片部署产物”的用户。
+
+目标不是介绍训练或 QAT，而是把当前仓库里真正可用的工具链路径讲清楚：
+
+```text
+部署态 PyTorch 模型
+  -> compile_to_paiir(...)
+  -> PAIIRGraph
+  -> Mapper().compile(...)
+  -> cfg_frame*.txt / .npy / .h + proto/
+  -> （如需要）work_frame1.h
+```
+
+这份 quickstart 以 `paibox.paiir` 和 `paibox.backendv2` 的公共接口为主线，应用样例只作为参考证据。
+
+## 1. 这条工具链负责什么
+
+当前 `dev` 分支里的 `PAIIR -> backendv2` 路径主要负责：
+
+- 把部署态 PyTorch 模型编译成 `PAIIRGraph`
+- 把 `PAIIRGraph` 下沉到 `backendv2`
+- 导出芯片配置帧 `cfg_frame*.txt/.npy/.h`
+- 导出 `proto/config.pb` 与便于人工查看的 `proto/config.json`
+- 在需要输入工作帧时，根据 `cfg_frame1.txt` 中的 `IO_LAYOUT_INFO` 生成 `work_frame1.h`
+
+它**不负责**：
+
+- 训练、校准、QAT、本身的量化流程
+- 任意 PyTorch 量化图的自动编译
+- 板端工程里的 UART/NoC 运行时协议
+- “前端编译成功”到“后端一定布线成功”的自动保证
+
+更准确地说，当前工具链擅长的是：
+
+- 你已经把模型整理成“部署态 PyTorch 模型”
+- 你希望把它变成 `PAIIRGraph`、平台相关帧文件以及 `proto/` 产物
+
+## 2. 部署前必须先理解的边界
+
+### 2.1 `compile_to_paiir(...)` 接收的是“部署态模型”，不是任意量化图
+
+当前前端降低器的主入口是：
+
+```python
+from paibox.paiir import compile_to_paiir
+```
+
+它能识别的是当前 lowering 代码支持的模块/算子表面，而不是任意 `torch.ao` 量化执行图。
+
+因此，“量化后模型可以部署”在当前仓库里的实际含义是：
+
+- 量化流程已经完成
+- 你已经把需要部署的整数语义整理到一个**可 trace、可 lowering** 的 PyTorch 模型表面上
+- 这个模型的 `forward(...)` 使用的是当前 lowering 能理解的模块和数据流
+
+### 2.2 推荐把量化结果整理成这种部署表面
+
+对于 ANN 量化模型，当前最稳妥的通用方式是：
+
+- 保留标准 `nn.Conv1d` / `nn.Conv2d` / `nn.Linear` / `nn.MaxPool*` / `nn.AvgPool*`
+- 或保留静态参数可解析的 `torch.nn.functional.conv1d/conv2d`
+- 把部署用的整数权重、偏置、scale、LUT 等信息固化到模块参数或 buffer 中
+- 把 requant / 激活整理成当前前端能识别的激活表面
+  - 直接使用内建 `nn.ReLU` / `nn.Sigmoid` / `nn.Tanh` / `nn.Softsign`
+  - 或使用 `paibox.paiir` 里的 LUT 激活
+  - 或使用 `register_neuron(...)` 注册自定义 neuron / 激活模块
+- 对自定义计算模块，使用 `register_module(...)` 显式转换到已有 canonical lowering 模块
+- 移除训练态、运行时量化包裹器、部署中不需要的辅助分支
+
+这也是为什么：
+
+- 芯片硬件能力和 `docs/Support-Ops.md` 里列出的能力范围，通常**大于**
+- 当前 `paibox.paiir.lowering.converter` 直接支持的 lowering 表面
+
+### 2.3 当前 lowering 的常用公共入口
+
+从代码接口看，当前高频公共入口是：
+
+```python
+from paibox.paiir import (
+    ANNNodeV25,
+    CompileConfig,
+    IFNodeV25,
+    LIFNodeV25,
+    LutCustom,
+    LutReLU,
+    compile_to_paiir,
+    register_module,
+    register_neuron,
+    torch_to_paiir,
+)
+from paibox.backendv2 import Mapper
+```
+
+其中：
+
+- `compile_to_paiir(...)` 是推荐的一站式编译入口
+- `torch_to_paiir(...)` 只做 1:1 lowering，不做完整融合和部署校验
+- `register_module(...)` 把自定义计算模块转换成 lowering 已支持的 canonical 模块
+- `register_neuron(...)` 把自定义 neuron / 激活模块转换成芯片 neuron 或 LUT
+- `Mapper.compile(...)` 负责布线、放置和帧文件导出
+
+## 3. 环境准备
+
+### 3.1 推荐安装方式
+
+```bash
+git clone https://github.com/PAICookers/PAIBox.git
+cd PAIBox
+
+uv venv .venv
+source .venv/bin/activate
+uv sync --group dev
+```
+
+当前 `pyproject.toml` 的 `dev` 依赖组已经覆盖这条路径所需的核心依赖，包括：
+
+- `torch`
+- `spikingjelly`
+- `paicorelib`
+- `ortools`
+- `numba`
+
+### 3.2 快速检查
+
+```bash
+uv run python -c "import torch, spikingjelly, paicorelib, numba, paibox; print('ok')"
+```
+
+## 4. 当前前端通常能直接识别什么
+
+根据 `paibox.paiir.lowering.converter`，当前常用 lowering 表面主要包括：
+
+- 计算模块
+  - `nn.Conv1d`
+  - `nn.Conv2d`
+  - `nn.Linear`
+  - `nn.MaxPool1d`
+  - `nn.MaxPool2d`
+  - `nn.AvgPool1d`
+  - `nn.AvgPool2d`
+- 函数式卷积
+  - `torch.nn.functional.conv1d`
+  - `torch.nn.functional.conv2d`
+  - 要求 weight / bias 等参数能从 buffer、常量或静态 tensor 表达式中解析出来
+- 常见激活
+  - `nn.ReLU`
+  - `nn.Sigmoid`
+  - `nn.Tanh`
+  - `nn.Softsign`
+- 脉冲神经元
+  - `spikingjelly.activation_based.neuron.IFNode`
+  - `spikingjelly.activation_based.neuron.LIFNode`
+- PAIIR 内建模块
+  - `ANNNodeV25`
+  - `IFNodeV25`
+  - `LIFNodeV25`
+  - `LutReLU`
+  - `LutSigmoid`
+  - `LutTanh`
+  - `LutSoftsign`
+  - `LutCustom`
+- 形状和布局相关变换
+  - `flatten`
+  - 常见 reshape / layout 变换
+
+此外：
+
+- `nn.Dropout`、`nn.Identity` 会在 lowering 早期被擦除
+- `nn.BatchNorm1d`、`nn.BatchNorm2d` 当前按 bypass 处理，不应把它们当成部署后仍需要的独立硬件语义
+
+如果模型里出现 unsupported op：
+
+- `strict=True` 时会抛 `UnsupportedOpError`
+- `strict=False` 时会 warning 并旁路该节点
+
+对于最终要落板的模型，建议最后回到 `strict=True`。
+
+## 5. 编译前需要满足什么
+
+### 5.1 模型约束
+
+进入 `compile_to_paiir(...)` 前，建议至少满足：
+
+- 已调用 `model.eval()`
+- `forward(...)` 中不再依赖训练态行为
+- 权重、偏置和激活语义已经是部署要用的版本
+- 不再依赖运行时 `QuantStub/DeQuantStub` 这类纯软件包裹来表达芯片行为
+
+### 5.2 `sample_inputs` 是部署契约的一部分
+
+当前 `torch_to_paiir(...)` / `compile_to_paiir(...)` 会用 `sample_inputs` 做 shape propagation 和 dims propagation。
+
+因此：
+
+- 输入 shape 必须与真实部署输入一致
+- 多输入模型按 `forward(self, xa, xb, ...)` 的顺序传入
+- 每个 `sample_input` 的 `batch_size` 必须为 `1`
+
+如果 batch size 不是 1，前端会直接报错。
+
+### 5.3 当前对量化模型的通用建议
+
+如果你手里的是 `torch.ao` 量化后的 checkpoint，不要默认认为可以直接：
+
+```python
+graph = compile_to_paiir(raw_quantized_model, sample_input)
+```
+
+更稳妥的通用做法是先做一层“部署态重建”：
+
+1. 从量化模型中提取部署参数  
+   例如 `int8` 权重、`int32` 偏置、输入/输出 scale、requant 规则。
+2. 用当前 lowering 能识别的模块重建一个部署态 `nn.Module`
+3. 对不能直接表达的激活或 requant，使用 LUT 激活或 `register_neuron(...)`
+4. 再把这个部署态模型送入 `compile_to_paiir(...)`
+
+## 6. 最小可运行示例
+
+下面给出一个通用的一站式示例：
+
+- 编译到 `PAIIRGraph`
+- 保存 `graph.summary()`
+- 调用 `backendv2`
+- 导出平台相关帧文件与 `proto/` 目录
+
+```python
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from paicorelib import DataSign, DataWidth
+
+from paibox.backendv2 import Mapper
+from paibox.paiir import CompileConfig, compile_to_paiir
+
+
+class Model(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(3, 16, 3, padding=1)
+        self.act = nn.ReLU()
+        self.pool = nn.MaxPool2d(2, 2)
+        self.fc = nn.Linear(16 * 16 * 16, 10)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv(x)
+        x = self.act(x)
+        x = self.pool(x)
+        x = torch.flatten(x, 1)
+        return self.fc(x)
+
+
+model = Model().eval()
+sample_input = torch.zeros(1, 3, 32, 32)
+
+build_dir = Path("build/my_model").resolve()
+output_dir = build_dir / "output"
+summary_path = build_dir / "paiir_summary.log"
+backend_log_path = build_dir / "backendv2.log"
+build_dir.mkdir(parents=True, exist_ok=True)
+
+cfg = CompileConfig(
+    tick_duration=0,
+    auto_reset=True,
+)
+
+graph = compile_to_paiir(
+    model,
+    sample_input,
+    compile_config=cfg,
+    input_formats={
+        "InputNode_0": (DataSign.SIGNED, DataWidth.WIDTH_8BIT),
+    },
+    strict=True,
+)
+
+with summary_path.open("w", encoding="utf-8") as fp, redirect_stdout(fp):
+    graph.summary()
+
+mapper = Mapper()
+with backend_log_path.open("w", encoding="utf-8") as fp, redirect_stdout(fp):
+    mapper.compile(
+        graph,
+        output_path=str(output_dir),
+        literal_format="hex",
+        target_platform="x86",
+        word_order="high_first",
+        export_merged_frames=True,
+        debug=True,
+        export_proto_python=True,
+    )
+
+print("summary:", summary_path)
+print("backend_log:", backend_log_path)
+print("routing_groups:", len(mapper.routing_groups))
+print("frame_dir:", output_dir)
+```
+
+推荐显式传 `output_path`，不要依赖当前工作目录。
+
+## 7. `compile_to_paiir(...)` 常用参数
+
+当前公共签名位于 `paibox.paiir.pipeline.compile.compile_to_paiir`。
+
+高频参数如下：
+
+| 参数 | 作用 |
+| --- | --- |
+| `*sample_inputs` | 示例输入，参与 shape/dims 推断，`batch_size` 必须为 `1` |
+| `tick_duration` | 全局工作时长，`0` 表示常开 |
+| `auto_reset` | 工作周期结束后是否自动复位 |
+| `tick_overrides` | 按节点名覆盖局部时序 |
+| `input_formats` | 按 `InputNode` 名称指定输入数据格式 |
+| `compile_config` | 统一承载默认配置 |
+| `concrete_args` | 固定 FX tracing 时的非 Tensor 参数 |
+| `strict` | 遇到 unsupported op 时是否直接报错 |
+| `enable_avgpool_calibration` | 共享核 `AvgPool + LIF` 阈值细化开关 |
+| `enable_split_avgpool_lif` | 条件式 `AvgPool + LIF` 分核部署开关 |
+| `enable_delayed_avgpool_division` | AvgPool 延迟除法改写开关，默认开启 |
+
+优先级为：
+
+```text
+显式关键字参数 > CompileConfig > 内置默认值
+```
+
+### 7.1 多输入模型
+
+```python
+graph = compile_to_paiir(
+    model,
+    sample_input_a,
+    sample_input_b,
+    strict=True,
+)
+```
+
+### 7.2 固定 tracing 时的非 Tensor 参数
+
+```python
+graph = compile_to_paiir(
+    model,
+    sample_input,
+    concrete_args={
+        "deploy_mode": True,
+        "return_aux": False,
+    },
+)
+```
+
+### 7.3 指定输入数据格式
+
+```python
+from paicorelib import DataSign, DataWidth
+
+graph = compile_to_paiir(
+    model,
+    sample_input,
+    input_formats={
+        "InputNode_0": (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT),
+    },
+)
+```
+
+如果你不确定 `InputNode` 的名字，先保存一次 `graph.summary()` 查看。
+
+### 7.4 只用于排查兼容性的 `strict=False`
+
+```python
+graph = compile_to_paiir(model, sample_input, strict=False)
+```
+
+这只适合：
+
+- 快速摸清有哪些 unsupported op
+- 看结构、看 warning、做前端兼容性排查
+
+不要把 `strict=False` 的返回图直接视为可部署图。
+
+## 8. 自定义激活 / 自定义 neuron / 自定义模块
+
+当模型里有当前 lowering 默认不认识的激活或 neuron 时，可先注册转换器：
+
+```python
+import torch
+import torch.nn as nn
+
+from paibox.paiir import LutCustom, register_neuron
+
+
+class MyQuantAct(nn.Module):
+    def __init__(self, thresholds: torch.Tensor, values: torch.Tensor) -> None:
+        super().__init__()
+        self.register_buffer("thresholds", thresholds.to(torch.int32))
+        self.register_buffer("values", values.to(torch.int8))
+        self.output_sign = 1
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError("runtime behavior omitted here")
+
+
+register_neuron(
+    MyQuantAct,
+    lambda mod: LutCustom(mod.thresholds, mod.values, mod.output_sign),
+)
+```
+
+说明：
+
+- `register_neuron(...)` 必须先于 `compile_to_paiir(...)`
+- converter 可返回 `CoreNeuronV25`，也可直接返回 `LutActivation`
+  - 直接返回 LUT 时，PAIIR 会按 ANN neuron 兼容层处理
+- 同一模块类型重复注册会抛 `ValueError`
+- 通常不需要额外手工设置 `_is_leaf_module`
+  - 当前 tracer 会把已注册类型视作自定义 leaf module
+
+这条接口对于量化部署尤其重要，因为很多 requant / 自定义激活本质上都可以落到 LUT 表达。
+
+对于自定义计算模块，优先把它转换成已有 canonical 模块：
+
+```python
+import torch.nn as nn
+
+from paibox.paiir import register_module
+
+
+class MyConvWrapper(nn.Module):
+    def __init__(self, conv: nn.Conv2d) -> None:
+        super().__init__()
+        self.conv = conv
+
+    def forward(self, x):
+        return self.conv(x)
+
+
+register_module(MyConvWrapper, lambda mod: mod.conv)
+```
+
+说明：
+
+- `register_module(...)` 的 converter 必须返回当前 PAIIR lowering 已支持的 `nn.Module`
+- 典型返回值是 `nn.Conv1d/2d`、`nn.Linear`、pool、内建激活或 PAIIR neuron / LUT 模块
+- 它不会根据字段名猜测量化参数；需要在 converter 里显式构造 canonical 模块
+
+## 9. `Mapper.compile(...)` 做了什么
+
+当前后端主入口是：
+
+```python
+from paibox.backendv2 import Mapper
+
+mapper = Mapper()
+mapper.compile(
+    graph,
+    output_path="./output",
+    literal_format="bin",
+)
+```
+
+它会完成：
+
+- 构建 routing groups
+- 分配神经元和 SRAM
+- 求解路由
+- 生成三类帧并导出到磁盘
+- 生成 `proto/config.pb`
+- 在 `debug=True` 时生成 `proto/config.json`
+
+### 9.1 参数说明
+
+- `output_path`
+  - 导出目录
+  - 如果不传，则优先取环境变量 `PAIBOX_OUTPUT_PATH`
+  - 若环境变量也没有，则默认写到当前目录下的 `./output`
+- `literal_format`
+  - 只影响 `.h` 文件中的 32 位字面量格式
+  - 可选 `"bin"` 或 `"hex"`
+  - 不影响 `.txt`、`.npy`、`.pb` 或 `.json`
+- `target_platform`
+  - `"x86"`、`"riscv"` 或 `"all"`
+  - `"x86"` 导出 `cfg_frame*.npy`
+  - `"riscv"` 导出 `cfg_frame*.h`
+  - `"all"` 同时导出两套平台相关产物
+- `word_order`
+  - 控制 `proto/config.pb` 与 `proto/config.json` 中 `config_frames.words` 的 32 位拆分顺序
+  - 可选 `"high_first"` 或 `"low_first"`
+- `export_merged_frames`
+  - 是否同时导出不同类型帧合并后的文件
+- `debug`
+  - 是否保留供人工查看的 `.txt` 与 `proto/config.json`
+  - 当 `debug=True` 时，会同时导出 x86 与 riscv 两套平台相关产物
+- `export_proto_python`
+  - 仅在 `target_platform="x86"` 时生效
+  - 控制是否把 `compile_artifacts_pb2.py` / `compile_artifacts_pb2.pyi` 复制到导出目录的 `proto/`
+
+### 9.2 默认导出文件
+
+后端当前会导出三类产物：
+
+- 人类可读调试文件（`debug=True` 时）
+  - `cfg_frame1.txt`
+  - `cfg_frame2.txt`
+  - `cfg_frame3.txt`
+  - `cfg_frames.txt`（不同类型帧合并）
+- 平台相关帧文件
+  - `target_platform="x86"`：
+    - `cfg_frame1.npy`
+    - `cfg_frame2.npy`
+    - `cfg_frame3.npy`
+    - `cfg_frames.npy`（不同类型帧合并，取决于 `export_merged_frames`）
+  - `target_platform="riscv"`：
+    - `cfg_frame1.h`
+    - `cfg_frame2.h`
+    - `cfg_frame3.h`
+    - `cfg_frames.h`（不同类型帧合并，取决于 `export_merged_frames`）
+- protobuf 产物（固定放在 `proto/` 子目录）
+  - `proto/config.pb`
+  - `proto/config.json`（`debug=True` 时）
+  - `proto/compile_artifacts.proto`
+  - `proto/compile_artifacts_pb2.py`（仅 x86 且 `export_proto_python=True`）
+  - `proto/compile_artifacts_pb2.pyi`（仅 x86 且 `export_proto_python=True`）
+
+### 9.3 三类帧的大致分工
+
+- `cfg_frame1`
+  - 核配置帧
+- `cfg_frame2`
+  - LUT 配置帧
+- `cfg_frame3`
+  - 神经元参数、权重等 SRAM 相关配置帧
+
+### 9.4 `.txt`、`.npy`、`.h` 和 `proto/` 的区别
+
+`cfg_frame*.txt`：
+
+- 每行一个 64 位帧
+- 按核坐标分段
+- 更适合检查、比对和调试
+
+`cfg_frame*.npy`：
+
+- 仅在 `target_platform="x86"` 时导出
+- 适合 Python / NumPy 侧直接加载和进一步处理
+
+`cfg_frame*.h`：
+
+- 仅在 `target_platform="riscv"` 时导出
+- 每个 64 位帧拆成两个 32 位元素
+- 可直接接入 C / C++ 板端工程
+
+`proto/config.pb` / `proto/config.json`：
+
+- 包含 I/O 映射与展平后的配置帧数据
+- `config.pb` 适合程序消费
+- `config.json` 适合开发人员人工查看
+- `config_frames.word_order` 明确描述了 64 位配置帧拆成 32 位 words 时的顺序
+
+## 10. `cfg_frame1.txt` 里的 `IO_LAYOUT_INFO`
+
+当前 `backendv2` 会在 `cfg_frame1.txt` 末尾自动追加一段注释化 JSON：
+
+```text
+# === IO_LAYOUT_INFO_BEGIN ===
+# { ... }
+# === IO_LAYOUT_INFO_END ===
+```
+
+它的作用是描述：
+
+- 输入组名
+- 对应的 `InputNode`
+- 输入元素下标和 copy 信息
+- 路由后的目标坐标偏移
+- `target_lcn_ex`
+- `tick_relative`
+- `addr_axon`
+- 完整的 `axon_bit_count`
+
+当前 `tests/app/script/generate_work_frame1.py` 就是基于这段元数据生成输入工作帧。
+
+## 11. 如何生成 `work_frame1.h`
+
+只有在你的板端流程真的需要“输入工作帧”时，才需要这一步。
+
+### 11.1 对图像输入，直接使用通用脚本
+
+```bash
+uv run python tests/app/script/generate_work_frame1.py \
+  --image tests/app/quant_img_mnist/0.bmp \
+  --frame-layout build/my_model/output/cfg_frame1.txt \
+  --target-h 28 \
+  --target-w 28 \
+  --output build/my_model/output/work_frame1.h
+```
+
+### 11.2 对一般数组输入，直接调用库函数
+
+如果你的输入不是图像，而是已经量化好的 `uint8` / `int8` 数组，更通用的方式是：
+
+```python
+from pathlib import Path
+
+import numpy as np
+
+from tests.app.script.generate_work_frame1 import (
+    encode_input_array_to_work_frames,
+    work_frames_to_header,
+)
+
+
+frame_layout = Path("build/my_model/output/cfg_frame1.txt")
+output_header = Path("build/my_model/output/work_frame1.h")
+
+# x_q 的顺序必须与 InputNode 的逻辑输入顺序一致
+x_q = np.asarray(..., dtype=np.int8)
+
+# 当前 work frame 携带的是 8-bit 原始码字；
+# 若输入是有符号 int8，建议以 two's complement 的 uint8 视图送入。
+frames = encode_input_array_to_work_frames(
+    x_q.view(np.uint8),
+    frame_layout,
+)
+work_frames_to_header(frames, output_header, array_name="work_frame1")
+```
+
+### 11.3 多输入模型
+
+如果 `cfg_frame1.txt` 里包含多个输入组：
+
+- CLI 方式用 `--input-group`
+- Python 调用传 `input_group=...`
+
+否则脚本会因为无法自动判定输入组而报错。
+
+## 12. 推荐的一般化部署流程
+
+对于“量化后网络模型”的通用部署，推荐按下面的顺序做：
+
+1. 完成量化，并拿到部署所需的整数参数  
+   例如输入 scale、每层权重、偏置、输出 scale、requant/LUT 规则。
+2. 重建一个“部署态 PyTorch 模型”  
+   保持当前 lowering 可识别的模块表面，不直接依赖原始量化执行图。
+3. 用 `compile_to_paiir(..., strict=True)` 编译  
+   同时保存 `graph.summary()`。
+4. 用 `Mapper.compile(...)` 导出平台相关帧文件与 `proto/` 目录  
+   同时保存 `backendv2.log` 与 `proto/config.pb`。
+5. 如果板端需要输入工作帧，再从 `cfg_frame1.txt` 生成 `work_frame1.h`
+6. 向板端交付至少这几类文件
+   - 平台相关帧文件（`cfg_frame*.h` 或 `cfg_frame*.npy`）
+   - `proto/config.pb`
+   - 如需人工检查，再附带 `proto/config.json`
+   - `paiir_summary.log`
+   - `backendv2.log`
+
+## 13. 已验证参考样例
+
+这份文档不以单个应用为中心，但当前仓库里已经有一个经过验证的参考路径：
+
+- [tests/app/model_zhr2/deploy_runtime_1d.py](/home/kafcoppelia/WORK/PAIBox_Workgroup/PAIBox/tests/app/model_zhr2/deploy_runtime_1d.py)
+- [tests/app/model_zhr2/generate_work_frame1_1d.py](/home/kafcoppelia/WORK/PAIBox_Workgroup/PAIBox/tests/app/model_zhr2/generate_work_frame1_1d.py)
+
+这条参考路径展示了一种当前可行的通用模式：
+
+- 从量化 checkpoint 中提取 `int_repr()` 权重
+- 把 bias 转成芯片友好的 `int32`
+- 把 requant 保留为精确 LUT
+- 重建成 lowering 可识别的部署态 `nn.Module`
+- 再进入 `compile_to_paiir(...) -> Mapper.compile(...)`
+
+在当前 `dev` 分支上，下面这个参考命令已经跑通：
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache uv run python tests/app/model_zhr2/deploy_runtime_1d.py --backend
+```
+
+其结果包括：
+
+- `backend_succeeded: True`
+- 成功导出平台相关帧文件和 `proto/` 目录
+- 输出 shape 为 `((1, 128, 32),)`
+
+对应的输入工作帧参考命令也已跑通：
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache uv run python tests/app/model_zhr2/generate_work_frame1_1d.py
+```
+
+## 14. 常见排障建议
+
+### 14.1 `UnsupportedOpError`
+
+优先顺序通常是：
+
+1. 改模型表面，回到 lowering 已支持的模块
+2. 用 `register_module(...)` 把自定义计算模块转换成 supported canonical module
+3. 用 `register_neuron(...)` 注册自定义 neuron / 激活模块
+4. 只在排查阶段使用 `strict=False`
+
+### 14.2 前端编译成功，但后端没有产物
+
+这通常意味着：
+
+- 前端 `compile_to_paiir(...)` 成功了
+- 但 `Mapper.compile(...)` 在路由、容量或导出阶段失败了
+
+此时要先看：
+
+- `backendv2.log`
+- `routing_groups` 数量
+- `output_path` 下是否真的写出了平台相关帧文件
+- `output_path/proto/config.pb`
+- `output_path/proto/config.json`（若 `debug=True`）
+
+### 14.3 `work_frame1.h` 生成失败
+
+优先检查：
+
+- `cfg_frame1.txt` 是否包含 `IO_LAYOUT_INFO_BEGIN/END`
+- 输入数组长度和布局是否与 `InputNode` 契约一致
+- 多输入模型是否正确指定了 `input_group`
+
+### 14.4 不要混淆“硬件支持”和“当前 lowering 直接支持”
+
+`docs/Support-Ops.md` 更接近硬件能力说明。
+
+真正决定你这次能否直接 `compile_to_paiir(...)` 成功的，是当前 `paibox.paiir.lowering.converter` 和后续编译/融合链路支持到什么程度。
+
+## 15. 一句话总结
+
+如果你希望“量化后模型能够通过这份手册完成编译部署”，当前最稳妥的通用方法不是把原始量化执行图直接丢给前端，而是：
+
+- 先把量化结果整理成 lowering 能理解的部署态 PyTorch 模型
+- 再走 `compile_to_paiir(...) -> Mapper.compile(...) -> 平台相关帧文件 + proto/`
+- 如有需要，再利用 `cfg_frame1.txt` 的 `IO_LAYOUT_INFO` 生成 `work_frame1.h`

--- a/paibox/backendv2/frame_cheader.py
+++ b/paibox/backendv2/frame_cheader.py
@@ -4,24 +4,32 @@ Each frame array is emitted as a volatile unsigned int array in the
 ``.large_const_data`` section, callable from C firmware on the chip.
 """
 
-import string
+from pathlib import Path
 from typing import TextIO
 
-C_ARRAY_DECL = string.Template(
-    'volatile uint32_t $name[] __attribute__((section("$section"))) ={\n'
-)
 C_ARRAY_CLOSE = "};\n"
 
 
+def _normalize_guard_name(file: TextIO) -> str:
+    name = getattr(file, "name", "FRAME_HEADER")
+    stem = Path(name).name.upper()
+    chars = [ch if ch.isalnum() else "_" for ch in stem]
+    return f"_{''.join(chars).removesuffix('_H')}_H"
+
+
 def write_c_array_decl(
-    file: TextIO,
-    name: str,
-    section: str = ".large_const_data",
+    file: TextIO, name: str, section: str = ".large_const_data"
 ) -> None:
-    """Write the opening line of a C array declaration."""
-    file.write(C_ARRAY_DECL.substitute(name=name, section=section))
+    """Write the header prologue and opening line of a C array declaration."""
+    guard = _normalize_guard_name(file)
+    file.write(f"#ifndef {guard}\n#define {guard}\n\n#include <stdint.h>\n\n")
+    file.write(
+        f'volatile uint32_t {name}[] __attribute__((section("{section}"))) ={{\n'
+    )
 
 
 def write_c_array_close(file: TextIO) -> None:
-    """Write the closing brace of a C array."""
+    """Write the closing brace of a C array and the header epilogue."""
+    guard = _normalize_guard_name(file)
     file.write(C_ARRAY_CLOSE)
+    file.write(f"#endif /* {guard} */\n")

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -293,7 +293,9 @@ class Mapper:
         frame_path = out / "cfg_frames.txt"
         with frame_path.open("w") as frame_file:
             for cp, frames in self._iter_frame_triplets():
-                frame_file.write(f"# Core at coord (X,Y)=({cp.coord.x},{cp.coord.y}):\n")
+                frame_file.write(
+                    f"# Core at coord (X,Y)=({cp.coord.x},{cp.coord.y}):\n"
+                )
                 _for_each_frame_type(
                     frames,
                     lambda idx, frame_array: (
@@ -458,12 +460,22 @@ class Mapper:
                 frames,
                 lambda idx, frame_array: (
                     typed_parts[idx - 1].append(frame_array),
-                    typed_counts.__setitem__(idx - 1, typed_counts[idx - 1] + len(frame_array)),
-                    merged_parts.append(frame_array) if merged_parts is not None else None,
+                    typed_counts.__setitem__(
+                        idx - 1, typed_counts[idx - 1] + len(frame_array)
+                    ),
+                    (
+                        merged_parts.append(frame_array)
+                        if merged_parts is not None
+                        else None
+                    ),
                 ),
             )
             if merged_parts is not None:
-                merged_count += sum(len(frame_array) for frame_array in frames if frame_array is not None)
+                merged_count += sum(
+                    len(frame_array)
+                    for frame_array in frames
+                    if frame_array is not None
+                )
 
         for idx, parts in enumerate(typed_parts, start=1):
             if parts:

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -33,9 +33,9 @@ from .routing import (
     toposort_for_rg,
 )
 
-SuffixType = Literal["bin", "hex"]
+LiteralFormat = Literal["bin", "hex"]
 WordOrder = Literal["high_first", "low_first"]
-TargetPlatform = Literal["x86", "riscv"]
+TargetPlatform = Literal["x86", "riscv", "all"]
 
 
 def export_single_framearray(
@@ -53,16 +53,16 @@ def export_framearray_to_bit(
     frame_array: FrameArrayType,
     file: TextIO,
     prefix: str = "",
-    suffix: SuffixType = "bin",
+    literal_format: LiteralFormat = "bin",
 ) -> None:
-    if suffix == "bin":
+    if literal_format == "bin":
         h_fmt = "0b{:032b}"
         l_fmt = "0b{:032b}"
-    elif suffix == "hex":
+    elif literal_format == "hex":
         h_fmt = "0x{:08X}"
         l_fmt = "0x{:08X}"
     else:
-        raise ValueError("suffix must be 'bin' or 'hex'")
+        raise ValueError("literal_format must be 'bin' or 'hex'")
 
     lines = [
         f"{prefix}{h_fmt.format((f >> 32) & 0xFFFFFFFF)},{l_fmt.format(f & 0xFFFFFFFF)},"
@@ -89,6 +89,37 @@ def export_framearray_to_int32(
     return result
 
 
+def _for_each_frame_type(
+    frames: tuple[FrameArrayType, FrameArrayType | None, FrameArrayType | None],
+    callback,
+) -> None:
+    for idx, frame_array in enumerate(frames, start=1):
+        if frame_array is not None:
+            callback(idx, frame_array)
+
+
+def _resolve_platform_exports(
+    target_platform: TargetPlatform, debug: bool
+) -> tuple[bool, bool]:
+    if target_platform == "x86":
+        export_x86 = True
+        export_riscv = False
+    elif target_platform == "riscv":
+        export_x86 = False
+        export_riscv = True
+    elif target_platform == "all":
+        export_x86 = True
+        export_riscv = True
+    else:
+        raise ValueError("target_platform must be 'x86', 'riscv', or 'all'")
+
+    if debug:
+        export_x86 = True
+        export_riscv = True
+
+    return export_x86, export_riscv
+
+
 class Mapper:
     def __init__(self) -> None:
         self.groups: list[RoutingGroup | RemapGroup] = []
@@ -99,9 +130,9 @@ class Mapper:
         self.coreplacements: list[CorePlacement] = []
         self.global_starts: dict[int, CoordZXYOffset] = {}
 
-    def _iter_core_frames(self):
+    def _iter_frame_triplets(self):
         for cp in self.coreplacements:
-            yield cp.to_frame()
+            yield cp, cp.to_frame()
 
     def generate_routing_groups(self, pai_graph: PAIIRGraph) -> None:
         self.nodes = build_nodes(pai_graph)
@@ -213,93 +244,101 @@ class Mapper:
             rg.set_auto_core_config()
 
     def export_cheader_file(
-        self, output_path: str | Path, suffix: SuffixType = "bin"
+        self, output_path: str | Path, literal_format: LiteralFormat = "bin"
     ) -> None:
+        """Export per-type config frames as C header arrays."""
         out = Path(output_path)
         out.mkdir(parents=True, exist_ok=True)
         paths = [
-            (out / "frame_type1.h", "config_frame1"),
-            (out / "frame_type2.h", "config_frame2"),
-            (out / "frame_type3.h", "config_frame3"),
+            (out / "cfg_frame1.h", "config_frame1"),
+            (out / "cfg_frame2.h", "config_frame2"),
+            (out / "cfg_frame3.h", "config_frame3"),
         ]
         with ExitStack() as stack:
             files = [stack.enter_context(p.open("w")) for p, _ in paths]
             for f, (_, name) in zip(files, paths):
                 write_c_array_decl(f, name)
-            for f1, f2, f3 in self._iter_core_frames():
-                export_framearray_to_bit(f1, files[0], "\t", suffix)
-                if f2 is not None:
-                    export_framearray_to_bit(f2, files[1], "\t", suffix)
-                if f3 is not None:
-                    export_framearray_to_bit(f3, files[2], "\t", suffix)
+            for _, frames in self._iter_frame_triplets():
+                _for_each_frame_type(
+                    frames,
+                    lambda idx, frame_array: export_framearray_to_bit(
+                        frame_array, files[idx - 1], "\t", literal_format
+                    ),
+                )
             for f in files:
                 write_c_array_close(f)
 
     def export_cheader_merge(
-        self, output_path: str | Path, suffix: SuffixType = "bin"
+        self, output_path: str | Path, literal_format: LiteralFormat = "bin"
     ) -> None:
+        """Export all config frame types into one merged C header array."""
         out = Path(output_path)
         out.mkdir(parents=True, exist_ok=True)
-        frame_path = out / "frame_type.h"
+        frame_path = out / "cfg_frames.h"
         with frame_path.open("w") as frame_file:
             write_c_array_decl(frame_file, "config_frame")
-            for f1, f2, f3 in self._iter_core_frames():
-                export_framearray_to_bit(f1, frame_file, "\t", suffix)
-                if f2 is not None:
-                    export_framearray_to_bit(f2, frame_file, "\t", suffix)
-                if f3 is not None:
-                    export_framearray_to_bit(f3, frame_file, "\t", suffix)
+            for _, frames in self._iter_frame_triplets():
+                _for_each_frame_type(
+                    frames,
+                    lambda _, frame_array: export_framearray_to_bit(
+                        frame_array, frame_file, "\t", literal_format
+                    ),
+                )
             write_c_array_close(frame_file)
 
     def export_merge(self, output_path: str | Path) -> None:
+        """Export all config frame types into one human-readable text file."""
         out = Path(output_path)
         out.mkdir(parents=True, exist_ok=True)
-        frame_path = out / "frame_type.txt"
+        frame_path = out / "cfg_frames.txt"
         with frame_path.open("w") as frame_file:
-            for cp, (f1, f2, f3) in zip(self.coreplacements, self._iter_core_frames()):
-                frame_file.write(f"# Core at coord ({cp.coord.x}, {cp.coord.y}):\n")
-                frame_file.write("\ttype1:\n")
-                export_single_framearray(f1, frame_file, prefix="\t\t0x")
-                frame_file.write("\ttype2:\n")
-                if f2 is not None:
-                    export_single_framearray(f2, frame_file, prefix="\t\t0x")
-                frame_file.write("\ttype3:\n")
-                if f3 is not None:
-                    export_single_framearray(f3, frame_file, prefix="\t\t0x")
+            for cp, frames in self._iter_frame_triplets():
+                frame_file.write(f"# Core at coord (X,Y)=({cp.coord.x},{cp.coord.y}):\n")
+                _for_each_frame_type(
+                    frames,
+                    lambda idx, frame_array: (
+                        frame_file.write(f"\ttype{idx}:\n"),
+                        export_single_framearray(
+                            frame_array, frame_file, prefix="\t\t0x"
+                        ),
+                    ),
+                )
 
-    def export(self, output_path: str | Path) -> None:
+    def export_txt(self, output_path: str | Path) -> None:
+        """Export per-type config frames as human-readable text files."""
         out = Path(output_path)
         out.mkdir(parents=True, exist_ok=True)
-        frame1_path = out / "frame_type1.txt"
-        frame2_path = out / "frame_type2.txt"
-        frame3_path = out / "frame_type3.txt"
+        frame1_path = out / "cfg_frame1.txt"
+        frame2_path = out / "cfg_frame2.txt"
+        frame3_path = out / "cfg_frame3.txt"
         with (
             frame1_path.open("w") as frame1_file,
             frame2_path.open("w") as frame2_file,
             frame3_path.open("w") as frame3_file,
         ):
-            for cp, (f1, f2, f3) in zip(self.coreplacements, self._iter_core_frames()):
-                coord_line = f"# Core at coord ({cp.coord.x}, {cp.coord.y}):\n"
+            files = [frame1_file, frame2_file, frame3_file]
+            for cp, frames in self._iter_frame_triplets():
+                coord_line = f"# Core at coord (X,Y)=({cp.coord.x},{cp.coord.y}):\n"
                 frame1_file.write(coord_line)
                 frame2_file.write(coord_line)
                 frame3_file.write(coord_line)
-
-                export_single_framearray(f1, frame1_file, prefix="\t0x")
-                if f2 is not None:
-                    export_single_framearray(f2, frame2_file, prefix="\t0x")
-                if f3 is not None:
-                    export_single_framearray(f3, frame3_file, prefix="\t0x")
+                _for_each_frame_type(
+                    frames,
+                    lambda idx, frame_array: export_single_framearray(
+                        frame_array, files[idx - 1], prefix="\t0x"
+                    ),
+                )
 
     def export_proto(
         self,
         output_path: str | Path,
         target_platform: TargetPlatform = "riscv",
-        export_python: bool = True,
-        debug: bool = True,
         word_order: WordOrder = "high_first",
+        export_python: bool = True,
+        debug: bool = False,
     ) -> Path:
-        if target_platform not in ("x86", "riscv"):
-            raise ValueError("target_platform must be 'x86' or 'riscv'")
+        """Export protobuf artifacts for config frames and I/O mappings."""
+        export_x86, _ = _resolve_platform_exports(target_platform, debug)
 
         proto_dir = Path(__file__).parent / "proto"
         proto_out_dir = Path(output_path) / "proto"
@@ -309,7 +348,7 @@ class Mapper:
         pb_text_path = proto_out_dir / "config.json"
 
         proto_files = ["compile_artifacts.proto"]
-        if export_python and target_platform == "x86":
+        if export_python and export_x86:
             proto_files.extend(
                 ["compile_artifacts_pb2.py", "compile_artifacts_pb2.pyi"]
             )
@@ -380,18 +419,15 @@ class Mapper:
                     output_entry.bit_width = elem.output_bit_num
                     output_entry.axon_bit_idx = axon_bit_idx
 
-        for f1, f2, f3 in self._iter_core_frames():
-            artifacts.config_frames.words.extend(
-                export_framearray_to_int32(f1, word_order)
+        config_words: list[int] = []
+        for _, frames in self._iter_frame_triplets():
+            _for_each_frame_type(
+                frames,
+                lambda _, frame_array: config_words.extend(
+                    export_framearray_to_int32(frame_array, word_order)
+                ),
             )
-            if f2 is not None:
-                artifacts.config_frames.words.extend(
-                    export_framearray_to_int32(f2, word_order)
-                )
-            if f3 is not None:
-                artifacts.config_frames.words.extend(
-                    export_framearray_to_int32(f3, word_order)
-                )
+        artifacts.config_frames.words.extend(config_words)
 
         artifacts.config_frames.word_order = (
             ConfigFrames.HIGH_FIRST
@@ -407,77 +443,119 @@ class Mapper:
 
         return pb_path
 
-    def export_frame_numpy(
+    def export_frame_npy(
         self, output_path: str | Path, export_merged_frames: bool = True
     ) -> None:
+        """Export frame arrays as explicit little-endian uint64 NumPy files."""
         out = Path(output_path)
         out.mkdir(parents=True, exist_ok=True)
         typed_parts: list[list[FrameArrayType]] = [[], [], []]
-        merged_parts: list[FrameArrayType] = []
-        for f1, f2, f3 in self._iter_core_frames():
-            typed_parts[0].append(f1)
-            merged_parts.append(f1)
-            if f2 is not None:
-                typed_parts[1].append(f2)
-                merged_parts.append(f2)
-            if f3 is not None:
-                typed_parts[2].append(f3)
-                merged_parts.append(f3)
+        typed_counts = [0, 0, 0]
+        merged_parts: list[FrameArrayType] | None = [] if export_merged_frames else None
+        merged_count = 0
+        for _, frames in self._iter_frame_triplets():
+            _for_each_frame_type(
+                frames,
+                lambda idx, frame_array: (
+                    typed_parts[idx - 1].append(frame_array),
+                    typed_counts.__setitem__(idx - 1, typed_counts[idx - 1] + len(frame_array)),
+                    merged_parts.append(frame_array) if merged_parts is not None else None,
+                ),
+            )
+            if merged_parts is not None:
+                merged_count += sum(len(frame_array) for frame_array in frames if frame_array is not None)
 
         for idx, parts in enumerate(typed_parts, start=1):
             if parts:
-                np.save(out / f"frame_type{idx}.npy", np.concatenate(parts, axis=0))
+                frame_array = np.zeros(typed_counts[idx - 1], dtype="<u8")
+                cursor = 0
+                for part in parts:
+                    n = len(part)
+                    frame_array[cursor : cursor + n] = part
+                    cursor += n
+                np.save(out / f"cfg_frame{idx}.npy", frame_array)
 
-        if export_merged_frames and merged_parts:
-            np.save(out / "frames.npy", np.concatenate(merged_parts, axis=0))
+        if merged_parts:
+            frame_array = np.zeros(merged_count, dtype="<u8")
+            cursor = 0
+            for part in merged_parts:
+                n = len(part)
+                frame_array[cursor : cursor + n] = part
+                cursor += n
+            np.save(out / "cfg_frames.npy", frame_array)
 
     def export_artifacts(
         self,
         output_path: str | Path,
-        suffix: SuffixType = "bin",
+        literal_format: LiteralFormat = "bin",
         target_platform: TargetPlatform = "riscv",
         word_order: WordOrder = "high_first",
         export_merged_frames: bool = True,
-        debug: bool = True,
         export_proto_python: bool = True,
+        debug: bool = False,
     ) -> None:
+        """Export all requested backend artifacts to the output directory."""
         out = Path(output_path)
         out.mkdir(parents=True, exist_ok=True)
+        export_x86, export_riscv = _resolve_platform_exports(target_platform, debug)
 
         if debug:
-            self.export(out)
+            self.export_txt(out)
             if export_merged_frames:
                 self.export_merge(out)
 
-        if target_platform == "x86":
-            self.export_frame_numpy(out, export_merged_frames)
-        elif target_platform == "riscv":
-            self.export_cheader_file(out, suffix)
-            if export_merged_frames:
-                self.export_cheader_merge(out, suffix)
-        else:
-            raise ValueError("target_platform must be 'x86' or 'riscv'")
+        if export_x86:
+            self.export_frame_npy(out, export_merged_frames)
 
-        self.export_proto(
-            out,
-            target_platform,
-            export_python=export_proto_python,
-            debug=debug,
-            word_order=word_order,
-        )
+        if export_riscv:
+            self.export_cheader_file(out, literal_format)
+            if export_merged_frames:
+                self.export_cheader_merge(out, literal_format)
+
+        self.export_proto(out, target_platform, word_order, export_proto_python, debug)
 
     def compile(
         self,
         pai_graph: PAIIRGraph,
         output_path: str | Path | None = None,
-        suffix: SuffixType = "bin",
+        literal_format: LiteralFormat = "bin",
         *,
-        target_platform: TargetPlatform = "riscv",
+        target_platform: TargetPlatform = "all",
         word_order: WordOrder = "high_first",
         export_merged_frames: bool = True,
-        debug: bool = True,
         export_proto_python: bool = True,
+        debug: bool = False,
     ) -> None:
+        """Compile a PAIIR graph and export backendv2 deployment artifacts.
+
+        Args:
+            pai_graph: The compiled PAIIR graph to place, route, and export.
+            output_path: Root directory for exported artifacts. When ``None``,
+                ``$PAIBOX_OUTPUT_PATH/frame_out`` is used if the environment
+                variable is set; otherwise defaults to ``./output`` under the
+                current working directory.
+            literal_format: Numeric radix used by generated C headers. ``"bin"``
+                writes 32-bit words as binary literals, while ``"hex"``
+                writes hexadecimal literals.
+            target_platform: Platform-specific artifact set to emit.
+                ``"x86"`` exports ``.npy`` frame arrays, ``"riscv"`` exports
+                C headers, and ``"all"`` exports both. When ``debug=True``,
+                platform-specific exports are always emitted for both targets.
+            word_order: Order used when splitting each 64-bit config frame
+                into 32-bit words for protobuf export. This affects
+                ``proto/config.pb`` and ``proto/config.json`` only; it does not
+                change the logical 64-bit frame sequence.
+            export_merged_frames: Whether to also emit merged frame artifacts
+                that concatenate frame types 1, 2, and 3 into one file per
+                platform or debug view.
+            debug: Whether to emit human-readable debug artifacts such as
+                ``cfg_frame*.txt``, merged text frames, and ``proto/config.json``.
+                When enabled, x86 and riscv platform artifacts are both
+                exported regardless of ``target_platform``.
+            export_proto_python: Whether to copy ``compile_artifacts_pb2.py``
+                and ``compile_artifacts_pb2.pyi`` into the exported ``proto/``
+                directory when x86 artifacts are part of the export set.
+        """
         # determine raw_neus in routing groups, other properties remain unset
         self.generate_routing_groups(pai_graph)
 
@@ -561,10 +639,10 @@ class Mapper:
 
         self.export_artifacts(
             output_path,
-            suffix,
+            literal_format,
             target_platform,
             word_order,
             export_merged_frames,
-            debug,
             export_proto_python,
+            debug,
         )

--- a/paibox/backendv2/proto/README.md
+++ b/paibox/backendv2/proto/README.md
@@ -122,7 +122,7 @@ def iter_config_frame_u64(config_frames: ConfigFrames):
         yield (int(high32) << 32) | int(low32)
 ```
 
-如果应用侧已经使用 `frame_type*.h` 或 `frames.npy` 下发配置帧，通常不需要再从 `config.pb` 还原配置帧。
+如果应用侧已经使用 `cfg_frame*.h` 或 `cfg_frames.npy` 下发配置帧，通常不需要再从 `config.pb` 还原配置帧。
 
 ## 5. I/O 映射
 

--- a/tests/backendv2/test_mapper.py
+++ b/tests/backendv2/test_mapper.py
@@ -2,6 +2,7 @@ import json
 import shutil
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from paibox.backendv2.mapper import Mapper
@@ -22,9 +23,41 @@ def _export_simple_cnn_proto(export_root: Path, word_order: str) -> Path:
 
     graph = compile_to_paiir(SimpleCNN().eval(), make_img_3ch_8x8(), strict=True)
     mapper = Mapper()
-    mapper.compile(graph, export_dir, target_platform="x86", word_order=word_order)  # type: ignore[arg-type]
+    mapper.compile(
+        graph,
+        export_dir,
+        target_platform="x86",  # type: ignore[arg-type]
+        word_order=word_order,
+        debug=True,
+    )
 
     return export_dir / "proto"
+
+
+def _export_simple_cnn(
+    export_root: Path,
+    case_name: str,
+    *,
+    target_platform: str,
+    debug: bool,
+    export_merged_frames: bool = True,
+) -> Path:
+    export_dir = export_root / case_name
+    if export_dir.exists():
+        shutil.rmtree(export_dir)
+    export_dir.mkdir(parents=True, exist_ok=True)
+
+    graph = compile_to_paiir(SimpleCNN().eval(), make_img_3ch_8x8(), strict=True)
+    mapper = Mapper()
+    mapper.compile(
+        graph,
+        export_dir,
+        target_platform=target_platform,  # type: ignore[arg-type]
+        debug=debug,
+        export_merged_frames=export_merged_frames,
+    )
+
+    return export_dir
 
 
 @pytest.fixture(scope="module")
@@ -74,3 +107,59 @@ def test_export_proto_real_workflow_keeps_pb_and_json(
     assert payload["configFrames"]["wordOrder"] == expected_json_value
     assert len(payload["configFrames"]["words"]) > 0
     assert len(payload["ioMapping"]["threads"]) == 1
+
+
+def test_export_artifacts_all_platforms_when_requested(ensure_backendv2_debug_dir):
+    export_dir = _export_simple_cnn(
+        ensure_backendv2_debug_dir,
+        "all_platforms",
+        target_platform="all",
+        debug=False,
+    )
+
+    assert (export_dir / "cfg_frame1.npy").exists()
+    assert (export_dir / "cfg_frame2.npy").exists()
+    assert (export_dir / "cfg_frame3.npy").exists()
+    assert (export_dir / "cfg_frames.npy").exists()
+
+    assert (export_dir / "cfg_frame1.h").exists()
+    assert (export_dir / "cfg_frame2.h").exists()
+    assert (export_dir / "cfg_frame3.h").exists()
+    assert (export_dir / "cfg_frames.h").exists()
+
+    assert not (export_dir / "cfg_frame1.txt").exists()
+    assert not (export_dir / "proto" / "config.json").exists()
+
+    cfg_frame1 = np.load(export_dir / "cfg_frame1.npy")
+    assert cfg_frame1.dtype == np.dtype("<u8")
+
+
+def test_export_artifacts_debug_forces_all_platform_outputs(
+    ensure_backendv2_debug_dir,
+):
+    export_dir = _export_simple_cnn(
+        ensure_backendv2_debug_dir,
+        "debug_forces_all",
+        target_platform="riscv",
+        debug=True,
+    )
+
+    assert (export_dir / "cfg_frame1.txt").exists()
+    assert (export_dir / "cfg_frame2.txt").exists()
+    assert (export_dir / "cfg_frame3.txt").exists()
+    assert (export_dir / "cfg_frames.txt").exists()
+
+    assert (export_dir / "cfg_frame1.npy").exists()
+    assert (export_dir / "cfg_frame2.npy").exists()
+    assert (export_dir / "cfg_frame3.npy").exists()
+    assert (export_dir / "cfg_frames.npy").exists()
+
+    assert (export_dir / "cfg_frame1.h").exists()
+    assert (export_dir / "cfg_frame2.h").exists()
+    assert (export_dir / "cfg_frame3.h").exists()
+    assert (export_dir / "cfg_frames.h").exists()
+
+    assert (export_dir / "proto" / "config.pb").exists()
+    assert (export_dir / "proto" / "config.json").exists()
+    assert (export_dir / "proto" / "compile_artifacts_pb2.py").exists()
+    assert (export_dir / "proto" / "compile_artifacts_pb2.pyi").exists()


### PR DESCRIPTION
## Summary
- rename backendv2 frame artifacts to the explicit `cfg_frame*` / `cfg_frames*` contract across text, header, and NumPy exports
- tighten `Mapper.compile(...)` export behavior, including `target_platform="all"`, `debug=True` full-platform fan-out, explicit little-endian `.npy` output, and cleaner export helper structure
- update the backendv2 proto manual, quickstart, and work-frame helper defaults to match the new artifact interface