### PR TITLE
Feat(paiir): support adaptive average pooling

### DIFF
--- a/docs/paiir_backend_guide.md
+++ b/docs/paiir_backend_guide.md
@@ -54,7 +54,7 @@ PAIIR 前端默认支持标准 PyTorch 模块、少量 canonical function-form �
 
 ### 自定义计算模块
 
-`register_module(...)` 用于把用户自定义 `nn.Module` 转换为 PAIIR 已支持的 canonical `nn.Module`，例如 `nn.Conv1d`、`nn.Conv2d`、`nn.Linear`、pooling 模块（含 `nn.AdaptiveMaxPool1d/2d`）、标准激活模块或 PAIIR 神经元/LUT 模块。
+`register_module(...)` 用于把用户自定义 `nn.Module` 转换为 PAIIR 已支持的 canonical `nn.Module`，例如 `nn.Conv1d`、`nn.Conv2d`、`nn.Linear`、pooling 模块（含 `nn.AdaptiveMaxPool1d/2d` 与 `nn.AdaptiveAvgPool1d/2d`）、标准激活模块或 PAIIR 神经元/LUT 模块。
 
 ```python
 from torch import nn
@@ -82,7 +82,7 @@ register_module(MyQuantConv, to_canonical_conv)
 
 注册函数返回的模块必须已经是当前 PAIIR lowering 支持的模块；返回 bypass 模块或未知模块会报错。重复注册同一模块类型也会报错，避免全局 lowering 规则被静默覆盖。
 
-SpikingJelly `activation_based.layer` wrapper 是另一类前端入口。当前支持的 wrapper 包括 `layer.Conv1d/2d`、`layer.Linear`、`layer.MaxPool1d/2d`、`layer.AvgPool1d/2d`、`layer.Flatten`；这些 wrapper 会按对应普通模块路径进入 PAIIR。原生 `nn.AdaptiveMaxPool1d/2d` 支持属于 `torch.nn` 模块路径，不应描述成 `layer.AdaptiveMaxPool*` 支持。
+SpikingJelly `activation_based.layer` wrapper 是另一类前端入口。当前支持的 wrapper 包括 `layer.Conv1d/2d`、`layer.Linear`、`layer.MaxPool1d/2d`、`layer.AvgPool1d/2d`、`layer.AdaptiveAvgPool1d/2d`、`layer.Flatten`；这些 wrapper 会按对应普通模块路径进入 PAIIR。注意这里讨论的是 SpikingJelly `activation_based.layer` 模块内实际存在的 wrapper；原生 `torch.nn` 模块支持属于另一类入口。
 
 ### 自定义神经元或 LUT 激活
 
@@ -479,7 +479,7 @@ raw_weights: list[Tensor] | None = op.weights
 >
 > - Conv：由 kernel 展开为 dense matrix
 > - Pool：由 `kernel_size / stride / padding / dilation` 合成窗口连接矩阵
-> - `nn.AdaptiveMaxPool1d/2d`：由 PyTorch adaptive pooling 的输出位置到输入窗口边界合成位置相关连接矩阵
+> - `nn.AdaptiveMaxPool1d/2d` / `nn.AdaptiveAvgPool1d/2d`：由 PyTorch adaptive pooling 的输出位置到输入窗口边界合成位置相关连接矩阵；矩阵只表达连接和符号，avgpool 的除法语义由后续补偿/解释路径处理
 > - `StandaloneActOp` / `PotentialAddOp`：在 `comp is None` 时按路径语义合成 signed identity matrix
 >
 > 因此，不要把 `op.weights` 直接理解为“最终部署权重矩阵”。
@@ -544,7 +544,7 @@ SNN 模式下 `lut_data` 为 `None`。
 from paibox.paiir.ir.op_node import SequentialOp
 
 seq: SequentialOp
-seq.comp: nn.Module        # 计算模块（Conv2d / Linear / MaxPool2d / AvgPool2d 等）
+seq.comp: nn.Module        # 计算模块（Conv2d / Linear / MaxPool2d / AvgPool2d / Adaptive*Pool2d 等）
 seq.act: CoreNeuronV25     # 激活模块
 seq.weights                # list[Tensor] | None，原始参数张量；池化通常为 None
 seq.neuron_params          # NeuronParams（含 bias 融合、AvgPool 补偿）

--- a/docs/user_quickstart.md
+++ b/docs/user_quickstart.md
@@ -59,7 +59,7 @@ from paibox.paiir import compile_to_paiir
 
 对于 ANN 量化模型，当前最稳妥的通用方式是：
 
-- 保留标准 `nn.Conv1d` / `nn.Conv2d` / `nn.Linear` / `nn.MaxPool*` / `nn.AvgPool*` / `nn.AdaptiveMaxPool*`
+- 保留标准 `nn.Conv1d` / `nn.Conv2d` / `nn.Linear` / `nn.MaxPool*` / `nn.AvgPool*` / `nn.AdaptiveMaxPool*` / `nn.AdaptiveAvgPool*`
 - 或保留当前支持的 `spikingjelly.activation_based.layer.X` wrapper，注意这和原生 `torch.nn.X` 支持面是两类入口
 - 或保留静态参数可解析的 `torch.nn.functional.conv1d/conv2d`
 - 把部署用的整数权重、偏置、scale、LUT 等信息固化到模块参数或 buffer 中
@@ -144,6 +144,8 @@ uv run python -c "import torch, spikingjelly, paicorelib, numba, paibox; print('
   - `nn.AvgPool2d`
   - `nn.AdaptiveMaxPool1d`
   - `nn.AdaptiveMaxPool2d`
+  - `nn.AdaptiveAvgPool1d`
+  - `nn.AdaptiveAvgPool2d`
 - 函数式卷积
   - `torch.nn.functional.conv1d`
   - `torch.nn.functional.conv2d`
@@ -156,8 +158,10 @@ uv run python -c "import torch, spikingjelly, paicorelib, numba, paibox; print('
   - `layer.MaxPool2d`
   - `layer.AvgPool1d`
   - `layer.AvgPool2d`
+  - `layer.AdaptiveAvgPool1d`
+  - `layer.AdaptiveAvgPool2d`
   - `layer.Flatten`
-  - 这些 wrapper 按当前 PAIIR 支持的普通模块路径 lowering；不要把原生 `nn.AdaptiveMaxPool1d/2d` 误写成 SJ `layer.AdaptiveMaxPool*` 支持
+  - 这些 wrapper 按当前 PAIIR 支持的普通模块路径 lowering；支持面与当前安装的 SpikingJelly `activation_based.layer` 模块实际提供的 wrapper 保持一致
 - 常见激活
   - `nn.ReLU`
   - `nn.Sigmoid`

--- a/paibox/backendv2/get_weight.py
+++ b/paibox/backendv2/get_weight.py
@@ -339,31 +339,100 @@ def _adaptive_pool_window_bounds(
     return start, end
 
 
+def _adaptive_pool_bounds(
+    input_size: int, output_size: int
+) -> tuple[tuple[int, int], ...]:
+    return tuple(
+        _adaptive_pool_window_bounds(out_pos, input_size, output_size)
+        for out_pos in range(output_size)
+    )
+
+
+def _adaptive_pool1d_weight_matrix(
+    channels: int, input_length: int, output_length: int, sign: int
+) -> np.ndarray:
+    n_input = channels * input_length
+    matrix = np.zeros((channels * output_length, n_input), dtype=np.int16)
+    bounds = _adaptive_pool_bounds(input_length, output_length)
+
+    for channel in range(channels):
+        input_offset = channel * input_length
+        output_offset = channel * output_length
+        for out_pos, (start, end) in enumerate(bounds):
+            row = output_offset + out_pos
+            matrix[row, input_offset + start : input_offset + end] = sign
+
+    return matrix
+
+
+def _adaptive_pool2d_weight_matrix(
+    channels: int,
+    input_height: int,
+    input_width: int,
+    output_height: int,
+    output_width: int,
+    sign: int,
+) -> np.ndarray:
+    input_area = input_height * input_width
+    output_area = output_height * output_width
+    matrix = np.zeros((channels * output_area, channels * input_area), dtype=np.int16)
+    h_bounds = _adaptive_pool_bounds(input_height, output_height)
+    w_bounds = _adaptive_pool_bounds(input_width, output_width)
+
+    for channel in range(channels):
+        input_offset = channel * input_area
+        output_offset = channel * output_area
+        for out_h, (h_start, h_end) in enumerate(h_bounds):
+            row_base = output_offset + out_h * output_width
+            for out_w, (w_start, w_end) in enumerate(w_bounds):
+                row = row_base + out_w
+                for in_h in range(h_start, h_end):
+                    col_start = input_offset + in_h * input_width + w_start
+                    col_end = input_offset + in_h * input_width + w_end
+                    matrix[row, col_start:col_end] = sign
+
+    return matrix
+
+
+def _adaptive_pool_weight_matrix(
+    channels: int,
+    input_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+    sign: int,
+    op_name: str,
+) -> np.ndarray:
+    in_channels, *input_spatial_shape = input_shape
+    out_channels, *output_spatial_shape = output_shape
+    if in_channels != channels or out_channels != channels:
+        raise ValueError(
+            f"{op_name} channel mismatch: input={in_channels}, output={out_channels}, channels={channels}."
+        )
+
+    match (tuple(input_spatial_shape), tuple(output_spatial_shape)):
+        case ((input_length,), (output_length,)):
+            return _adaptive_pool1d_weight_matrix(
+                channels, input_length, output_length, sign
+            )
+        case ((input_height, input_width), (output_height, output_width)):
+            return _adaptive_pool2d_weight_matrix(
+                channels, input_height, input_width, output_height, output_width, sign
+            )
+        case _:
+            raise ValueError(
+                "Adaptive pooling input/output spatial rank mismatch: "
+                f"input={tuple(input_spatial_shape)}, output={tuple(output_spatial_shape)}."
+            )
+
+
 def adaptive_maxpool1d_weight_matrix(
     channels: int,
     input_shape: tuple[int, int],
     output_shape: tuple[int, int],
     sign: int,
 ) -> np.ndarray:
-    in_channels, in_length = input_shape
-    out_channels, out_length = output_shape
-    if in_channels != channels or out_channels != channels:
-        raise ValueError(
-            f"AdaptiveMaxPool1d channel mismatch: input={in_channels}, output={out_channels}, channels={channels}."
-        )
-
-    n_input = in_channels * in_length
-    matrix = np.zeros((out_channels * out_length, n_input), dtype=np.int16)
-
-    for channel in range(channels):
-        for out_pos in range(out_length):
-            start, end = _adaptive_pool_window_bounds(out_pos, in_length, out_length)
-            row = channel * out_length + out_pos
-            for in_pos in range(start, end):
-                col = channel * in_length + in_pos
-                matrix[row, col] = sign
-
-    return matrix
+    return _adaptive_pool_weight_matrix(
+        channels, input_shape, output_shape, sign, "AdaptiveMaxPool1d"
+    )
 
 
 def adaptive_maxpool2d_weight_matrix(
@@ -372,31 +441,31 @@ def adaptive_maxpool2d_weight_matrix(
     output_shape: tuple[int, int, int],
     sign: int,
 ) -> np.ndarray:
-    in_channels, in_height, in_width = input_shape
-    out_channels, out_height, out_width = output_shape
-    if in_channels != channels or out_channels != channels:
-        raise ValueError(
-            f"AdaptiveMaxPool2d channel mismatch: input={in_channels}, output={out_channels}, channels={channels}."
-        )
+    return _adaptive_pool_weight_matrix(
+        channels, input_shape, output_shape, sign, "AdaptiveMaxPool2d"
+    )
 
-    out_size = out_height * out_width
-    n_input = in_channels * in_height * in_width
-    matrix = np.zeros((out_channels * out_size, n_input), dtype=np.int16)
 
-    for channel in range(channels):
-        for out_h in range(out_height):
-            h_start, h_end = _adaptive_pool_window_bounds(out_h, in_height, out_height)
-            for out_w in range(out_width):
-                w_start, w_end = _adaptive_pool_window_bounds(
-                    out_w, in_width, out_width
-                )
-                row = channel * out_size + out_h * out_width + out_w
-                for in_h in range(h_start, h_end):
-                    for in_w in range(w_start, w_end):
-                        col = channel * in_height * in_width + in_h * in_width + in_w
-                        matrix[row, col] = sign
+def adaptive_avgpool1d_weight_matrix(
+    channels: int,
+    input_shape: tuple[int, int],
+    output_shape: tuple[int, int],
+    sign: int,
+) -> np.ndarray:
+    return _adaptive_pool_weight_matrix(
+        channels, input_shape, output_shape, sign, "AdaptiveAvgPool1d"
+    )
 
-    return matrix
+
+def adaptive_avgpool2d_weight_matrix(
+    channels: int,
+    input_shape: tuple[int, int, int],
+    output_shape: tuple[int, int, int],
+    sign: int,
+) -> np.ndarray:
+    return _adaptive_pool_weight_matrix(
+        channels, input_shape, output_shape, sign, "AdaptiveAvgPool2d"
+    )
 
 
 def expanded_path_weight_matrix(
@@ -488,6 +557,26 @@ def expanded_path_weight_matrix(
         assert len(input_shape) == 3
         assert len(output_shape) == 3
         return adaptive_maxpool2d_weight_matrix(
+            input_shape[0], input_shape, output_shape, sign
+        )
+
+    if isinstance(comp, nn.AdaptiveAvgPool1d):
+        print(
+            f"\tExpanding AdaptiveAvgPool1d from {input_shape} to {output_shape} with output_size={comp.output_size}."
+        )
+        assert len(input_shape) == 2
+        assert len(output_shape) == 2
+        return adaptive_avgpool1d_weight_matrix(
+            input_shape[0], input_shape, output_shape, sign
+        )
+
+    if isinstance(comp, nn.AdaptiveAvgPool2d):
+        print(
+            f"\tExpanding AdaptiveAvgPool2d from {input_shape} to {output_shape} with output_size={comp.output_size}."
+        )
+        assert len(input_shape) == 3
+        assert len(output_shape) == 3
+        return adaptive_avgpool2d_weight_matrix(
             input_shape[0], input_shape, output_shape, sign
         )
 

--- a/paibox/paiir/ir/maxpool_export.py
+++ b/paibox/paiir/ir/maxpool_export.py
@@ -42,9 +42,21 @@ class MaxPoolExportKind(Enum):
     LUT = auto()
 
 
-def is_maxpool_comp(comp: nn.Module) -> TypeGuard[nn.MaxPool1d | nn.MaxPool2d]:
+def is_maxpool_comp(
+    comp: nn.Module,
+) -> TypeGuard[
+    nn.MaxPool1d | nn.MaxPool2d | nn.AdaptiveMaxPool1d | nn.AdaptiveMaxPool2d
+]:
     """Return whether ``comp`` is a standalone MaxPool compute op."""
-    return isinstance(comp, (nn.MaxPool1d, nn.MaxPool2d))
+    return isinstance(
+        comp,
+        (
+            nn.MaxPool1d,
+            nn.MaxPool2d,
+            nn.AdaptiveMaxPool1d,
+            nn.AdaptiveMaxPool2d,
+        ),
+    )
 
 
 def select_maxpool_export_kind(

--- a/paibox/paiir/ir/op_node.py
+++ b/paibox/paiir/ir/op_node.py
@@ -77,15 +77,15 @@ def _run_comp(comp: nn.Module, x: Tensor) -> Tensor:
     the incoming dtype where possible so standalone/preceding-value MaxPool
     simulation does not spuriously widen into float.
 
-    ``MaxPool1d`` is a special case on the current PyTorch CPU build: integer
-    ``Byte``/``Char`` inputs raise ``NotImplementedError``. For that case we
-    execute the pool in float32 and cast the exact max values back to the
-    original integer dtype.
+    Some MaxPool modules are special cases on the current PyTorch CPU build:
+    integer ``Byte``/``Char`` inputs raise ``NotImplementedError``. For those
+    cases we execute the pool in float32 and cast the exact max values back to
+    the original integer dtype.
 
     Other compute ops such as Conv/Linear still require floating-point tensors
     in PyTorch and therefore use :func:`_ensure_float`.
     """
-    if isinstance(comp, nn.MaxPool1d):
+    if isinstance(comp, (nn.MaxPool1d, nn.AdaptiveMaxPool1d, nn.AdaptiveMaxPool2d)):
         if x.is_floating_point():
             return comp(x)
         return comp(x.to(torch.float32)).to(x.dtype)

--- a/paibox/paiir/lowering/converter.py
+++ b/paibox/paiir/lowering/converter.py
@@ -128,9 +128,6 @@ ModuleMapper = dict[type[_M], Callable[[_M], OpNode]]
 _USER_MODULE_MAP: ModuleMapper = {}
 """User-registered module mappings layered on top of built-in lowering rules."""
 
-
-ADAPTIVE_MAXPOOL_MODULE_TYPES = (nn.AdaptiveMaxPool1d, nn.AdaptiveMaxPool2d)
-
 # Modules that are kept in the FX graph but intentionally disappear from PAIIR
 # data flow during lowering.
 LOWERING_BYPASS_MODULE_TYPES = (nn.BatchNorm1d, nn.BatchNorm2d)
@@ -176,7 +173,15 @@ def _describe_avgpool_lowering_issue(m: nn.Module) -> str | None:
 
 
 def _describe_maxpool_lowering_issue(m: nn.Module) -> str | None:
-    if not isinstance(m, (nn.MaxPool1d, nn.MaxPool2d)):
+    if not isinstance(
+        m,
+        (
+            nn.MaxPool1d,
+            nn.MaxPool2d,
+            nn.AdaptiveMaxPool1d,
+            nn.AdaptiveMaxPool2d,
+        ),
+    ):
         return None
 
     if m.return_indices:
@@ -209,42 +214,6 @@ def _set_sj_layer_step_mode_single(model: nn.Module) -> None:
             stacklevel=3,
         )
         sj_F.set_step_mode(model, "s")
-
-
-def _extract_adaptive_maxpool_ir_node(
-    node: fx.Node, m: nn.Module
-) -> tuple[StandaloneCompOp, tuple[fx.Node, ...]] | str | None:
-    """Extract an AdaptiveMaxPool module into a PAIIR standalone compute node.
-
-    Returns:
-        (StandaloneCompOp, inputs): The IR node and its input node.
-        str: Error message for an invalid AdaptiveMaxPool module.
-        None: The module is not AdaptiveMaxPool.
-    """
-    if not isinstance(m, ADAPTIVE_MAXPOOL_MODULE_TYPES):
-        return None
-    if not node.args or not isinstance(node.args[0], fx.Node):
-        return f"nn.Module '{type(m).__name__}' without a tensor input"
-
-    input_node = node.args[0]
-    input_shape = get_output_shape(input_node)
-
-    # Backend expansion requires a fixed spatial input shape.
-    if isinstance(m, nn.AdaptiveMaxPool1d):
-        ndim = 1
-    else:
-        ndim = 2
-
-    if len(input_shape) < ndim + 2:
-        return f"nn.Module '{type(m).__name__}' without a fixed input shape"
-
-    try:
-        _ = tuple(int(dim) for dim in input_shape[-ndim:])
-    except TypeError:
-        return f"nn.Module '{type(m).__name__}' without a static input shape"
-
-    ir_node = StandaloneCompOp(m)
-    return (ir_node, (input_node,))
 
 
 def _map_comp(m: nn.Module, **kwargs) -> StandaloneCompOp:
@@ -379,8 +348,12 @@ def _build_compute_module_map() -> ModuleMapper:
         nn.Linear,
         nn.MaxPool1d,
         nn.MaxPool2d,
+        nn.AdaptiveMaxPool1d,
+        nn.AdaptiveMaxPool2d,
         nn.AvgPool1d,
         nn.AvgPool2d,
+        nn.AdaptiveAvgPool1d,
+        nn.AdaptiveAvgPool2d,
     ]
     return dict.fromkeys(modules, _map_comp)
 
@@ -1207,22 +1180,6 @@ def _apply_module_lowering_rule(
 
     torch_module = gm.get_submodule(str(node.target))
     input_override = ctx.input_nodes_overrides.get(node)
-
-    adaptive_maxpool_result = _extract_adaptive_maxpool_ir_node(node, torch_module)
-    if adaptive_maxpool_result is not None:
-        if isinstance(adaptive_maxpool_result, str):
-            _mark_unsupported(ctx, node, adaptive_maxpool_result, strict)
-            return True
-
-        ir_node, adaptive_input_override = adaptive_maxpool_result
-        _register_ir_node(
-            paiir_graph,
-            ctx,
-            node,
-            ir_node,
-            input_nodes_override=adaptive_input_override,
-        )
-        return True
 
     sink_info = _get_reshape_sink_info(ctx, node)
     if sink_info is not None:

--- a/paibox/paiir/lowering/sj_layers.py
+++ b/paibox/paiir/lowering/sj_layers.py
@@ -7,8 +7,8 @@ SJ_LAYER_ERASE_MODULE_TYPES = (layer.Dropout, layer.Dropout2d)
 
 # SJ layer types that lower correctly through Python MRO; no canonicalization needed.
 #
-# Conv1d/2d, Linear, MaxPool1d/2d, and AvgPool1d/2d lower through explicit
-# module_map registration.
+# Conv1d/2d, Linear, MaxPool1d/2d, AvgPool1d/2d, and AdaptiveAvgPool1d/2d lower
+# through explicit module_map registration.
 # Flatten lowers via reshape-sink handling.
 _SUPPORTED_SJ_LAYER_COMP_TYPES = (
     layer.Conv1d,
@@ -18,6 +18,8 @@ _SUPPORTED_SJ_LAYER_COMP_TYPES = (
     layer.MaxPool2d,
     layer.AvgPool1d,
     layer.AvgPool2d,
+    layer.AdaptiveAvgPool1d,
+    layer.AdaptiveAvgPool2d,
 )
 
 _SUPPORTED_SJ_LAYER_TYPES = (

--- a/paibox/paiir/pipeline/avgpool/utils.py
+++ b/paibox/paiir/pipeline/avgpool/utils.py
@@ -12,6 +12,7 @@ __all__ = [
     "get_avgpool_divisor",
     "get_pool_window_size",
     "is_avgpool",
+    "is_value_avgpool",
 ]
 
 
@@ -21,6 +22,23 @@ PoolWindowModule: TypeAlias = nn.AvgPool1d | nn.AvgPool2d | SumPool1d | SumPool2
 def is_avgpool(comp: nn.Module) -> TypeGuard[nn.AvgPool1d | nn.AvgPool2d]:
     """Check if a compute module is an average-pooling op."""
     return isinstance(comp, (nn.AvgPool1d, nn.AvgPool2d))
+
+
+def is_value_avgpool(
+    comp: nn.Module,
+) -> TypeGuard[
+    nn.AvgPool1d | nn.AvgPool2d | nn.AdaptiveAvgPool1d | nn.AdaptiveAvgPool2d
+]:
+    """Check if a compute module emits VALUE-domain average-pooling data."""
+    return isinstance(
+        comp,
+        (
+            nn.AvgPool1d,
+            nn.AvgPool2d,
+            nn.AdaptiveAvgPool1d,
+            nn.AdaptiveAvgPool2d,
+        ),
+    )
 
 
 def build_sum_pool(comp: nn.AvgPool1d | nn.AvgPool2d) -> SumPool1d | SumPool2d:

--- a/paibox/paiir/pipeline/graph_utils.py
+++ b/paibox/paiir/pipeline/graph_utils.py
@@ -54,7 +54,13 @@ def is_order_preserving_transform_node(
 def is_standalone_maxpool(node: PAIIRNode) -> TypeGuard[StandaloneCompOp]:
     """Return whether *node* is a standalone MaxPool compute op."""
     return isinstance(node, StandaloneCompOp) and isinstance(
-        node.comp, (nn.MaxPool1d, nn.MaxPool2d)
+        node.comp,
+        (
+            nn.MaxPool1d,
+            nn.MaxPool2d,
+            nn.AdaptiveMaxPool1d,
+            nn.AdaptiveMaxPool2d,
+        ),
     )
 
 

--- a/paibox/paiir/pipeline/passes.py
+++ b/paibox/paiir/pipeline/passes.py
@@ -47,7 +47,7 @@ from ..ir.value_code import code_range_for_data_format, merge_code_ranges
 from .avgpool import calibrate_avgpool_thresholds
 from .avgpool.calibration import CalibrationResult
 from .avgpool.fusion import _try_handle_avgpool_activation
-from .avgpool.utils import is_avgpool
+from .avgpool.utils import is_value_avgpool
 from .data_format import (
     DataFormat,
     infer_output_code_range,
@@ -298,7 +298,7 @@ def _try_fuse_sequential(
     # AvgPool patterns are handled first by the dedicated AvgPool fusion logic,
     # which may choose shared-core or split-core depending on activation type
     # and deployment constraints. Skip here to avoid bypassing that policy.
-    if is_avgpool(pred.comp):
+    if is_value_avgpool(pred.comp):
         return None
 
     return _materialize_shared_sequential(
@@ -996,7 +996,7 @@ def propagate_signal_semantics(
                 _set_node_signal_semantics(node, *inferred)
             continue
 
-        if isinstance(node, StandaloneCompOp) and is_avgpool(node.comp):
+        if isinstance(node, StandaloneCompOp) and is_value_avgpool(node.comp):
             inferred = _infer_standalone_avgpool_signal_semantics(pred_facts)
             if inferred is not None:
                 _set_node_signal_semantics(node, *inferred)
@@ -1490,7 +1490,7 @@ def _infer_node_output_format(
 
     if (
         isinstance(node, StandaloneCompOp)
-        and is_avgpool(node.comp)
+        and is_value_avgpool(node.comp)
         and node.signal_semantics.output_domain is SignalDomain.VALUE
     ):
         if not pred_formats:

--- a/tests/backendv2/test_get_weight.py
+++ b/tests/backendv2/test_get_weight.py
@@ -4,9 +4,12 @@ import numpy as np
 import pytest
 import torch
 from torch import nn
+from torch.nn import functional as F
 
 from paibox.backendv2.get_weight import (
     _adaptive_pool_window_bounds,
+    adaptive_avgpool1d_weight_matrix,
+    adaptive_avgpool2d_weight_matrix,
     adaptive_maxpool1d_weight_matrix,
     adaptive_maxpool2d_weight_matrix,
     expanded_path_weight_matrix,
@@ -18,6 +21,17 @@ from paibox.paiir.ir.op_node import StandaloneCompOp
 
 def _active_cols(row: np.ndarray) -> set[int]:
     return set(np.flatnonzero(row).tolist())
+
+
+def _row_active_counts(matrix: np.ndarray) -> np.ndarray:
+    return np.count_nonzero(matrix, axis=1)
+
+
+def _adaptive_avgpool_from_connectivity(
+    matrix: np.ndarray, input_tensor: torch.Tensor
+) -> np.ndarray:
+    summed = matrix @ input_tensor.numpy().reshape(-1)
+    return summed / _row_active_counts(matrix)
 
 
 def _input_node(name: str, shape: torch.Size | tuple[int, ...]) -> InNode:
@@ -61,6 +75,22 @@ EXPANDED_PATH_CASES = (
         predecessor_shape=(1, 1, 7, 7),
         target_shape=(1, 1, 4, 4),
         comp=nn.AdaptiveMaxPool2d((4, 4)),
+        expected_shape=(16, 49),
+        probe_row=1,
+        expected_cols={1, 2, 3, 8, 9, 10},
+    ),
+    ExpandedPathCase(
+        predecessor_shape=(1, 2, 7),
+        target_shape=(1, 2, 4),
+        comp=nn.AdaptiveAvgPool1d(4),
+        expected_shape=(8, 14),
+        probe_row=1,
+        expected_cols={1, 2, 3},
+    ),
+    ExpandedPathCase(
+        predecessor_shape=(1, 1, 7, 7),
+        target_shape=(1, 1, 4, 4),
+        comp=nn.AdaptiveAvgPool2d((4, 4)),
         expected_shape=(16, 49),
         probe_row=1,
         expected_cols={1, 2, 3, 8, 9, 10},
@@ -109,18 +139,81 @@ def test_adaptive_maxpool2d_weight_matrix_respects_sign():
     assert _active_cols(matrix[0]) == {0, 1, 4, 5}
 
 
+def test_adaptive_maxpool2d_weight_matrix_regular_windows_and_channel_isolation():
+    matrix = adaptive_maxpool2d_weight_matrix(2, (2, 8, 8), (2, 4, 4), sign=1)
+
+    assert matrix.shape == (32, 128)
+    assert _active_cols(matrix[0]) == {0, 1, 8, 9}
+    assert _active_cols(matrix[16]) == {64, 65, 72, 73}
+    assert matrix[:16, 64:].sum() == 0
+    assert matrix[16:, :64].sum() == 0
+
+
+def test_adaptive_avgpool2d_weight_matrix_irregular_windows():
+    matrix = adaptive_avgpool2d_weight_matrix(1, (1, 7, 7), (1, 4, 4), sign=1)
+
+    assert matrix.shape == (16, 49)
+    assert _active_cols(matrix[0]) == {0, 1, 7, 8}
+    assert _active_cols(matrix[1]) == {1, 2, 3, 8, 9, 10}
+    assert _active_cols(matrix[15]) == {40, 41, 47, 48}
+
+
+def test_adaptive_avgpool1d_weight_matrix_irregular_windows_and_channels():
+    matrix = adaptive_avgpool1d_weight_matrix(2, (2, 7), (2, 4), sign=1)
+
+    assert matrix.shape == (8, 14)
+    assert _active_cols(matrix[0]) == {0, 1}
+    assert _active_cols(matrix[1]) == {1, 2, 3}
+    assert _active_cols(matrix[4]) == {7, 8}
+    assert _active_cols(matrix[5]) == {8, 9, 10}
+
+
+def test_adaptive_avgpool2d_weight_matrix_respects_sign():
+    matrix = adaptive_avgpool2d_weight_matrix(1, (1, 4, 4), (1, 2, 2), sign=-1)
+
+    assert set(matrix[0].tolist()) == {-1, 0}
+    assert _active_cols(matrix[0]) == {0, 1, 4, 5}
+
+
+def test_adaptive_avgpool1d_weight_matrix_upsampling_shape():
+    matrix = adaptive_avgpool1d_weight_matrix(1, (1, 3), (1, 5), sign=1)
+
+    assert matrix.shape == (5, 3)
+    assert [_active_cols(row) for row in matrix] == [{0}, {0, 1}, {1}, {1, 2}, {2}]
+
+
+def test_adaptive_avgpool1d_matrix_matches_functional_after_window_division():
+    input_tensor = torch.arange(10, dtype=torch.float32).reshape(1, 2, 5)
+    matrix = adaptive_avgpool1d_weight_matrix(2, (2, 5), (2, 3), sign=1)
+
+    averaged = _adaptive_avgpool_from_connectivity(matrix, input_tensor)
+    expected = F.adaptive_avg_pool1d(input_tensor, 3).numpy().reshape(-1)
+
+    np.testing.assert_allclose(averaged, expected)
+
+
+def test_adaptive_avgpool2d_matrix_matches_pytorch_after_window_division():
+    input_tensor = torch.arange(49, dtype=torch.float32).reshape(1, 1, 7, 7)
+    matrix = adaptive_avgpool2d_weight_matrix(1, (1, 7, 7), (1, 4, 4), sign=1)
+
+    averaged = _adaptive_avgpool_from_connectivity(matrix, input_tensor)
+    expected = F.adaptive_avg_pool2d(input_tensor, (4, 4)).numpy().reshape(-1)
+
+    np.testing.assert_allclose(averaged, expected)
+
+
 @pytest.mark.parametrize(
     "case", EXPANDED_PATH_CASES, ids=lambda case: type(case.comp).__name__
 )
-def test_expanded_path_weight_matrix_handles_adaptive_maxpool(case: ExpandedPathCase):
+def test_expanded_path_weight_matrix_handles_adaptive_pool(case: ExpandedPathCase):
     predecessor = _input_node("input", case.predecessor_shape)
     target = _core_node("pool", case.comp, case.target_shape)
     matrix = expanded_path_weight_matrix(
         predecessor,
         target,
-        target.raw_node.comp,
+        target.raw_node.comp,  # type: ignore
         None,
-        1,  # type: ignore
+        1,
     )
 
     assert matrix.shape == case.expected_shape

--- a/tests/paiir/lowering/test_converter.py
+++ b/tests/paiir/lowering/test_converter.py
@@ -23,6 +23,7 @@ from paibox.paiir.ir.op_node import (
     StandaloneCompOp,
 )
 from paibox.paiir.lowering.converter import (
+    build_default_module_map,
     register_module,
     register_neuron,
     torch_to_paiir,
@@ -714,6 +715,14 @@ class TestLegacyClockDrivenCompatibility:
 
 
 class TestSpikingJellyLayerCanonicalization:
+    def test_adaptive_pool_modules_use_default_module_map(self):
+        module_map = build_default_module_map()
+
+        assert nn.AdaptiveMaxPool1d in module_map
+        assert nn.AdaptiveMaxPool2d in module_map
+        assert nn.AdaptiveAvgPool1d in module_map
+        assert nn.AdaptiveAvgPool2d in module_map
+
     def test_conv2d_layer_lowers_to_canonical_conv2d(self):
         class Model(nn.Module):
             def __init__(self):
@@ -891,19 +900,7 @@ class TestSpikingJellyLayerCanonicalization:
         assert len(pool_nodes) == 1
         assert pool_nodes[0].comp.output_size == 4
 
-    def test_sj_adaptive_avgpool2d_is_rejected_as_layer_wrapper(self):
-        class Model(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.pool = layer.AdaptiveAvgPool2d((4, 4), step_mode="m")
-
-            def forward(self, x):
-                return self.pool(x)
-
-        with pytest.raises(UnsupportedOpError, match="AdaptiveAvgPool2d"):
-            torch_to_paiir(Model().eval(), torch.randn(1, 3, 7, 7))
-
-    def test_adaptive_avgpool2d_is_not_supported_in_this_slice(self):
+    def test_adaptive_avgpool2d_lowers_to_standalone_comp(self):
         class Model(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -912,8 +909,72 @@ class TestSpikingJellyLayerCanonicalization:
             def forward(self, x):
                 return self.pool(x)
 
-        with pytest.raises(UnsupportedOpError, match="AdaptiveAvgPool2d"):
-            torch_to_paiir(Model().eval(), make_img_3ch_8x8())
+        graph = torch_to_paiir(Model().eval(), torch.randn(1, 3, 7, 7))
+
+        pool_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.AdaptiveAvgPool2d)
+        ]
+        assert len(pool_nodes) == 1
+        assert pool_nodes[0].comp.output_size == (4, 4)
+
+    def test_adaptive_avgpool1d_lowers_to_standalone_comp(self):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = nn.AdaptiveAvgPool1d(4)
+
+            def forward(self, x):
+                return self.pool(x)
+
+        graph = torch_to_paiir(Model().eval(), torch.randn(1, 2, 7))
+
+        pool_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.AdaptiveAvgPool1d)
+        ]
+        assert len(pool_nodes) == 1
+        assert pool_nodes[0].comp.output_size == 4
+
+    @pytest.mark.parametrize(
+        ("module", "sample", "expected_type"),
+        [
+            (
+                layer.AdaptiveAvgPool1d(4, step_mode="m"),
+                torch.randn(1, 2, 7),
+                nn.AdaptiveAvgPool1d,
+            ),
+            (
+                layer.AdaptiveAvgPool2d((4, 4), step_mode="m"),
+                torch.randn(1, 3, 7, 7),
+                nn.AdaptiveAvgPool2d,
+            ),
+        ],
+        ids=["layer-adaptive-avgpool1d", "layer-adaptive-avgpool2d"],
+    )
+    def test_sj_adaptive_avgpool_layers_lower_to_standalone_comp(
+        self, module: nn.Module, sample: torch.Tensor, expected_type: type[nn.Module]
+    ):
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = module
+
+            def forward(self, x):
+                return self.pool(x)
+
+        graph = torch_to_paiir(Model().eval(), sample)
+
+        pool_nodes = [
+            node
+            for node in graph.nodes.values()
+            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, expected_type)
+        ]
+        assert len(pool_nodes) == 1
 
     @pytest.mark.parametrize(
         ("module", "sample"),

--- a/tests/paiir/lowering/test_converter.py
+++ b/tests/paiir/lowering/test_converter.py
@@ -972,7 +972,8 @@ class TestSpikingJellyLayerCanonicalization:
         pool_nodes = [
             node
             for node in graph.nodes.values()
-            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, expected_type)
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, expected_type)
         ]
         assert len(pool_nodes) == 1
 

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -33,6 +33,7 @@ from paibox.paiir.ir.op_node import (
     StandaloneActOp,
     StandaloneCompOp,
 )
+from paibox.paiir.ir.signal_domain import SignalDomain
 from paibox.paiir.lowering.converter import _analyze_graph, _LoweringContext
 from paibox.paiir.nn import SumPool1d, SumPool2d
 from paibox.paiir.pipeline.avgpool import (
@@ -117,6 +118,34 @@ class SpikingJellyLayerCompileSmoke(nn.Module):
 
     def forward(self, x: Tensor) -> Tensor:
         return self.linear(self.flatten(self.pool(x)))
+
+
+class AdaptiveAvgPoolCompileSmoke(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.pool = nn.AdaptiveAvgPool2d((4, 4))
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.pool(x)
+
+
+class AdaptiveAvgPoolRelu(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.pool = nn.AdaptiveAvgPool2d((4, 4))
+        self.relu = nn.ReLU()
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.relu(self.pool(x))
+
+
+class AdaptiveMaxPoolCompileSmoke(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.pool = nn.AdaptiveMaxPool2d((4, 4))
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.pool(x)
 
 
 class TransformThenLinear(nn.Module):
@@ -393,6 +422,52 @@ class TestCompileBasic:
         assert graph.predecessors(pool_nodes[0].name) == ["InputNode_0"]
         assert pool_nodes[0].core_params.input_sign is not None
         assert pool_nodes[0].core_params.input_width is not None
+
+    def test_adaptive_avgpool2d_standalone_compiles(self):
+        graph = compile_to_paiir(AdaptiveAvgPoolCompileSmoke(), torch.randn(1, 3, 7, 7))
+
+        pool_nodes = [
+            node
+            for node in find_nodes(graph, StandaloneCompOp)
+            if isinstance(node.comp, nn.AdaptiveAvgPool2d)
+        ]
+        assert len(pool_nodes) == 1
+        assert graph.predecessors(pool_nodes[0].name) == ["InputNode_0"]
+        assert pool_nodes[0].core_params.input_sign is not None
+        assert pool_nodes[0].core_params.input_width is not None
+
+    def test_adaptive_maxpool2d_standalone_compiles_as_value_maxpool(self):
+        graph = compile_to_paiir(AdaptiveMaxPoolCompileSmoke(), torch.randn(1, 3, 7, 7))
+
+        pool_nodes = [
+            node
+            for node in find_nodes(graph, StandaloneCompOp)
+            if isinstance(node.comp, nn.AdaptiveMaxPool2d)
+        ]
+        assert len(pool_nodes) == 1
+        assert graph.predecessors(pool_nodes[0].name) == ["InputNode_0"]
+        assert pool_nodes[0].signal_semantics.output_domain is SignalDomain.VALUE
+        assert pool_nodes[0].core_params.input_sign is not None
+        assert pool_nodes[0].core_params.input_width is not None
+
+    def test_adaptive_avgpool2d_relu_does_not_use_fixed_avgpool_fusion(self):
+        graph = compile_to_paiir(AdaptiveAvgPoolRelu(), torch.randn(1, 3, 7, 7))
+
+        pool_nodes = [
+            node
+            for node in find_nodes(graph, StandaloneCompOp)
+            if isinstance(node.comp, nn.AdaptiveAvgPool2d)
+        ]
+        act_nodes = find_nodes(graph, StandaloneActOp)
+        seq_nodes = [
+            node
+            for node in find_nodes(graph, SequentialOp)
+            if isinstance(node.comp, nn.AdaptiveAvgPool2d)
+        ]
+        assert len(pool_nodes) == 1
+        assert len(act_nodes) == 1
+        assert seq_nodes == []
+        assert graph.predecessors(act_nodes[0].name) == [pool_nodes[0].name]
 
 
 class TestDataFormat:


### PR DESCRIPTION
## Summary

- Lower `nn.AdaptiveAvgPool1d/2d` and SpikingJelly `layer.AdaptiveAvgPool1d/2d` through the existing compute-module path.
- Classify adaptive pooling semantics without folding adaptive avgpool into fixed-window AvgPool fusion or delayed-division logic.
- Add backendv2 dense connectivity expansion for adaptive avgpool 1d/2d, sharing the optimized adaptive pool window expansion path with adaptive maxpool.
- Add lowering, pipeline, and backend tests covering irregular windows, channel isolation, sign handling, and PyTorch functional avgpool equivalence after window division.