### PR TITLE
Feat(paiir): support SpikingJelly layers & adaptive maxpool

### DIFF
--- a/docs/paiir_backend_guide.md
+++ b/docs/paiir_backend_guide.md
@@ -50,11 +50,11 @@ paibox.paiir/
 
 ## 前端 lowering 扩展点
 
-PAIIR 前端默认支持标准 PyTorch 模块和少量 canonical function-form 算子。自定义模块不要依赖 lowering 猜测字段名或量化表达式，应显式注册到受支持的 canonical 模块或神经元。
+PAIIR 前端默认支持标准 PyTorch 模块、少量 canonical function-form 算子，以及当前白名单内的 `spikingjelly.activation_based.layer.X` wrapper。自定义模块不要依赖 lowering 猜测字段名或量化表达式，应显式注册到受支持的 canonical 模块或神经元。
 
 ### 自定义计算模块
 
-`register_module(...)` 用于把用户自定义 `nn.Module` 转换为 PAIIR 已支持的 canonical `nn.Module`，例如 `nn.Conv1d`、`nn.Conv2d`、`nn.Linear`、pooling 模块、标准激活模块或 PAIIR 神经元/LUT 模块。
+`register_module(...)` 用于把用户自定义 `nn.Module` 转换为 PAIIR 已支持的 canonical `nn.Module`，例如 `nn.Conv1d`、`nn.Conv2d`、`nn.Linear`、pooling 模块（含 `nn.AdaptiveMaxPool1d/2d`）、标准激活模块或 PAIIR 神经元/LUT 模块。
 
 ```python
 from torch import nn
@@ -81,6 +81,8 @@ register_module(MyQuantConv, to_canonical_conv)
 ```
 
 注册函数返回的模块必须已经是当前 PAIIR lowering 支持的模块；返回 bypass 模块或未知模块会报错。重复注册同一模块类型也会报错，避免全局 lowering 规则被静默覆盖。
+
+SpikingJelly `activation_based.layer` wrapper 是另一类前端入口。当前支持的 wrapper 包括 `layer.Conv1d/2d`、`layer.Linear`、`layer.MaxPool1d/2d`、`layer.AvgPool1d/2d`、`layer.Flatten`；这些 wrapper 会按对应普通模块路径进入 PAIIR。原生 `nn.AdaptiveMaxPool1d/2d` 支持属于 `torch.nn` 模块路径，不应描述成 `layer.AdaptiveMaxPool*` 支持。
 
 ### 自定义神经元或 LUT 激活
 
@@ -477,6 +479,7 @@ raw_weights: list[Tensor] | None = op.weights
 >
 > - Conv：由 kernel 展开为 dense matrix
 > - Pool：由 `kernel_size / stride / padding / dilation` 合成窗口连接矩阵
+> - `nn.AdaptiveMaxPool1d/2d`：由 PyTorch adaptive pooling 的输出位置到输入窗口边界合成位置相关连接矩阵
 > - `StandaloneActOp` / `PotentialAddOp`：在 `comp is None` 时按路径语义合成 signed identity matrix
 >
 > 因此，不要把 `op.weights` 直接理解为“最终部署权重矩阵”。

--- a/docs/user_quickstart.md
+++ b/docs/user_quickstart.md
@@ -59,7 +59,8 @@ from paibox.paiir import compile_to_paiir
 
 对于 ANN 量化模型，当前最稳妥的通用方式是：
 
-- 保留标准 `nn.Conv1d` / `nn.Conv2d` / `nn.Linear` / `nn.MaxPool*` / `nn.AvgPool*`
+- 保留标准 `nn.Conv1d` / `nn.Conv2d` / `nn.Linear` / `nn.MaxPool*` / `nn.AvgPool*` / `nn.AdaptiveMaxPool*`
+- 或保留当前支持的 `spikingjelly.activation_based.layer.X` wrapper，注意这和原生 `torch.nn.X` 支持面是两类入口
 - 或保留静态参数可解析的 `torch.nn.functional.conv1d/conv2d`
 - 把部署用的整数权重、偏置、scale、LUT 等信息固化到模块参数或 buffer 中
 - 把 requant / 激活整理成当前前端能识别的激活表面
@@ -141,10 +142,22 @@ uv run python -c "import torch, spikingjelly, paicorelib, numba, paibox; print('
   - `nn.MaxPool2d`
   - `nn.AvgPool1d`
   - `nn.AvgPool2d`
+  - `nn.AdaptiveMaxPool1d`
+  - `nn.AdaptiveMaxPool2d`
 - 函数式卷积
   - `torch.nn.functional.conv1d`
   - `torch.nn.functional.conv2d`
   - 要求 weight / bias 等参数能从 buffer、常量或静态 tensor 表达式中解析出来
+- SpikingJelly `activation_based.layer` wrapper
+  - `layer.Conv1d`
+  - `layer.Conv2d`
+  - `layer.Linear`
+  - `layer.MaxPool1d`
+  - `layer.MaxPool2d`
+  - `layer.AvgPool1d`
+  - `layer.AvgPool2d`
+  - `layer.Flatten`
+  - 这些 wrapper 按当前 PAIIR 支持的普通模块路径 lowering；不要把原生 `nn.AdaptiveMaxPool1d/2d` 误写成 SJ `layer.AdaptiveMaxPool*` 支持
 - 常见激活
   - `nn.ReLU`
   - `nn.Sigmoid`
@@ -169,6 +182,7 @@ uv run python -c "import torch, spikingjelly, paicorelib, numba, paibox; print('
 此外：
 
 - `nn.Dropout`、`nn.Identity` 会在 lowering 早期被擦除
+- `layer.Dropout`、`layer.Dropout2d` 也会在 lowering 早期被擦除
 - `nn.BatchNorm1d`、`nn.BatchNorm2d` 当前按 bypass 处理，不应把它们当成部署后仍需要的独立硬件语义
 
 如果模型里出现 unsupported op：

