### PR TITLE
Feat(paiir): canonicalize add chains before fusion

### DIFF
--- a/paibox/paiir/pipeline/compile.py
+++ b/paibox/paiir/pipeline/compile.py
@@ -6,16 +6,18 @@ conversion pipeline:
 1. :func:`torch_to_paiir` -- FX trace and 1:1 node mapping
 2. pre-fusion fixed-point rewrites -- canonicalize transform chains and
    commute transparent pre-activation transforms
-3. :func:`specialize_general_adds` -- narrow expression-layer add nodes into
+3. :func:`flatten_general_add_chains` -- collapse deployable binary add chains
+   into n-ary add nodes
+4. :func:`specialize_general_adds` -- narrow expression-layer add nodes into
    deployable add IR where possible
-4. :func:`fuse_to_offline_cores` -- choose topology, rewrite nodes, and apply
+5. :func:`fuse_to_offline_cores` -- choose topology, rewrite nodes, and apply
    AvgPool deployment params
-5. post-fusion fixed-point rewrites with analysis refresh
-6. :func:`assign_tick_params` -- assign timing parameters
-7. :func:`calibrate_avgpool_thresholds` -- optional AvgPool threshold refinement
-8. :func:`validate_compiled_graph` -- final post-pass validation before returning
+6. post-fusion fixed-point rewrites with analysis refresh
+7. :func:`assign_tick_params` -- assign timing parameters
+8. :func:`calibrate_avgpool_thresholds` -- optional AvgPool threshold refinement
+9. :func:`validate_compiled_graph` -- final post-pass validation before returning
    the graph
-9. :func:`validate_deployable_graph` -- reject residual expression-layer IR
+10. :func:`validate_deployable_graph` -- reject residual expression-layer IR
 
 Use :func:`compile_to_paiir` for a one-step compilation, or call the
 individual passes directly for fine-grained control.