--- a/paibox/backendv2/get_weight.py
+++ b/paibox/backendv2/get_weight.py
@@ -5,11 +5,8 @@ from dataclasses import dataclass
 
 import numpy as np
 import torch
-from paicorelib import (
-    AddPotentialMode,
-    DataWidth,
-    WeightCompressType,
-)
+from numba import njit
+from paicorelib import AddPotentialMode, DataWidth, WeightCompressType
 from rich.progress import track
 from torch import Tensor, nn
 from torch.nn import functional as F
@@ -22,12 +19,7 @@ from ..paiir.ir import (
     StandaloneCompOp,
 )
 from ..paiir.nn.pool import SumPool1d, SumPool2d
-from .op_node import (
-    CoreOpNode,
-    Neuron,
-    SourceElem,
-    SourceNode,
-)
+from .op_node import CoreOpNode, Neuron, SourceElem, SourceNode
 from .weight import Weight
 
 
@@ -119,9 +111,7 @@ def direct_weight_matrix(
 
 
 def identity_weight_matrix(
-    input_shape: tuple[int, ...],
-    output_shape: tuple[int, ...],
-    sign: int,
+    input_shape: tuple[int, ...], output_shape: tuple[int, ...], sign: int
 ) -> np.ndarray:
     # Activation-only / add-only paths do not own raw parameter tensors, but
     # backend routing still needs their implicit identity connectivity.
@@ -154,13 +144,7 @@ def unfold_input_indices_2d(
     input_ids = torch.arange(1, n_input + 1, dtype=torch.float64).reshape(
         1, channels, height, width
     )
-    patches = F.unfold(
-        input_ids,
-        kernel_size=kernel_size,
-        dilation=dilation,
-        padding=padding,
-        stride=stride,
-    )
+    patches = F.unfold(input_ids, kernel_size, dilation, padding, stride)
     return patches.to(torch.int64).squeeze(0)
 
 
@@ -258,12 +242,7 @@ def pool2d_weight_matrix(
 
     patches = (
         unfold_input_indices_2d(
-            in_channels,
-            (height, width),
-            kernel_size,
-            stride,
-            padding,
-            dilation,
+            in_channels, (height, width), kernel_size, stride, padding, dilation
         )
         .cpu()
         .numpy()
@@ -339,6 +318,87 @@ def pool1d_weight_matrix(
     )
 
 
+def _adaptive_pool_window_bounds(
+    output_pos: int, input_size: int, output_size: int
+) -> tuple[int, int]:
+    if output_size <= 0:
+        raise ValueError(
+            f"Adaptive pooling output size must be positive, got {output_size}."
+        )
+    if input_size <= 0:
+        raise ValueError(
+            f"Adaptive pooling input size must be positive, got {input_size}."
+        )
+    if output_pos < 0 or output_pos >= output_size:
+        raise ValueError(
+            f"Adaptive pooling output position {output_pos} is outside [0, {output_size})."
+        )
+
+    start = output_pos * input_size // output_size
+    end = ((output_pos + 1) * input_size + output_size - 1) // output_size
+    return start, end
+
+
+def adaptive_maxpool1d_weight_matrix(
+    channels: int,
+    input_shape: tuple[int, int],
+    output_shape: tuple[int, int],
+    sign: int,
+) -> np.ndarray:
+    in_channels, in_length = input_shape
+    out_channels, out_length = output_shape
+    if in_channels != channels or out_channels != channels:
+        raise ValueError(
+            f"AdaptiveMaxPool1d channel mismatch: input={in_channels}, output={out_channels}, channels={channels}."
+        )
+
+    n_input = in_channels * in_length
+    matrix = np.zeros((out_channels * out_length, n_input), dtype=np.int16)
+
+    for channel in range(channels):
+        for out_pos in range(out_length):
+            start, end = _adaptive_pool_window_bounds(out_pos, in_length, out_length)
+            row = channel * out_length + out_pos
+            for in_pos in range(start, end):
+                col = channel * in_length + in_pos
+                matrix[row, col] = sign
+
+    return matrix
+
+
+def adaptive_maxpool2d_weight_matrix(
+    channels: int,
+    input_shape: tuple[int, int, int],
+    output_shape: tuple[int, int, int],
+    sign: int,
+) -> np.ndarray:
+    in_channels, in_height, in_width = input_shape
+    out_channels, out_height, out_width = output_shape
+    if in_channels != channels or out_channels != channels:
+        raise ValueError(
+            f"AdaptiveMaxPool2d channel mismatch: input={in_channels}, output={out_channels}, channels={channels}."
+        )
+
+    out_size = out_height * out_width
+    n_input = in_channels * in_height * in_width
+    matrix = np.zeros((out_channels * out_size, n_input), dtype=np.int16)
+
+    for channel in range(channels):
+        for out_h in range(out_height):
+            h_start, h_end = _adaptive_pool_window_bounds(out_h, in_height, out_height)
+            for out_w in range(out_width):
+                w_start, w_end = _adaptive_pool_window_bounds(
+                    out_w, in_width, out_width
+                )
+                row = channel * out_size + out_h * out_width + out_w
+                for in_h in range(h_start, h_end):
+                    for in_w in range(w_start, w_end):
+                        col = channel * in_height * in_width + in_h * in_width + in_w
+                        matrix[row, col] = sign
+
+    return matrix
+
+
 def expanded_path_weight_matrix(
     predecessor: SourceNode,
     target: CoreOpNode,
@@ -409,6 +469,26 @@ def expanded_path_weight_matrix(
             dilation,
             comp.groups,
             sign,
+        )
+
+    if isinstance(comp, nn.AdaptiveMaxPool1d):
+        print(
+            f"\tExpanding AdaptiveMaxPool1d from {input_shape} to {output_shape} with output_size={comp.output_size}."
+        )
+        assert len(input_shape) == 2
+        assert len(output_shape) == 2
+        return adaptive_maxpool1d_weight_matrix(
+            input_shape[0], input_shape, output_shape, sign
+        )
+
+    if isinstance(comp, nn.AdaptiveMaxPool2d):
+        print(
+            f"\tExpanding AdaptiveMaxPool2d from {input_shape} to {output_shape} with output_size={comp.output_size}."
+        )
+        assert len(input_shape) == 3
+        assert len(output_shape) == 3
+        return adaptive_maxpool2d_weight_matrix(
+            input_shape[0], input_shape, output_shape, sign
         )
 
     if isinstance(comp, nn.MaxPool1d):
@@ -567,9 +647,6 @@ def build_weights(
             weights[i, js] = matrix[neu_idx, idxs]
 
 
-from numba import njit
-
-
 @njit
 def _fill_weights_numba(
     weights,
@@ -695,18 +772,11 @@ def get_raw_weights(raw_neus: list[Neuron], input_neus: list[SourceElem]) -> np.
         path_matrices: dict[SourceNode, np.ndarray] = {}
 
         for predecessor, comp, weight, sign in zip(
-            target.predecessors,
-            target.comps,
-            target.weights,
-            signs,
+            target.predecessors, target.comps, target.weights, signs
         ):
             # Each predecessor contributes one dense [target_out, pred_out] block.
             matrix = expanded_path_weight_matrix(
-                predecessor,
-                target,
-                comp,
-                weight,
-                sign,
+                predecessor, target, comp, weight, sign
             )
             if predecessor in path_matrices:
                 path_matrices[predecessor] = path_matrices[predecessor] + matrix

--- a/paibox/backendv2/route_solver.py
+++ b/paibox/backendv2/route_solver.py
@@ -218,12 +218,8 @@ def route_solve(
         total_distance += dx_input + dy_input
 
     for output_area_id in output_area_ids:
-        dx_output = model.NewIntVar(
-            X_START, X_END - 1, f"dx_output_{output_area_id}"
-        )
-        dy_output = model.NewIntVar(
-            Y_START, Y_END - 1, f"dy_output_{output_area_id}"
-        )
+        dx_output = model.NewIntVar(X_START, X_END - 1, f"dx_output_{output_area_id}")
+        dy_output = model.NewIntVar(Y_START, Y_END - 1, f"dy_output_{output_area_id}")
         model.AddAbsEquality(dx_output, cx[output_area_id] - io_target[0])
         model.AddAbsEquality(dy_output, cy[output_area_id] - io_target[1])
         total_distance += dx_output + dy_output

--- a/paibox/paiir/lowering/converter.py
+++ b/paibox/paiir/lowering/converter.py
@@ -2,11 +2,16 @@
 
 Pipeline:
 
-1. FX symbolic trace with registered module types + bypass types as leaf modules.
-2. ``_EraseModuleTransformer`` removes Dropout/Identity nodes from the graph.
-3. ``ShapeProp`` for tensor shape propagation (when *sample_inputs* given).
-4. ``DimsProp`` for axis ordering propagation (detects transpose/permute).
-5. 1:1 node mapping to PAIIR nodes (no fusion at this stage).
+1. ``copy.deepcopy`` the model; force ``step_mode='s'`` on all SpikingJelly
+   ``StepModule`` instances (original model is never modified).
+2. FX symbolic trace with registered module types + bypass types as leaf modules.
+3. ``_EraseModuleTransformer`` removes no-op modules (Dropout/Identity) from
+   the graph.
+4. ``ShapeProp`` for tensor shape propagation (when *sample_inputs* given).
+5. ``DimsProp`` for axis ordering propagation (detects transpose/permute).
+6. 1:1 node mapping to PAIIR nodes (no fusion at this stage).
+   Supported ``spikingjelly.activation_based.layer.X`` modules lower directly
+   via Python MRO; no canonicalization step required.
 
 Example::
 
@@ -46,19 +51,16 @@ from functools import partial
 from typing import Any, TypeVar
 
 import torch
+from spikingjelly.activation_based import functional as sj_F
 from spikingjelly.activation_based import neuron
+from spikingjelly.activation_based.base import StepModule
 from torch import Tensor, fx, nn
 from torch.fx.node import Argument, Target
 from torch.fx.passes.shape_prop import ShapeProp
 
 from ..exceptions import UnsupportedOpError, UnsupportedOpWarning
 from ..ir.add_ops import AddOperandKind, AddOperandSpec, GeneralAddOp
-from ..ir.core_neuron import (
-    ANNNodeV25,
-    CoreNeuronV25,
-    IFNodeV25,
-    LIFNodeV25,
-)
+from ..ir.core_neuron import ANNNodeV25, CoreNeuronV25, IFNodeV25, LIFNodeV25
 from ..ir.graph import PAIIRGraph
 from ..ir.ir_base import InputNode, OutputNode
 from ..ir.lut_activation import (
@@ -84,7 +86,6 @@ from ..ir.reshape_semantics import RESHAPE_LEAF_MODULE_TYPES
 from .conv_lowering import (
     build_conv_ir_node,
     extract_functional_conv_spec,
-    extract_module_conv_spec,
 )
 from .dims_prop import DimsProp
 from .fx_utils import (
@@ -95,6 +96,13 @@ from .fx_utils import (
     get_output_shape,
 )
 from .shape_analysis import ReshapeSinkInfo, ShapeAnalysisResult, analyze_shape_helpers
+from .sj_layers import (
+    _SUPPORTED_SJ_LAYER_COMP_TYPES,
+    SJ_LAYER_ERASE_MODULE_TYPES,
+    describe_sj_layer_module,
+    is_sj_layer_module,
+    is_supported_sj_layer_module,
+)
 from .split_lowering import (
     SplitProducerInfo,
     apply_split_analysis_rule,
@@ -120,6 +128,9 @@ ModuleMapper = dict[type[_M], Callable[[_M], OpNode]]
 _USER_MODULE_MAP: ModuleMapper = {}
 """User-registered module mappings layered on top of built-in lowering rules."""
 
+
+ADAPTIVE_MAXPOOL_MODULE_TYPES = (nn.AdaptiveMaxPool1d, nn.AdaptiveMaxPool2d)
+
 # Modules that are kept in the FX graph but intentionally disappear from PAIIR
 # data flow during lowering.
 LOWERING_BYPASS_MODULE_TYPES = (nn.BatchNorm1d, nn.BatchNorm2d)
@@ -135,7 +146,7 @@ TRACE_LEAF_MODULE_TYPES = LOWERING_BYPASS_MODULE_TYPES + RESHAPE_LEAF_MODULE_TYP
 
 # Modules removed by _EraseModuleTransformer: each call_module node is replaced
 # by its input, leaving no trace in the graph after dead-code elimination.
-ERASE_MODULE_TYPES = (nn.Dropout, nn.Identity)
+ERASE_MODULE_TYPES = (nn.Dropout, nn.Identity) + SJ_LAYER_ERASE_MODULE_TYPES
 
 ADD_OPS = (operator.add, torch.add)
 SUB_OPS = (operator.sub, torch.sub)
@@ -162,6 +173,78 @@ def _describe_avgpool_lowering_issue(m: nn.Module) -> str | None:
         )
 
     return None
+
+
+def _describe_maxpool_lowering_issue(m: nn.Module) -> str | None:
+    if not isinstance(m, (nn.MaxPool1d, nn.MaxPool2d)):
+        return None
+
+    if m.return_indices:
+        return f"nn.Module '{type(m).__name__}' with return_indices=True"
+
+    return None
+
+
+def _set_sj_layer_step_mode_single(model: nn.Module) -> None:
+    """Force step_mode='s' on all SpikingJelly StepModule instances in the model copy.
+
+    Covers sj_layer.X (compute wrappers) and neuron.IFNode/LIFNode (MemoryModule ->
+    StepModule), and any other StepModule subclass in the model.
+
+    Called before FX tracing so ShapeProp can execute SJ forwards safely.
+    Emits a warning if any module actually had step_mode != 's'.
+    """
+    multi_step_modules = [
+        type(m).__name__
+        for m in model.modules()
+        if isinstance(m, StepModule) and m.step_mode != "s"
+    ]
+    if multi_step_modules:
+        warnings.warn(
+            f"Model contains SpikingJelly modules with step_mode='m' "
+            f"({', '.join(multi_step_modules)}). "
+            f"step_mode has been set to 's' on the internal model copy for "
+            f"chip deployment. The original model is not modified.",
+            UserWarning,
+            stacklevel=3,
+        )
+        sj_F.set_step_mode(model, "s")
+
+
+def _extract_adaptive_maxpool_ir_node(
+    node: fx.Node, m: nn.Module
+) -> tuple[StandaloneCompOp, tuple[fx.Node, ...]] | str | None:
+    """Extract an AdaptiveMaxPool module into a PAIIR standalone compute node.
+
+    Returns:
+        (StandaloneCompOp, inputs): The IR node and its input node.
+        str: Error message for an invalid AdaptiveMaxPool module.
+        None: The module is not AdaptiveMaxPool.
+    """
+    if not isinstance(m, ADAPTIVE_MAXPOOL_MODULE_TYPES):
+        return None
+    if not node.args or not isinstance(node.args[0], fx.Node):
+        return f"nn.Module '{type(m).__name__}' without a tensor input"
+
+    input_node = node.args[0]
+    input_shape = get_output_shape(input_node)
+
+    # Backend expansion requires a fixed spatial input shape.
+    if isinstance(m, nn.AdaptiveMaxPool1d):
+        ndim = 1
+    else:
+        ndim = 2
+
+    if len(input_shape) < ndim + 2:
+        return f"nn.Module '{type(m).__name__}' without a fixed input shape"
+
+    try:
+        _ = tuple(int(dim) for dim in input_shape[-ndim:])
+    except TypeError:
+        return f"nn.Module '{type(m).__name__}' without a static input shape"
+
+    ir_node = StandaloneCompOp(m)
+    return (ir_node, (input_node,))
 
 
 def _map_comp(m: nn.Module, **kwargs) -> StandaloneCompOp:
@@ -333,10 +416,17 @@ def _build_builtin_paiir_neuron_map() -> ModuleMapper:
     }
 
 
+def _build_spikingjelly_layer_comp_map() -> ModuleMapper:
+    # These wrappers lower exactly like their torch.nn base types, but still need
+    # explicit registration because module_map uses exact type() keys.
+    return dict.fromkeys(_SUPPORTED_SJ_LAYER_COMP_TYPES, _map_comp)
+
+
 def build_default_module_map() -> ModuleMapper:
     return {
         **_build_compute_module_map(),
         **_build_spikingjelly_neuron_module_map(),
+        **_build_spikingjelly_layer_comp_map(),
         **_build_standard_activation_module_map(),
         **_build_builtin_paiir_lut_map(),
         **_build_builtin_paiir_neuron_map(),
@@ -813,8 +903,10 @@ def _build_layout_transform_ir_node(
 
 
 class _PAIIRTracer(fx.Tracer):
-    """Custom FX Tracer that treats registered, bypass, and erase types as
-    leaf modules so they are not traced into.
+    """Custom FX Tracer that treats known frontend modules as leaves.
+
+    SpikingJelly ``layer.X`` modules are always leaves. Supported ones lower
+    directly via Python MRO; unsupported ones fail through normal lowering.
     """
 
     def __init__(
@@ -824,6 +916,8 @@ class _PAIIRTracer(fx.Tracer):
         self.custom_leaf_modules = custom_leaf_modules
 
     def is_leaf_module(self, m: nn.Module, module_qualified_name: str) -> bool:
+        if is_sj_layer_module(m):
+            return True
         if self.custom_leaf_modules and isinstance(m, self.custom_leaf_modules):
             return True
         if getattr(m, "_is_leaf_module", False):
@@ -832,7 +926,7 @@ class _PAIIRTracer(fx.Tracer):
 
 
 class _EraseModuleTransformer(fx.Transformer):
-    """Remove ``ERASE_MODULE_TYPES`` (Dropout, Identity) nodes from a traced graph.
+    """Remove ``ERASE_MODULE_TYPES`` nodes from a traced graph.
 
     Each matching ``call_module`` node is replaced by its single input node.
     Dead-code elimination is run automatically so no orphaned nodes remain.
@@ -902,7 +996,7 @@ def torch_to_paiir(
 ) -> PAIIRGraph:
     """Convert a PyTorch model to a :class:`PAIIRGraph`.
 
-    Performs 1:1 node mapping only — no fusion.  Use
+    Performs 1:1 node mapping only; no fusion. Use
     :func:`fuse_to_offline_cores` afterwards to fuse nodes into
     offline-core units.
 
@@ -925,13 +1019,19 @@ def torch_to_paiir(
         UnsupportedOpError: If ``strict=True`` and an unsupported operator
             is encountered. See :exc:`~paibox.paiir.exceptions.UnsupportedOpError`.
     """
+    model = copy.deepcopy(model)
     model.eval()
+    # force 's' so ShapeProp can execute SJ forwards
+    _set_sj_layer_step_mode_single(model)
     full_map = _get_full_module_map()
 
-    # Edge case: root module itself is supported by the module map.
-    # FX trace always decomposes the root module. Wrap in Sequential
-    # so it becomes a submodule and is treated as a leaf module.
-    if type(model) in full_map:
+    # Edge case: FX trace always decomposes the root module. Wrap supported roots
+    # so they become submodules and are treated as leaf modules.
+    if (
+        type(model) in full_map
+        or isinstance(model, TRACE_LEAF_MODULE_TYPES)
+        or is_sj_layer_module(model)
+    ):
         model = nn.Sequential(model)
 
     # Leaf types = module_map keys + modules that need special post-trace handling.
@@ -1108,11 +1208,19 @@ def _apply_module_lowering_rule(
     torch_module = gm.get_submodule(str(node.target))
     input_override = ctx.input_nodes_overrides.get(node)
 
-    conv_spec = extract_module_conv_spec(node, torch_module)
-    if conv_spec is not None:
-        ir_node, conv_input_override = build_conv_ir_node(conv_spec)
+    adaptive_maxpool_result = _extract_adaptive_maxpool_ir_node(node, torch_module)
+    if adaptive_maxpool_result is not None:
+        if isinstance(adaptive_maxpool_result, str):
+            _mark_unsupported(ctx, node, adaptive_maxpool_result, strict)
+            return True
+
+        ir_node, adaptive_input_override = adaptive_maxpool_result
         _register_ir_node(
-            paiir_graph, ctx, node, ir_node, input_nodes_override=conv_input_override
+            paiir_graph,
+            ctx,
+            node,
+            ir_node,
+            input_nodes_override=adaptive_input_override,
         )
         return True
 
@@ -1134,8 +1242,18 @@ def _apply_module_lowering_rule(
         )
         return True
 
+    if is_sj_layer_module(torch_module) and not is_supported_sj_layer_module(
+        torch_module
+    ):
+        _mark_unsupported(ctx, node, describe_sj_layer_module(torch_module), strict)
+        return True
+
     if _is_lowering_bypass_module(torch_module):
         ctx.bypass_nodes.add(node)
+        return True
+
+    if (maxpool_issue := _describe_maxpool_lowering_issue(torch_module)) is not None:
+        _mark_unsupported(ctx, node, maxpool_issue, strict)
         return True
 
     if (avgpool_issue := _describe_avgpool_lowering_issue(torch_module)) is not None:

--- a/paibox/paiir/lowering/sj_layers.py
+++ b/paibox/paiir/lowering/sj_layers.py
@@ -1,0 +1,39 @@
+"""Frontend policy for ``spikingjelly.activation_based.layer`` modules."""
+
+from spikingjelly.activation_based import layer
+from torch import nn
+
+SJ_LAYER_ERASE_MODULE_TYPES = (layer.Dropout, layer.Dropout2d)
+
+# SJ layer types that lower correctly through Python MRO; no canonicalization needed.
+#
+# Conv1d/2d, Linear, MaxPool1d/2d, and AvgPool1d/2d lower through explicit
+# module_map registration.
+# Flatten lowers via reshape-sink handling.
+_SUPPORTED_SJ_LAYER_COMP_TYPES = (
+    layer.Conv1d,
+    layer.Conv2d,
+    layer.Linear,
+    layer.MaxPool1d,
+    layer.MaxPool2d,
+    layer.AvgPool1d,
+    layer.AvgPool2d,
+)
+
+_SUPPORTED_SJ_LAYER_TYPES = (
+    *_SUPPORTED_SJ_LAYER_COMP_TYPES,
+    layer.Flatten,
+)
+
+
+def is_sj_layer_module(m: nn.Module) -> bool:
+    return type(m).__module__ == layer.__name__
+
+
+def is_supported_sj_layer_module(m: nn.Module) -> bool:
+    """Return True if this SJ layer module lowers correctly without canonicalization."""
+    return isinstance(m, _SUPPORTED_SJ_LAYER_TYPES)
+
+
+def describe_sj_layer_module(m: nn.Module) -> str:
+    return f"spikingjelly.activation_based.layer.{type(m).__name__}"

--- a/tests/backendv2/test_get_weight.py
+++ b/tests/backendv2/test_get_weight.py
@@ -116,7 +116,11 @@ def test_expanded_path_weight_matrix_handles_adaptive_maxpool(case: ExpandedPath
     predecessor = _input_node("input", case.predecessor_shape)
     target = _core_node("pool", case.comp, case.target_shape)
     matrix = expanded_path_weight_matrix(
-        predecessor, target, target.raw_node.comp, None, 1  # type: ignore
+        predecessor,
+        target,
+        target.raw_node.comp,
+        None,
+        1,  # type: ignore
     )
 
     assert matrix.shape == case.expected_shape

--- a/tests/backendv2/test_get_weight.py
+++ b/tests/backendv2/test_get_weight.py
@@ -1,0 +1,123 @@
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from paibox.backendv2.get_weight import (
+    _adaptive_pool_window_bounds,
+    adaptive_maxpool1d_weight_matrix,
+    adaptive_maxpool2d_weight_matrix,
+    expanded_path_weight_matrix,
+)
+from paibox.backendv2.op_node import CoreOpNode, InNode
+from paibox.paiir.ir.ir_base import InputNode
+from paibox.paiir.ir.op_node import StandaloneCompOp
+
+
+def _active_cols(row: np.ndarray) -> set[int]:
+    return set(np.flatnonzero(row).tolist())
+
+
+def _input_node(name: str, shape: torch.Size | tuple[int, ...]) -> InNode:
+    raw_input = InputNode(shape=torch.Size(shape))
+    raw_input.name = name
+    return InNode(raw_input.name, raw_input, tuple(raw_input.shape))
+
+
+def _core_node(name: str, comp: nn.Module, shape: tuple[int, ...]) -> CoreOpNode:
+    return CoreOpNode(name, _standalone_comp(comp), shape)
+
+
+def _standalone_comp(comp: nn.Module) -> StandaloneCompOp:
+    raw_node = StandaloneCompOp(comp)
+    raw_node.core_params.tick_start = 1
+    raw_node.core_params.tick_duration = 0
+    raw_node.core_params.tick_initial = 1
+    return raw_node
+
+
+@dataclass(frozen=True)
+class ExpandedPathCase:
+    predecessor_shape: tuple[int, ...]
+    target_shape: tuple[int, ...]
+    comp: nn.Module
+    expected_shape: tuple[int, int]
+    probe_row: int
+    expected_cols: set[int]
+
+
+EXPANDED_PATH_CASES = (
+    ExpandedPathCase(
+        predecessor_shape=(1, 2, 7),
+        target_shape=(1, 2, 4),
+        comp=nn.AdaptiveMaxPool1d(4),
+        expected_shape=(8, 14),
+        probe_row=1,
+        expected_cols={1, 2, 3},
+    ),
+    ExpandedPathCase(
+        predecessor_shape=(1, 1, 7, 7),
+        target_shape=(1, 1, 4, 4),
+        comp=nn.AdaptiveMaxPool2d((4, 4)),
+        expected_shape=(16, 49),
+        probe_row=1,
+        expected_cols={1, 2, 3, 8, 9, 10},
+    ),
+)
+
+
+def test_adaptive_pool_window_bounds_matches_pytorch_formula():
+    assert [_adaptive_pool_window_bounds(i, 7, 4) for i in range(4)] == [
+        (0, 2),
+        (1, 4),
+        (3, 6),
+        (5, 7),
+    ]
+    assert [_adaptive_pool_window_bounds(i, 8, 4) for i in range(4)] == [
+        (0, 2),
+        (2, 4),
+        (4, 6),
+        (6, 8),
+    ]
+
+
+def test_adaptive_maxpool2d_weight_matrix_irregular_windows():
+    matrix = adaptive_maxpool2d_weight_matrix(1, (1, 7, 7), (1, 4, 4), sign=1)
+
+    assert matrix.shape == (16, 49)
+    assert _active_cols(matrix[0]) == {0, 1, 7, 8}
+    assert _active_cols(matrix[1]) == {1, 2, 3, 8, 9, 10}
+    assert _active_cols(matrix[15]) == {40, 41, 47, 48}
+
+
+def test_adaptive_maxpool1d_weight_matrix_irregular_windows_and_channels():
+    matrix = adaptive_maxpool1d_weight_matrix(2, (2, 7), (2, 4), sign=1)
+
+    assert matrix.shape == (8, 14)
+    assert _active_cols(matrix[0]) == {0, 1}
+    assert _active_cols(matrix[1]) == {1, 2, 3}
+    assert _active_cols(matrix[4]) == {7, 8}
+    assert _active_cols(matrix[5]) == {8, 9, 10}
+
+
+def test_adaptive_maxpool2d_weight_matrix_respects_sign():
+    matrix = adaptive_maxpool2d_weight_matrix(1, (1, 4, 4), (1, 2, 2), sign=-1)
+
+    assert set(matrix[0].tolist()) == {-1, 0}
+    assert _active_cols(matrix[0]) == {0, 1, 4, 5}
+
+
+@pytest.mark.parametrize(
+    "case", EXPANDED_PATH_CASES, ids=lambda case: type(case.comp).__name__
+)
+def test_expanded_path_weight_matrix_handles_adaptive_maxpool(case: ExpandedPathCase):
+    predecessor = _input_node("input", case.predecessor_shape)
+    target = _core_node("pool", case.comp, case.target_shape)
+    matrix = expanded_path_weight_matrix(
+        predecessor, target, target.raw_node.comp, None, 1  # type: ignore
+    )
+
+    assert matrix.shape == case.expected_shape
+    assert _active_cols(matrix[case.probe_row]) == case.expected_cols

--- a/tests/paiir/lowering/test_converter.py
+++ b/tests/paiir/lowering/test_converter.py
@@ -726,7 +726,7 @@ class TestSpikingJellyLayerCanonicalization:
         model = Model().eval()
         with torch.no_grad():
             model.conv.weight.fill_(2.0)
-            model.conv.bias.fill_(3.0) # type: ignore
+            model.conv.bias.fill_(3.0)  # type: ignore
 
         graph = torch_to_paiir(model, make_img_3ch_8x8())
 
@@ -739,7 +739,7 @@ class TestSpikingJellyLayerCanonicalization:
         comp = conv_nodes[0].comp
         assert isinstance(comp, nn.Conv2d)
         assert torch.equal(comp.weight, model.conv.weight)
-        assert torch.equal(comp.bias, model.conv.bias) # type: ignore
+        assert torch.equal(comp.bias, model.conv.bias)  # type: ignore
 
     def test_linear_layer_lowers_to_canonical_linear(self):
         class Model(nn.Module):

--- a/tests/paiir/lowering/test_converter.py
+++ b/tests/paiir/lowering/test_converter.py
@@ -5,6 +5,7 @@ import warnings
 import pytest
 import torch
 import torch.nn.functional as F
+from spikingjelly.activation_based import layer
 from spikingjelly.activation_based import neuron as sj
 from torch import Tensor, nn
 
@@ -619,7 +620,7 @@ class TestSpikingJellyNeuronAttributeForwarding:
         graph = torch_to_paiir(model, make_vec_8d())
 
         lowered = _find_single_act(graph, IFNodeV25)
-        assert lowered.surrogate_function is model.act.surrogate_function
+        assert type(lowered.surrogate_function) is type(model.act.surrogate_function)
         assert lowered.detach_reset is model.act.detach_reset
 
     def test_activation_based_lifnode_preserves_surrogate_and_detach_reset(self):
@@ -636,7 +637,7 @@ class TestSpikingJellyNeuronAttributeForwarding:
         graph = torch_to_paiir(model, make_vec_8d())
 
         lowered = _find_single_act(graph, LIFNodeV25)
-        assert lowered.surrogate_function is model.act.surrogate_function
+        assert type(lowered.surrogate_function) is type(model.act.surrogate_function)
         assert lowered.detach_reset is model.act.detach_reset
 
 
@@ -663,7 +664,7 @@ class TestLegacyClockDrivenCompatibility:
             graph = torch_to_paiir(model, make_vec_8d())
 
         lowered = _find_single_act(graph, IFNodeV25)
-        assert lowered.surrogate_function is model.act.surrogate_function
+        assert type(lowered.surrogate_function) is type(model.act.surrogate_function)
         assert lowered.detach_reset is model.act.detach_reset
 
     def test_clock_driven_lifnode_warns_and_lowers(self):
@@ -686,7 +687,7 @@ class TestLegacyClockDrivenCompatibility:
             graph = torch_to_paiir(model, make_vec_8d())
 
         lowered = _find_single_act(graph, LIFNodeV25)
-        assert lowered.surrogate_function is model.act.surrogate_function
+        assert type(lowered.surrogate_function) is type(model.act.surrogate_function)
         assert lowered.detach_reset is model.act.detach_reset
 
     def test_activation_based_lifnode_does_not_warn(self):
@@ -710,3 +711,243 @@ class TestLegacyClockDrivenCompatibility:
         ]
         lowered = _find_single_act(graph, LIFNodeV25)
         assert isinstance(lowered, LIFNodeV25)
+
+
+class TestSpikingJellyLayerCanonicalization:
+    def test_conv2d_layer_lowers_to_canonical_conv2d(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = layer.Conv2d(3, 4, 3, padding=1, bias=True, step_mode="m")
+
+            def forward(self, x):
+                return self.conv(x)
+
+        model = Model().eval()
+        with torch.no_grad():
+            model.conv.weight.fill_(2.0)
+            model.conv.bias.fill_(3.0) # type: ignore
+
+        graph = torch_to_paiir(model, make_img_3ch_8x8())
+
+        conv_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.Conv2d)
+        ]
+        assert len(conv_nodes) == 1
+        comp = conv_nodes[0].comp
+        assert isinstance(comp, nn.Conv2d)
+        assert torch.equal(comp.weight, model.conv.weight)
+        assert torch.equal(comp.bias, model.conv.bias) # type: ignore
+
+    def test_linear_layer_lowers_to_canonical_linear(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = layer.Linear(8, 4, bias=True, step_mode="m")
+
+            def forward(self, x):
+                return self.linear(x)
+
+        model = Model().eval()
+        graph = torch_to_paiir(model, make_vec_8d())
+
+        linear_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.Linear)
+        ]
+        assert len(linear_nodes) == 1
+        assert isinstance(linear_nodes[0].comp, nn.Linear)
+
+    def test_pool_and_flatten_layers_lower_to_canonical_nodes(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.maxpool = layer.MaxPool2d(2, step_mode="m")
+                self.avgpool = layer.AvgPool2d(2, step_mode="m")
+                self.flatten = layer.Flatten(start_dim=1, step_mode="m")
+
+            def forward(self, x):
+                return self.flatten(self.avgpool(self.maxpool(x)))
+
+        graph = torch_to_paiir(Model().eval(), make_img_3ch_8x8())
+
+        assert (
+            len(
+                [
+                    node
+                    for node in graph.nodes.values()
+                    if isinstance(node, StandaloneCompOp)
+                    and isinstance(node.comp, nn.MaxPool2d)
+                ]
+            )
+            == 1
+        )
+        assert (
+            len(
+                [
+                    node
+                    for node in graph.nodes.values()
+                    if isinstance(node, StandaloneCompOp)
+                    and isinstance(node.comp, nn.AvgPool2d)
+                ]
+            )
+            == 1
+        )
+        assert (
+            len(
+                [
+                    node
+                    for node in graph.nodes.values()
+                    if type(node).__name__ == "TransformOp"
+                ]
+            )
+            == 1
+        )
+
+    def test_dropout_layer_is_erased_in_eval_deploy_path(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.dropout = layer.Dropout(p=0.5, step_mode="m")
+                self.linear = nn.Linear(8, 4)
+
+            def forward(self, x):
+                return self.linear(self.dropout(x))
+
+        graph = torch_to_paiir(Model().eval(), make_vec_8d())
+
+        assert (
+            len(
+                [
+                    node
+                    for node in graph.nodes.values()
+                    if isinstance(node, StandaloneCompOp)
+                    and isinstance(node.comp, nn.Linear)
+                ]
+            )
+            == 1
+        )
+
+    def test_regular_adaptive_maxpool2d_lowers_to_standalone_comp(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = nn.AdaptiveMaxPool2d((4, 4))
+
+            def forward(self, x):
+                return self.pool(x)
+
+        graph = torch_to_paiir(Model().eval(), make_img_3ch_8x8())
+
+        pool_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.AdaptiveMaxPool2d)
+        ]
+        assert len(pool_nodes) == 1
+        assert pool_nodes[0].comp.output_size == (4, 4)
+
+    def test_irregular_adaptive_maxpool2d_lowers_to_standalone_comp(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = nn.AdaptiveMaxPool2d((4, 4))
+
+            def forward(self, x):
+                return self.pool(x)
+
+        graph = torch_to_paiir(Model().eval(), torch.randn(1, 3, 7, 7))
+
+        pool_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.AdaptiveMaxPool2d)
+        ]
+        assert len(pool_nodes) == 1
+        assert pool_nodes[0].comp.output_size == (4, 4)
+
+    def test_irregular_adaptive_maxpool1d_lowers_to_standalone_comp(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = nn.AdaptiveMaxPool1d(4)
+
+            def forward(self, x):
+                return self.pool(x)
+
+        graph = torch_to_paiir(Model().eval(), torch.randn(1, 2, 7))
+
+        pool_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.AdaptiveMaxPool1d)
+        ]
+        assert len(pool_nodes) == 1
+        assert pool_nodes[0].comp.output_size == 4
+
+    def test_sj_adaptive_avgpool2d_is_rejected_as_layer_wrapper(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = layer.AdaptiveAvgPool2d((4, 4), step_mode="m")
+
+            def forward(self, x):
+                return self.pool(x)
+
+        with pytest.raises(UnsupportedOpError, match="AdaptiveAvgPool2d"):
+            torch_to_paiir(Model().eval(), torch.randn(1, 3, 7, 7))
+
+    def test_adaptive_avgpool2d_is_not_supported_in_this_slice(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = nn.AdaptiveAvgPool2d((4, 4))
+
+            def forward(self, x):
+                return self.pool(x)
+
+        with pytest.raises(UnsupportedOpError, match="AdaptiveAvgPool2d"):
+            torch_to_paiir(Model().eval(), make_img_3ch_8x8())
+
+    @pytest.mark.parametrize(
+        ("module", "sample"),
+        [
+            (layer.BatchNorm2d(3), make_img_3ch_8x8()),
+            (layer.ConvTranspose2d(3, 4, 3), make_img_3ch_8x8()),
+            (layer.Conv3d(1, 1, 3), torch.randn(1, 1, 5, 5, 5)),
+            (layer.VotingLayer(2), make_vec_8d()),
+            (layer.NeuNorm(3, 8, 8), make_img_3ch_8x8()),
+        ],
+    )
+    def test_unsupported_layer_modules_are_rejected_by_lowering(self, module, sample):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.module = module
+
+            def forward(self, x):
+                return self.module(x)
+
+        with pytest.raises(UnsupportedOpError, match="spikingjelly"):
+            torch_to_paiir(Model().eval(), sample)
+
+    def test_non_strict_unsupported_layer_warns_and_bypasses_during_lowering(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.module = layer.ConvTranspose2d(3, 3, 3, padding=1)
+
+            def forward(self, x):
+                return self.module(x)
+
+        with pytest.warns(UnsupportedOpWarning, match="spikingjelly"):
+            graph = torch_to_paiir(Model().eval(), make_img_3ch_8x8(), strict=False)
+
+        assert "InputNode_0" in graph.nodes
+        assert "OutputNode_0" in graph.nodes

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 from paicorelib import DataSign, DataWidth
+from spikingjelly.activation_based import layer as sj_layer
 from spikingjelly.activation_based import neuron as sj
 from torch import Tensor, nn
 
@@ -105,6 +106,17 @@ class AvgPool2dWrapper(nn.Module):
 
     def forward(self, x: Tensor) -> Tensor:
         return self.pool(x)
+
+
+class SpikingJellyLayerCompileSmoke(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.pool = sj_layer.MaxPool2d(2, step_mode="m")
+        self.flatten = sj_layer.Flatten(step_mode="m")
+        self.linear = sj_layer.Linear(3 * 4 * 4, 2, step_mode="m")
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.linear(self.flatten(self.pool(x)))
 
 
 class TransformThenLinear(nn.Module):
@@ -327,6 +339,13 @@ class TestCompileBasic:
         concat_nodes = find_nodes(graph, ConcatOp)
         assert len(concat_nodes) == 1
         assert concat_nodes[0].dim == 1
+
+    def test_spikingjelly_layer_compile_smoke(self):
+        graph = compile_to_paiir(SpikingJellyLayerCompileSmoke(), make_img_3ch_8x8())
+        # SJ layer wrappers lower via inheritance; comp is an nn.X subclass instance.
+        comp_types = [type(node.comp) for node in find_nodes(graph, StandaloneCompOp)]
+        assert any(issubclass(comp_type, nn.MaxPool2d) for comp_type in comp_types)
+        assert any(issubclass(comp_type, nn.Linear) for comp_type in comp_types)
 
     @pytest.mark.parametrize(
         ("model_factory", "sample_input", "expected_stage_types"),


### PR DESCRIPTION
## Summary
- Lower `spikingjelly.activation_based.layer` wrappers through native PAIIR paths without changing the tracer API.
- Add backendv2 adaptive maxpool weight expansion and keep the dense weight contract in `int16`.
- Add focused lowering, compile, and backend tests for the new support paths.
- Update user and backend-facing docs to distinguish SJ `layer.X` wrappers from native `torch.nn` adaptive maxpool support.