@@ -37,6 +39,7 @@ from .passes import (
     analyze_graph,
     assign_tick_params,
     calibrate_avgpool_thresholds,
+    flatten_general_add_chains,
     fuse_to_offline_cores,
     specialize_general_adds,
     validate_compiled_graph,
@@ -80,22 +83,24 @@ def compile_to_paiir(
     1. :func:`torch_to_paiir` -- FX trace and 1:1 node mapping
     2. pre-fusion fixed-point rewrite phase -- canonicalize transform chains and
        commute transparent pre-activation transforms
-    3. :func:`specialize_general_adds` -- narrow expression-layer add nodes
+    3. :func:`flatten_general_add_chains` -- collapse deployable binary add
+       chains into n-ary add nodes
+    4. :func:`specialize_general_adds` -- narrow expression-layer add nodes
        into deployable add IR where possible
-    4. :func:`fuse_to_offline_cores` -- choose topology, rewrite nodes, and
+    5. :func:`fuse_to_offline_cores` -- choose topology, rewrite nodes, and
        apply AvgPool deployment params
-    5. analysis phase -- validate graph, infer signal semantics, infer data formats
-    6. delayed AvgPool division rewrite when an exact-sum single-consumer chain
+    6. analysis phase -- validate graph, infer signal semantics, infer data formats
+    7. delayed AvgPool division rewrite when an exact-sum single-consumer chain
        can materialize the divisor safely at a later endpoint
-    7. standalone AvgPool auto-rewrite that depends on those analyses
-    8. re-run the analysis phase if a rewrite changed the graph
-    9. :func:`assign_tick_params` -- assign timing parameters
-    10. :func:`calibrate_avgpool_thresholds` -- (experimental) refine shared-core
+    8. standalone AvgPool auto-rewrite that depends on those analyses
+    9. re-run the analysis phase if a rewrite changed the graph
+    10. :func:`assign_tick_params` -- assign timing parameters
+    11. :func:`calibrate_avgpool_thresholds` -- (experimental) refine shared-core
        AvgPool+LIF thresholds via offline integer search
-    11. :func:`validate_compiled_graph` -- final post-pass graph validation
+    12. :func:`validate_compiled_graph` -- final post-pass graph validation
         after connectivity cleanup, signal-semantics propagation, data-format
         propagation, and tick assignment
-    12. :func:`validate_deployable_graph` -- ensure no frontend-only IR remains
+    13. :func:`validate_deployable_graph` -- ensure no frontend-only IR remains
     """
     cfg = compile_config or CompileConfig()
     _tick_duration = tick_duration if tick_duration is not None else cfg.tick_duration
@@ -122,6 +127,7 @@ def compile_to_paiir(
     )
 
     graph = _run_pre_fusion_rewrite_phase(graph)
+    graph = flatten_general_add_chains(graph)
     graph = specialize_general_adds(graph)
     graph = fuse_to_offline_cores(
         graph, _enable_split_avgpool_lif, _enable_avgpool_calibration

--- a/paibox/paiir/pipeline/passes.py
+++ b/paibox/paiir/pipeline/passes.py
@@ -17,6 +17,7 @@ Two validation stages live in this module:
 
 import math
 import warnings
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal, TypedDict
 
@@ -24,10 +25,10 @@ import torch
 from paicorelib import AddPotentialMode, DataSign, DataWidth, OutputType, SNNMode
 
 from ..exceptions import GraphCleanupWarning, GraphValidationError
-from ..ir.add_ops import GeneralAddOp, PotentialAddOp
+from ..ir.add_ops import AddOperandKind, AddOperandSpec, GeneralAddOp, PotentialAddOp
 from ..ir.core_neuron import CoreNeuronV25
 from ..ir.graph import Edge, PAIIRGraph
-from ..ir.ir_base import InputNode, OutputNode, PAIIRNode
+from ..ir.ir_base import InputNode, OutputNode, PAIIRNode, TensorLayout
 from ..ir.maxpool_export import refresh_maxpool_export_kind
 from ..ir.op_node import (
     AccumulateOp,
@@ -59,6 +60,7 @@ from .fusion_utils import _materialize_shared_sequential
 from .graph_utils import (
     collect_effective_predecessor_values,
     is_format_transparent_routing_node,
+    is_order_preserving_transform_node,
     is_standalone_maxpool,
 )
 
@@ -67,6 +69,7 @@ __all__ = [
     "assign_tick_params",
     "calibrate_avgpool_thresholds",
     "CalibrationResult",
+    "flatten_general_add_chains",
     "fuse_to_offline_cores",
     "propagate_signal_semantics",
     "propagate_data_format",
@@ -168,6 +171,233 @@ def _single_output_shape(node: OpNode) -> torch.Size:
     if node.num_outputs != 1:
         return torch.Size()
     return node.output_layouts[0].shape
+
+
+@dataclass(frozen=True, slots=True)
+class _FlatAddOperand:
+    source_name: str
+    source_port: int
+    coeff: int
+    layout: TensorLayout
+
+
+@dataclass(frozen=True, slots=True)
+class _FlatAddPlan:
+    operands: tuple[_FlatAddOperand, ...]
+    consumed_adds: frozenset[str]
+    consumed_transforms: frozenset[str]
+    changed: bool
+
+
+def flatten_general_add_chains(graph: PAIIRGraph) -> PAIIRGraph:
+    """Flatten single-use chains of :class:`GeneralAddOp` before specialization.
+
+    FX represents ``a + b + c`` as a chain of binary adds.  Keeping that shape
+    prevents later passes from seeing all signed paths at once.  Flattening
+    serves both no-activation chains that specialize directly to an n-ary
+    ``PotentialAddOp`` and activated chains that later fuse as
+    ``PotentialAddOp -> ActivationOp -> AccumulateOp``.  This pass rewrites
+    only the narrow subset that can still be specialized to deployable
+    potential add:
+
+    - tensor operands only
+    - no broadcasted operands
+    - per-path coefficients in ``{-1, +1}``
+    - nested add nodes are single-use
+
+    Order-preserving, shape-preserving ``TransformOp`` wrappers are treated as
+    transparent when they are single-use.  Shape-changing transforms remain in
+    the graph because ``AccumulateOp`` does not model per-path reshape stages.
+    """
+    flattened = graph.clone_shallow()
+    changed_any = False
+    changed = True
+
+    while changed:
+        changed = False
+        for name in flattened.topo_sort():
+            node = flattened.nodes.get(name)
+            if not isinstance(node, GeneralAddOp):
+                continue
+
+            if _try_flatten_general_add_node(flattened, name):
+                changed = True
+                changed_any = True
+                break
+
+    return flattened if changed_any else graph
+
+
+def _try_flatten_general_add_node(graph: PAIIRGraph, name: str) -> bool:
+    node = graph.nodes.get(name)
+    if not isinstance(node, GeneralAddOp):
+        return False
+
+    plan = _collect_flat_add_operands(graph, name, 1, frozenset())
+    if plan is None or not plan.changed or not plan.consumed_adds:
+        return False
+
+    if _has_duplicate_flat_add_sources(plan.operands):
+        return False
+
+    output_shape = _single_output_shape(node)
+    if output_shape and any(
+        operand.layout.shape and operand.layout.shape != output_shape
+        for operand in plan.operands
+    ):
+        return False
+
+    replacement = GeneralAddOp(
+        tuple(
+            AddOperandSpec(operand.coeff, AddOperandKind.TENSOR, idx)
+            for idx, operand in enumerate(plan.operands)
+        )
+    )
+    replacement.input_layouts = tuple(operand.layout for operand in plan.operands)
+    replacement.output_layouts = node.output_layouts
+
+    outgoing = graph.outgoing_edges(name)
+    graph.add_node(replacement)
+    for idx, operand in enumerate(plan.operands):
+        graph.add_edge(
+            operand.source_name,
+            replacement.name,
+            src_port=operand.source_port,
+            dst_port=idx,
+        )
+    for edge in outgoing:
+        graph.add_edge(
+            replacement.name, edge.dst, src_port=edge.src_port, dst_port=edge.dst_port
+        )
+
+    graph.remove_node(name)
+    for consumed_name in sorted(plan.consumed_adds):
+        if consumed_name in graph.nodes:
+            graph.remove_node(consumed_name)
+    for consumed_name in sorted(plan.consumed_transforms):
+        if consumed_name in graph.nodes:
+            graph.remove_node(consumed_name)
+
+    return True
+
+
+def _collect_flat_add_operands(
+    graph: PAIIRGraph, add_name: str, outer_coeff: int, seen_adds: frozenset[str]
+) -> _FlatAddPlan | None:
+    if add_name in seen_adds:
+        return None
+
+    node = graph.nodes.get(add_name)
+    if not isinstance(node, GeneralAddOp):
+        return None
+    if not _is_flattenable_general_add(node):
+        return None
+
+    incoming_by_port = _incoming_edges_by_port(graph, add_name)
+    operands: list[_FlatAddOperand] = []
+    consumed_adds: set[str] = set()
+    consumed_transforms: set[str] = set()
+    changed = False
+
+    for operand in node.operands:
+        if operand.kind is not AddOperandKind.TENSOR:
+            return None
+        assert operand.tensor_port is not None
+        source_edge = incoming_by_port.get(operand.tensor_port)
+        if source_edge is None:
+            return None
+
+        coeff = outer_coeff * operand.coeff
+        if coeff not in (-1, 1):
+            return None
+
+        transparent_edge = _transparent_add_operand_edge(graph, source_edge)
+        if transparent_edge is None:
+            return None
+
+        source_edge, consumed_transform = transparent_edge
+        if consumed_transform is not None:
+            consumed_transforms.add(consumed_transform)
+
+        source_node = graph.nodes[source_edge.src]
+        if isinstance(source_node, GeneralAddOp):
+            if len(graph.successors(source_edge.src)) != 1:
+                return None
+            nested = _collect_flat_add_operands(
+                graph, source_edge.src, coeff, seen_adds | {add_name}
+            )
+            if nested is None:
+                return None
+
+            operands.extend(nested.operands)
+            consumed_adds.add(source_edge.src)
+            consumed_adds.update(nested.consumed_adds)
+            consumed_transforms.update(nested.consumed_transforms)
+            changed = True
+            continue
+
+        layout = _edge_output_layout(graph, source_edge)
+        if layout is None:
+            return None
+        operands.append(
+            _FlatAddOperand(source_edge.src, source_edge.src_port, coeff, layout)
+        )
+
+    return _FlatAddPlan(
+        tuple(operands),
+        frozenset(consumed_adds),
+        frozenset(consumed_transforms),
+        changed,
+    )
+
+
+def _is_flattenable_general_add(node: GeneralAddOp) -> bool:
+    if node.has_const_operands or node.has_broadcasted_operands:
+        return False
+    if len(node.tensor_operands) < 2:
+        return False
+    return all(coeff in (-1, 1) for coeff in node.tensor_coeffs)
+
+
+def _incoming_edges_by_port(graph: PAIIRGraph, name: str) -> dict[int, Edge]:
+    return {edge.dst_port: edge for edge in graph.incoming_edges(name)}
+
+
+def _transparent_add_operand_edge(
+    graph: PAIIRGraph, edge: Edge
+) -> tuple[Edge, str | None] | None:
+    node = graph.nodes.get(edge.src)
+    if not isinstance(node, TransformOp):
+        return edge, None
+    if len(graph.successors(edge.src)) != 1:
+        return None
+    if len(graph.predecessors(edge.src)) != 1:
+        return None
+    if not is_order_preserving_transform_node(node):
+        return None
+    if node.input_layouts != node.output_layouts:
+        return None
+
+    return graph.incoming_edges(edge.src)[0], edge.src
+
+
+def _edge_output_layout(graph: PAIIRGraph, edge: Edge) -> TensorLayout | None:
+    node = graph.nodes.get(edge.src)
+    if isinstance(node, InputNode):
+        return node.layout
+    if isinstance(node, OpNode) and edge.src_port < len(node.output_layouts):
+        return node.output_layouts[edge.src_port]
+    return None
+
+
+def _has_duplicate_flat_add_sources(operands: Sequence[_FlatAddOperand]) -> bool:
+    seen: set[tuple[str, int]] = set()
+    for operand in operands:
+        key = (operand.source_name, operand.source_port)
+        if key in seen:
+            return True
+        seen.add(key)
+    return False
 
 
 def specialize_general_adds(graph: PAIIRGraph) -> PAIIRGraph:

--- a/tests/paiir/conftest.py
+++ b/tests/paiir/conftest.py
@@ -22,6 +22,7 @@ from paibox.paiir.pipeline.layout_cross_node_elision import (
     commute_pre_activation_transforms,
 )
 from paibox.paiir.pipeline.passes import (
+    flatten_general_add_chains,
     fuse_to_offline_cores,
     propagate_data_format,
     propagate_signal_semantics,
@@ -409,8 +410,9 @@ def convert_and_fuse(model: nn.Module, *sample_inputs: Tensor) -> PAIIRGraph:
     """Trace a PyTorch model to PAIIR and fuse."""
     unfused = torch_to_paiir(model, *sample_inputs)
     unfused = canonicalize_layout_chains(unfused)
-    unfused = specialize_general_adds(unfused)
     unfused = commute_pre_activation_transforms(unfused)
+    unfused = flatten_general_add_chains(unfused)
+    unfused = specialize_general_adds(unfused)
     return fuse_to_offline_cores(unfused)
 
 

--- a/tests/paiir/ir/test_add_ops.py
+++ b/tests/paiir/ir/test_add_ops.py
@@ -15,6 +15,17 @@ class TestPotentialAddOp:
         assert out.shape == x1.shape
         assert torch.allclose(out, x1 - x2)
 
+    def test_nary_elementwise_add_forward(self):
+        op = PotentialAddOp(op_signs=(1, -1, 1))
+        x1 = torch.randn(1, 4, 8, 8)
+        x2 = torch.randn(1, 4, 8, 8)
+        x3 = torch.randn(1, 4, 8, 8)
+
+        out = op(x1, x2, x3)
+
+        assert out.shape == x1.shape
+        assert torch.allclose(out, x1 - x2 + x3)
+
     def test_requires_two_paths(self):
         with pytest.raises(ValueError, match="at least two signed input paths"):
             PotentialAddOp(op_signs=(1,))

--- a/tests/paiir/pipeline/test_graph_simulation.py
+++ b/tests/paiir/pipeline/test_graph_simulation.py
@@ -1643,7 +1643,8 @@ class TestStandaloneOpSimulation:
         pool_nodes = [
             node
             for node in graph.nodes.values()
-            if isinstance(node, StandaloneCompOp) and isinstance(node.comp, nn.AvgPool1d)
+            if isinstance(node, StandaloneCompOp)
+            and isinstance(node.comp, nn.AvgPool1d)
         ]
         assert len(pool_nodes) == 1
 

--- a/tests/paiir/pipeline/test_passes.py
+++ b/tests/paiir/pipeline/test_passes.py
@@ -12,7 +12,7 @@ in `PAIBox/paibox/paiir/pipeline/passes.py`:
 import pytest
 import torch
 from paicorelib import DataSign, DataWidth, OutputType, PoolingMode, SNNMode
-from spikingjelly.activation_based import neuron as sj
+from spikingjelly.activation_based import neuron
 from torch import nn
 
 from paibox.paiir.ir.add_ops import (
@@ -36,6 +36,7 @@ from paibox.paiir.ir.op_node import (
     StandaloneActOp,
     StandaloneCompOp,
     TensorLayout,
+    TransformOp,
 )
 from paibox.paiir.ir.signal_domain import SignalDomain
 from paibox.paiir.lowering.converter import torch_to_paiir
@@ -44,6 +45,7 @@ from paibox.paiir.pipeline.passes import (
     GraphCleanupWarning,
     GraphValidationError,
     assign_tick_params,
+    flatten_general_add_chains,
     fuse_to_offline_cores,
     propagate_data_format,
     propagate_signal_semantics,
@@ -168,7 +170,7 @@ class TestSNNConversion:
         assert len(seq_nodes) == 2
 
         conv_ops = [n for n in seq_nodes if isinstance(n.comp, nn.Conv2d)]
-        groups = sorted([n.comp.groups for n in conv_ops])
+        groups = sorted([n.comp.groups for n in conv_ops])  # type: ignore
         assert groups == [1, 16]
 
     def test_flatten_transition(self):
@@ -212,7 +214,7 @@ class TestANNConversion:
 
         for node in fused.nodes.values():
             if hasattr(node, "comp"):
-                assert not isinstance(node.comp, (nn.BatchNorm1d, nn.BatchNorm2d))
+                assert not isinstance(node.comp, (nn.BatchNorm1d, nn.BatchNorm2d))  # type: ignore
 
     def test_subtract_branch(self):
         """Two linear branches with subtraction -> tanh."""
@@ -223,6 +225,377 @@ class TestANNConversion:
         assert len(accum_nodes) == 1
         assert accum_nodes[0].signs == (1, -1)
         assert isinstance(accum_nodes[0].act.lut, LutTanh)
+
+
+class TestGeneralAddChainFlattening:
+    """Test add-chain canonicalization before add specialization."""
+
+    class LinearAddChain(nn.Module):
+        def __init__(self, num_terms: int):
+            super().__init__()
+            self.linears = nn.ModuleList(nn.Linear(8, 4) for _ in range(num_terms))
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            terms = [linear(x) for linear in self.linears]
+            result = terms[0]
+            for term in terms[1:]:
+                result = result + term
+            return self.relu(result)
+
+    class SubtractLeftChain(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_a = nn.Linear(8, 4)
+            self.linear_b = nn.Linear(8, 4)
+            self.linear_c = nn.Linear(8, 4)
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            return self.relu(self.linear_a(x) - self.linear_b(x) + self.linear_c(x))
+
+    class SubtractRightChain(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_a = nn.Linear(8, 4)
+            self.linear_b = nn.Linear(8, 4)
+            self.linear_c = nn.Linear(8, 4)
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            return self.relu(self.linear_a(x) + (self.linear_b(x) - self.linear_c(x)))
+
+    class ThreeConvLIFAdd(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv_a = nn.Conv2d(3, 4, 3, padding=1)
+            self.conv_b = nn.Conv2d(3, 4, 3, padding=1)
+            self.conv_c = nn.Conv2d(3, 4, 3, padding=1)
+            self.lif = neuron.LIFNode(tau=2.0)
+
+        def forward(self, x):
+            return self.lif(self.conv_a(x) + self.conv_b(x) + self.conv_c(x))
+
+    class MultiInputThreeLinearAdd(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_a = nn.Linear(8, 4)
+            self.linear_b = nn.Linear(8, 4)
+            self.linear_c = nn.Linear(8, 4)
+            self.relu = nn.ReLU()
+
+        def forward(self, x, y, z):
+            return self.relu(self.linear_a(x) + self.linear_b(y) + self.linear_c(z))
+
+    class OrderPreservingTransformChain(nn.Module):
+        def __init__(self, transform_kind: str):
+            super().__init__()
+            self.transform_kind = transform_kind
+            self.linear_a = nn.Linear(8, 4)
+            self.linear_b = nn.Linear(8, 4)
+            self.linear_c = nn.Linear(8, 4)
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            a = self.linear_a(x)
+            if self.transform_kind == "view":
+                a = a.view_as(a)
+            elif self.transform_kind == "reshape":
+                a = a.reshape(a.shape)
+            elif self.transform_kind == "flatten":
+                a = a.flatten(1, 1)
+            else:
+                raise AssertionError(f"unknown transform_kind={self.transform_kind}")
+            return self.relu(a + self.linear_b(x) + self.linear_c(x))
+
+    class LayoutTransformOperandChain(nn.Module):
+        def __init__(self, transform_kind: str):
+            super().__init__()
+            self.transform_kind = transform_kind
+            self.conv_a = nn.Conv2d(3, 4, 1)
+            self.conv_b = nn.Conv2d(3, 4, 1)
+            self.conv_c = nn.Conv2d(3, 4, 1)
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            b = self.conv_b(x)
+            if self.transform_kind == "transpose":
+                b = b.transpose(2, 3)
+            elif self.transform_kind == "permute":
+                b = b.permute(0, 1, 3, 2)
+            else:
+                raise AssertionError(f"unknown transform_kind={self.transform_kind}")
+            return self.relu(self.conv_a(x) + b + self.conv_c(x))
+
+    class ShapeChangingFlattenOperandChain(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv_a = nn.Conv2d(1, 1, 1)
+            self.linear_b = nn.Linear(4, 4)
+            self.linear_c = nn.Linear(4, 4)
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            flattened_x = x.flatten(1)
+            return self.relu(
+                self.conv_a(x).flatten(1)
+                + self.linear_b(flattened_x)
+                + self.linear_c(flattened_x)
+            )
+
+    class MultiConsumerMiddleAdd(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_a = nn.Linear(8, 4)
+            self.linear_b = nn.Linear(8, 4)
+            self.linear_c = nn.Linear(8, 4)
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            mid = self.linear_a(x) + self.linear_b(x)
+            return self.relu(mid + self.linear_c(x)), mid
+
+    class MultiConsumerTransformOperand(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_a = nn.Linear(8, 4)
+            self.linear_b = nn.Linear(8, 4)
+            self.linear_c = nn.Linear(8, 4)
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            a = self.linear_a(x)
+            transformed = a.view_as(a)
+            return (
+                self.relu(transformed + self.linear_b(x) + self.linear_c(x)),
+                transformed,
+            )
+
+    class ConstOperandChain(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_a = nn.Linear(8, 4)
+            self.linear_b = nn.Linear(8, 4)
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            return self.relu(self.linear_a(x) + (self.linear_b(x) + 1))
+
+    class BroadcastOperandChain(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_a = nn.Linear(8, 4)
+            self.linear_b = nn.Linear(8, 1)
+            self.linear_c = nn.Linear(8, 4)
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            return self.relu(self.linear_a(x) + (self.linear_b(x) + self.linear_c(x)))
+
+    class RepeatedProducerChain(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_a = nn.Linear(8, 4)
+            self.linear_b = nn.Linear(8, 4)
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            a = self.linear_a(x)
+            return self.relu(a + self.linear_b(x) + a)
+
+    class NonUnitCoeffChain(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_a = nn.Linear(8, 4)
+            self.linear_b = nn.Linear(8, 4)
+            self.linear_c = nn.Linear(8, 4)
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            return self.relu(
+                self.linear_a(x)
+                + torch.add(self.linear_b(x), self.linear_c(x), alpha=2)
+            )
+
+    class NoActivationAddChain(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_a = nn.Linear(8, 4)
+            self.linear_b = nn.Linear(8, 4)
+            self.linear_c = nn.Linear(8, 4)
+
+        def forward(self, x):
+            return self.linear_a(x) + self.linear_b(x) + self.linear_c(x)
+
+    class NoActivationSubtractChain(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_a = nn.Linear(8, 4)
+            self.linear_b = nn.Linear(8, 4)
+            self.linear_c = nn.Linear(8, 4)
+
+        def forward(self, x):
+            return self.linear_a(x) - self.linear_b(x) + self.linear_c(x)
+
+    def _single_accumulate(self, compiled):
+        accum_nodes = find_nodes(compiled, AccumulateOp)
+        assert len(accum_nodes) == 1
+        assert find_nodes(compiled, PotentialAddOp) == []
+        return accum_nodes[0]
+
+    def _single_potential_add(self, compiled):
+        add_nodes = find_nodes(compiled, PotentialAddOp)
+        assert len(add_nodes) == 1
+        assert find_nodes(compiled, GeneralAddOp) == []
+        assert find_nodes(compiled, AccumulateOp) == []
+        return add_nodes[0]
+
+    def _assert_binary_add_chain_not_flattened(self, model, *sample_inputs):
+        flattened, add_nodes = self._flattened_add_nodes(model, *sample_inputs)
+
+        assert len(add_nodes) == 2
+        assert [node.coeffs for node in add_nodes] == [(1, 1), (1, 1)]
+        return flattened
+
+    def _flattened_add_nodes(self, model, *sample_inputs):
+        graph = torch_to_paiir(model, *sample_inputs)
+        flattened = flatten_general_add_chains(graph)
+        return flattened, find_nodes(flattened, GeneralAddOp)
+
+    def _assert_not_accumulated(self, model, *sample_inputs):
+        compiled = compile_to_paiir(model, *sample_inputs)
+        assert find_nodes(compiled, AccumulateOp) == []
+        assert len(find_nodes(compiled, PotentialAddOp)) == 2
+        return compiled
+
+    @pytest.mark.parametrize(
+        ("num_terms", "expected_signs"),
+        [(3, (1, 1, 1)), (4, (1, 1, 1, 1))],
+        ids=["three_terms", "four_terms"],
+    )
+    def test_linear_chain_compiles_to_single_accumulate(
+        self, num_terms, expected_signs
+    ):
+        compiled = compile_to_paiir(self.LinearAddChain(num_terms), make_vec_8d())
+
+        accum = self._single_accumulate(compiled)
+        assert len(accum.comps) == num_terms
+        assert accum.signs == expected_signs
+        assert isinstance(accum.act, ANNNodeV25)
+
+    def test_conv_lif_chain_compiles_to_single_accumulate(self):
+        compiled = compile_to_paiir(self.ThreeConvLIFAdd(), make_img_3ch_8x8())
+
+        accum = self._single_accumulate(compiled)
+        assert len(accum.comps) == 3
+        assert accum.signs == (1, 1, 1)
+        assert isinstance(accum.act, LIFNodeV25)
+        assert {type(comp) for comp in accum.comps} == {nn.Conv2d}
+
+    def test_multi_input_chain_compiles_to_single_accumulate(self):
+        compiled = compile_to_paiir(
+            self.MultiInputThreeLinearAdd(), make_vec_8d(), make_vec_8d(), make_vec_8d()
+        )
+
+        accum = self._single_accumulate(compiled)
+        assert len(accum.comps) == 3
+        assert accum.signs == (1, 1, 1)
+        assert len(compiled.input_nodes()) == 3
+
+    @pytest.mark.parametrize(
+        ("model_cls", "expected_signs"),
+        [(SubtractLeftChain, (1, -1, 1)), (SubtractRightChain, (1, 1, -1))],
+        ids=["a_minus_b_plus_c", "a_plus_b_minus_c"],
+    )
+    def test_chain_signs_are_preserved(self, model_cls, expected_signs):
+        compiled = compile_to_paiir(model_cls(), make_vec_8d())
+
+        accum = self._single_accumulate(compiled)
+        assert accum.signs == expected_signs
+
+    @pytest.mark.parametrize(
+        ("model_cls", "expected_signs"),
+        [
+            (NoActivationAddChain, (1, 1, 1)),
+            (NoActivationSubtractChain, (1, -1, 1)),
+        ],
+        ids=["add", "subtract"],
+    )
+    def test_no_activation_chain_compiles_to_nary_potential_add(
+        self, model_cls, expected_signs
+    ):
+        compiled = compile_to_paiir(model_cls(), make_vec_8d())
+
+        add = self._single_potential_add(compiled)
+        assert add.signs == expected_signs
+        assert len(find_nodes(compiled, StandaloneCompOp)) == 3
+
+    @pytest.mark.parametrize("transform_kind", ["view", "reshape", "flatten"])
+    def test_shape_preserving_order_preserving_operand_transform_flattens(
+        self, transform_kind
+    ):
+        flattened, add_nodes = self._flattened_add_nodes(
+            self.OrderPreservingTransformChain(transform_kind), make_vec_8d()
+        )
+
+        assert len(add_nodes) == 1
+        assert add_nodes[0].coeffs == (1, 1, 1)
+        assert find_nodes(flattened, TransformOp) == []
+
+    @pytest.mark.parametrize("transform_kind", ["transpose", "permute"])
+    def test_layout_transform_operand_does_not_flatten_or_accumulate(
+        self, transform_kind
+    ):
+        x = torch.randn(1, 3, 4, 4)
+        model = self.LayoutTransformOperandChain(transform_kind)
+
+        flattened = self._assert_binary_add_chain_not_flattened(model, x)
+        assert find_nodes(flattened, TransformOp)
+
+        self._assert_not_accumulated(model, x)
+
+    def test_shape_changing_order_preserving_transform_does_not_flatten(self):
+        x = torch.randn(1, 1, 2, 2)
+        model = self.ShapeChangingFlattenOperandChain()
+
+        flattened = self._assert_binary_add_chain_not_flattened(model, x)
+        transform_nodes = find_nodes(flattened, TransformOp)
+        assert transform_nodes
+        assert any(
+            node.input_layouts[0].shape != node.output_layouts[0].shape
+            for node in transform_nodes
+        )
+
+        self._assert_not_accumulated(model, x)
+
+    @pytest.mark.parametrize(
+        "model_cls",
+        [MultiConsumerMiddleAdd, MultiConsumerTransformOperand],
+        ids=["middle_add", "transform_operand"],
+    )
+    def test_multi_consumer_chain_member_does_not_flatten(self, model_cls):
+        flattened = self._assert_binary_add_chain_not_flattened(
+            model_cls(), make_vec_8d()
+        )
+        assert all(
+            node.coeffs == (1, 1) for node in find_nodes(flattened, GeneralAddOp)
+        )
+
+    @pytest.mark.parametrize(
+        "model_cls",
+        [
+            ConstOperandChain,
+            BroadcastOperandChain,
+            RepeatedProducerChain,
+            NonUnitCoeffChain,
+        ],
+        ids=["const", "broadcast", "repeated_producer", "non_unit_coeff"],
+    )
+    def test_unsupported_operand_form_does_not_flatten(self, model_cls):
+        _, add_nodes = self._flattened_add_nodes(model_cls(), make_vec_8d())
+
+        assert len(add_nodes) == 2
+        assert all(len(node.operands) == 2 for node in add_nodes)
 
 
 class TestComplexPatterns:
@@ -400,7 +773,7 @@ class TestAssignTickParams:
             assert node.core_params.tick_start is not None
             assert node.core_params.tick_start >= 1
 
-        tick_starts = sorted([n.core_params.tick_start for n in seq_nodes])
+        tick_starts = sorted([n.core_params.tick_start for n in seq_nodes])  # type: ignore
         assert tick_starts[0] < tick_starts[1]
 
     def test_tick_start_explicit_override(self, fused_snn):
@@ -552,7 +925,7 @@ class TestValidGraphs:
             def __init__(self):
                 super().__init__()
                 self.conv = nn.Conv2d(3, 16, 3, padding=1)
-                self.ifn = sj.IFNode()
+                self.ifn = neuron.IFNode()
 
             def forward(self, x):
                 return self.ifn(self.conv(x))
@@ -585,7 +958,7 @@ class TestValidGraphs:
                 super().__init__()
                 self.conv_a = nn.Conv2d(3, 16, 3, padding=1)
                 self.conv_b = nn.Conv2d(3, 16, 3, padding=1)
-                self.lif = sj.LIFNode(tau=2.0)
+                self.lif = neuron.LIFNode(tau=2.0)
 
             def forward(self, x):
                 return self.lif(self.conv_a(x) + self.conv_b(x))
@@ -1212,8 +1585,8 @@ class ValueBranchAdd(nn.Module):
         super().__init__()
         self.conv_a = nn.Conv2d(3, 4, 1)
         self.conv_b = nn.Conv2d(3, 4, 1)
-        self.if_a = sj.IFNode(v_threshold=1.0)
-        self.if_b = sj.IFNode(v_threshold=1.0)
+        self.if_a = neuron.IFNode(v_threshold=1.0)
+        self.if_b = neuron.IFNode(v_threshold=1.0)
 
     def forward(self, x):
         return self.if_a(self.conv_a(x)) + self.if_b(self.conv_b(x))
@@ -1333,10 +1706,7 @@ class TestSignalSemantics:
         propagate_signal_semantics(
             graph,
             input_formats={
-                graph.input_nodes()[0].name: (
-                    DataSign.UNSIGNED,
-                    DataWidth.WIDTH_1BIT,
-                )
+                graph.input_nodes()[0].name: (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT)
             },
         )
 
@@ -1398,9 +1768,7 @@ class TestSignalSemantics:
         inp_a = InputNode(shape=torch.Size((1, 4)))
         inp_b = InputNode(shape=torch.Size((1, 4)))
         acc = AccumulateOp(
-            comps=[nn.Linear(4, 4), nn.Linear(4, 4)],
-            act=IFNodeV25(),
-            op_signs=(1, 1),
+            comps=[nn.Linear(4, 4), nn.Linear(4, 4)], act=IFNodeV25(), op_signs=(1, 1)
         )
         out = OutputNode()
 
@@ -1409,11 +1777,7 @@ class TestSignalSemantics:
         acc.signal_semantics.output_domain = SignalDomain.VALUE
         out.signal_semantics.output_domain = SignalDomain.VALUE
         _set_multi_input_single_output_layouts(
-            acc,
-            [(1, 4), (1, 4)],
-            (1, 4),
-            [(0, 1), (0, 1)],
-            (0, 1),
+            acc, [(1, 4), (1, 4)], (1, 4), [(0, 1), (0, 1)], (0, 1)
         )
         acc.signs = (1, 0)
 


### PR DESCRIPTION
## Summary
- flatten deployable `GeneralAddOp` chains before add specialization
- enable activated multi-branch add chains to fuse into one `AccumulateOp`
- preserve no-activation add chains as n-ary `PotentialAddOp`
- add focused PAIIR coverage for signs, transform passthrough, rejection cases, and n-ary `PotentialAddOp`