### PR TITLE
Feat(proto): export output kind & voltage metadata

### DIFF
--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -9,6 +9,7 @@ from google.protobuf.json_format import MessageToJson
 from paicorelib import CoordZXYOffset, FrameArrayType
 
 from paibox.paiir import PAIIRGraph
+from paibox.paiir.ir.signal_domain import SignalDomain
 
 from .coreplacement import CorePlacement
 from .frame_cheader import write_c_array_close, write_c_array_decl
@@ -20,6 +21,7 @@ from .proto.compile_artifacts_pb2 import (
     CompileArtifacts,
     ConfigFrames,
     InputTensorMapping,
+    OutputEntry,
     OutputTensorMapping,
 )
 from .rg_build import build_groups
@@ -36,6 +38,29 @@ from .routing import (
 LiteralFormat = Literal["bin", "hex"]
 WordOrder = Literal["high_first", "low_first"]
 TargetPlatform = Literal["x86", "riscv", "all"]
+
+
+def _set_output_entry_kind(output_entry: OutputEntry, elem: SourceElem) -> None:
+    domain = elem.target.raw_node.signal_semantics.output_domain
+    if domain is SignalDomain.VALUE:
+        kind = OutputEntry.DATA
+    else:
+        kind = OutputEntry.VOLTAGE
+
+    if kind == OutputEntry.DATA:
+        if elem.output_bit_num > 8:
+            raise ValueError(
+                f"DATA output {elem} has unsupported bit width "
+                f"{elem.output_bit_num}; expected <= 8."
+            )
+    else:
+        if elem.output_bit_num != 32:
+            raise ValueError(
+                f"VOLTAGE output {elem} has bit width "
+                f"{elem.output_bit_num}; expected 32."
+            )
+
+    output_entry.kind = kind
 
 
 def export_single_framearray(
@@ -404,6 +429,7 @@ class Mapper:
             for out_grp in self.output_groups:
                 if out_grp.thread_id != thread_id:
                     continue
+                thread_mapping.output_mappings.target_lcn = out_grp.lcn
                 for axon_bit_idx, elem in sorted(
                     out_grp.axon_bit_allocator.axon_infos, key=lambda item: item[0]
                 ):
@@ -420,6 +446,7 @@ class Mapper:
                     output_entry.copy_id = elem.index.copy_id
                     output_entry.bit_width = elem.output_bit_num
                     output_entry.axon_bit_idx = axon_bit_idx
+                    _set_output_entry_kind(output_entry, elem)
 
         config_words: list[int] = []
         for _, frames in self._iter_frame_triplets():

--- a/paibox/backendv2/proto/README.md
+++ b/paibox/backendv2/proto/README.md
@@ -323,16 +323,16 @@ message OutputEntry {
 }
 ```
 
-| 字段                     | 含义                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------ |
-| `output_mappings.target_lcn` | 输出工作帧地址解析使用的目标 LCN 编号，对应 `paicorelib.LCN_EX` 枚举值。       |
-| `name`                   | PAIIR 输出节点名。                                                             |
-| `shape.size`             | 逻辑输出张量 shape。                                                           |
-| `elem_idx`               | 输出张量按 C-order 展平后的元素下标。                                          |
-| `copy_id`                | tiling/folding 产生的逻辑 copy 编号。                                          |
-| `bit_width`              | 输出元素位宽。`DATA` 通常不超过 8 bit；`VOLTAGE` 为 32 bit 膜电平。            |
-| `axon_bit_idx`           | 平坦 output axon bit index。`DATA` 为数据地址；`VOLTAGE` 为膜电平基地址。      |
-| `kind`                   | 输出语义。`DATA` 表示普通激活值/脉冲数据，`VOLTAGE` 表示膜电平。               |
+| 字段                         | 含义                                                                      |
+| ---------------------------- | ------------------------------------------------------------------------- |
+| `output_mappings.target_lcn` | 输出工作帧地址解析使用的目标 LCN 编号，对应 `paicorelib.LCN_EX` 枚举值。  |
+| `name`                       | PAIIR 输出节点名。                                                        |
+| `shape.size`                 | 逻辑输出张量 shape。                                                      |
+| `elem_idx`                   | 输出张量按 C-order 展平后的元素下标。                                     |
+| `copy_id`                    | tiling/folding 产生的逻辑 copy 编号。                                     |
+| `bit_width`                  | 输出元素位宽。`DATA` 通常不超过 8 bit；`VOLTAGE` 为 32 bit 膜电平。       |
+| `axon_bit_idx`               | 平坦 output axon bit index。`DATA` 为数据地址；`VOLTAGE` 为膜电平基地址。 |
+| `kind`                       | 输出语义。`DATA` 表示普通激活值/脉冲数据，`VOLTAGE` 表示膜电平。          |
 
 CPU 接收端仍应先根据返回工作帧的帧头区分 I/II 型。`kind` 的作用是让应用侧在运行前从 `config.pb` 预生成静态解码表，并保留调试语义。不要用 `bit_width` 反推出输出语义；应以 `kind` 为准。
 

--- a/paibox/backendv2/proto/README.md
+++ b/paibox/backendv2/proto/README.md
@@ -298,6 +298,11 @@ def encode_input_tensor(artifacts: CompileArtifacts, input_name: str, data) -> n
 ## 7. 输出映射与输出工作帧解码
 
 ```proto
+message OutputTensorMappings {
+    repeated OutputTensorMapping items = 1;
+    optional uint32 target_lcn = 2;
+}
+
 message OutputTensorMapping {
     string name = 1;
     Shape shape = 2;
@@ -305,32 +310,66 @@ message OutputTensorMapping {
 }
 
 message OutputEntry {
+    enum OutputKind {
+        DATA = 0;
+        VOLTAGE = 1;
+    }
+
     optional uint32 elem_idx = 1;
     optional uint32 copy_id = 2;
     optional uint32 bit_width = 3;
     optional uint32 axon_bit_idx = 4;
+    optional OutputKind kind = 5;
 }
 ```
 
-| 字段           | 含义                                               |
-| -------------- | -------------------------------------------------- |
-| `name`         | PAIIR 输出节点名。                                 |
-| `shape.size`   | 逻辑输出张量 shape。                               |
-| `elem_idx`     | 输出张量按 C-order 展平后的元素下标。              |
-| `copy_id`      | tiling/folding 产生的逻辑 copy 编号。              |
-| `bit_width`    | 输出元素位宽。                                     |
-| `axon_bit_idx` | 后端为该输出元素分配的平坦 output axon bit index。 |
+| 字段                     | 含义                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| `output_mappings.target_lcn` | 输出工作帧地址解析使用的目标 LCN 编号，对应 `paicorelib.LCN_EX` 枚举值。       |
+| `name`                   | PAIIR 输出节点名。                                                             |
+| `shape.size`             | 逻辑输出张量 shape。                                                           |
+| `elem_idx`               | 输出张量按 C-order 展平后的元素下标。                                          |
+| `copy_id`                | tiling/folding 产生的逻辑 copy 编号。                                          |
+| `bit_width`              | 输出元素位宽。`DATA` 通常不超过 8 bit；`VOLTAGE` 为 32 bit 膜电平。            |
+| `axon_bit_idx`           | 平坦 output axon bit index。`DATA` 为数据地址；`VOLTAGE` 为膜电平基地址。      |
+| `kind`                   | 输出语义。`DATA` 表示普通激活值/脉冲数据，`VOLTAGE` 表示膜电平。               |
 
-当前 `OutputEntry` 只能表示普通输出数据帧的地址标注与解码，即应用侧可通过 `axon_bit_idx` 把芯片返回的工作帧 payload 放回逻辑输出张量。它不能表示膜电平帧的地址信息，也不能描述膜电平帧的 4 帧基地址。因此，基于当前 schema，应用侧无法仅依赖 `config.pb` 完成膜电平帧定位或解码。
+CPU 接收端仍应先根据返回工作帧的帧头区分 I/II 型。`kind` 的作用是让应用侧在运行前从 `config.pb` 预生成静态解码表，并保留调试语义。不要用 `bit_width` 反推出输出语义；应以 `kind` 为准。
 
-这点已按当前代码核对：`compile_artifacts.proto` 的 `OutputEntry` 只有 `elem_idx/copy_id/bit_width/axon_bit_idx`；`Mapper.export_proto(...)` 只从 `OutputAxonAllocator.axon_infos` 写入普通输出数据帧地址，没有写入膜电平帧字段或 `oneof` 输出位置类型。
+`kind` 是 `OutputEntry` 级字段，不是 `OutputTensorMapping` 级字段。同一个 `OutputTensorMapping.entries` 内可以同时包含 `DATA` 和 `VOLTAGE` entry。
 
-普通输出数据帧的解码流程：
+普通 `DATA` 输出对应工作帧 I 型。解码流程：
 
-1. 从 `OutputTensorMapping.entries` 建立 `axon_bit_idx -> elem_idx` 表。
+1. 从 `kind == DATA` 的 `OutputTensorMapping.entries` 建立 `axon_bit_idx -> elem_idx` 表。
 2. 板端运行时先把芯片返回帧解析为 `(axon_bit_idx, payload_byte)`。
 3. 根据映射表把 payload 写回输出张量的展平位置 `elem_idx`。
 4. 根据模型 ABI 解释 signedness、语义域和多 byte 组合方式。
+
+膜电平 `VOLTAGE` 输出对应工作帧 II 型。后端只记录每个神经元膜电平输出的基地址 `axon_bit_idx`，芯片内部按 `base + 8 * i` 访问 4 个 byte lane。应用侧可预先把每个 `VOLTAGE` entry 展开为 `(base, base + 8, base + 16, base + 24)`，运行时收集 4 个 payload byte 后拼回一个 32-bit 膜电平。
+
+如果应用侧需要主动构造工作帧 II 型，可把每个膜电平元素拆成一个 `int32`，再调用 `OfflineFrameGenV2.gen_work_frame2(...)`。该接口会为每个膜电平值自动展开 4 个 byte lane，并生成 4 帧 64-bit work frame type 2。下面的示例未经过板端流程验证，仅供实现参考：
+
+```python
+import numpy as np
+from paicorelib import AERPacketZXYCopy, CoordZXYOffset, OfflineFrameGenV2
+
+
+def encode_voltage_frames(
+    coord_offset: CoordZXYOffset,
+    target_lcn: int,
+    timesteps: np.ndarray,
+    base_axons: np.ndarray,
+    voltage: np.ndarray,
+):
+    return OfflineFrameGenV2.gen_work_frame2(
+        coord_offset,
+        AERPacketZXYCopy(0, 0, 0),
+        timesteps,
+        base_axons,
+        target_lcn,
+        voltage.astype(np.int32, copy=False),
+    )
+```
 
 下面的 Python 代码未经过板端流程验证，仅供实现参考。实际应用应以板端返回帧格式和运行时 ABI 为准。
 
@@ -343,21 +382,27 @@ from compile_artifacts_pb2 import CompileArtifacts
 def build_output_tables(artifacts: CompileArtifacts):
     tables = {}
     for thread in artifacts.io_mapping.threads:
+        target_lcn = int(thread.output_mappings.target_lcn)
         for mapping in thread.output_mappings.items:
             shape = tuple(mapping.shape.size)
-            by_axon = {}
+            data_by_axon = {}
+            voltage_by_base = {}
             for entry in mapping.entries:
-                by_axon[int(entry.axon_bit_idx)] = (
+                item = (
                     int(entry.elem_idx),
                     int(entry.copy_id),
                     int(entry.bit_width),
                 )
-            tables[mapping.name] = (shape, by_axon)
+                if entry.kind == entry.DATA:
+                    data_by_axon[int(entry.axon_bit_idx)] = item
+                elif entry.kind == entry.VOLTAGE:
+                    voltage_by_base[int(entry.axon_bit_idx)] = item
+            tables[mapping.name] = (shape, target_lcn, data_by_axon, voltage_by_base)
     return tables
 
 
 def scatter_u8_output(output_tables, output_name: str, decoded_items):
-    shape, by_axon = output_tables[output_name]
+    shape, _, by_axon, _ = output_tables[output_name]
     output = np.zeros(int(np.prod(shape)), dtype=np.uint8)
 
     for axon_bit_idx, payload in decoded_items:
@@ -369,7 +414,7 @@ def scatter_u8_output(output_tables, output_name: str, decoded_items):
     return output.reshape(shape)
 ```
 
-如果板端返回的是 64-bit offline work frame type 1 原始帧，可先解析出 `(axon_bit_idx, payload)`，再执行 scatter。当前 backendv2 输出组使用 `LCN_128X` 的 output axon 空间；若未来 schema 增加输出 LCN 字段，应以 schema 字段为准。
+如果板端返回的是 64-bit offline work frame type 1 原始帧，可先解析出 `(axon_bit_idx, payload)`，再执行 scatter。输出 work frame 的 timestep / axon 宽度应使用 `thread.output_mappings.target_lcn` 解析。
 
 下面的解析代码未经过板端流程验证，仅供实现参考：
 
@@ -392,7 +437,7 @@ def decode_offline_work_frame1_u64(frame: int, target_lcn: int = LCN_EX.LCN_128X
     return axon_bit_idx, payload
 ```
 
-对于 `bit_width <= 8` 的输出，通常一个 `OutputEntry` 对应一个 payload byte。对于 `bit_width == 32` 的输出，当前后端会为同一个逻辑输出元素保留 `axon_bit_idx + 8 * i` 这四个 byte lane；应用侧需要收集四个 byte 后再按模型 ABI 组合为 32-bit 值。下面的 little-endian 组合逻辑未经过板端流程验证，仅供实现参考：
+对于 `kind == VOLTAGE` 的输出，一个 `OutputEntry` 的 `axon_bit_idx` 是膜电平基地址。应用侧需要收集 `base + 8 * i` 这四个 byte lane 后再按模型 ABI 组合为 32-bit 值。下面的 little-endian 组合逻辑未经过板端流程验证，仅供实现参考：
 
 ```python
 def collect_u32_le(decoded_by_axon: dict[int, int], base_axon_bit_idx: int) -> int:
@@ -401,6 +446,8 @@ def collect_u32_le(decoded_by_axon: dict[int, int], base_axon_bit_idx: int) -> i
         value |= (decoded_by_axon.get(base_axon_bit_idx + 8 * i, 0) & 0xFF) << (8 * i)
     return value
 ```
+
+例如，若 `OfflineFrameGenV2.gen_work_frame2(...)` 对某个膜电平 `0x11223344` 生成的 4 帧 payload 依次为 `0x44, 0x33, 0x22, 0x11`，则应用侧应按 little-endian 次序把它们还原回 `0x11223344`，并使用对应 entry 的 `axon_bit_idx` 作为第一个 byte lane 的基地址。
 
 ## 8. JSON 字段名
 
@@ -415,5 +462,6 @@ def collect_u32_le(decoded_by_axon: dict[int, int], base_axon_bit_idx: int) -> i
 | `elem_idx`         | `elemIdx`        |
 | `addr_axon`        | `addrAxon`       |
 | `axon_bit_idx`     | `axonBitIdx`     |
+| `target_lcn`       | `targetLcn`      |
 
 应用程序读取 `config.pb` 时使用 proto 字段名；人工查看 `config.json` 时使用 JSON 字段名。

--- a/paibox/backendv2/proto/compile_artifacts.proto
+++ b/paibox/backendv2/proto/compile_artifacts.proto
@@ -29,11 +29,17 @@ message InputEntry {
 }
 
 message OutputEntry {
+    enum OutputKind {
+        DATA = 0;
+        VOLTAGE = 1;
+    }
+
     optional uint32 elem_idx = 1;
     optional uint32 copy_id = 2;
     optional uint32 bit_width = 3;
-    /* Flat output axon bit index allocated by OutputAxonAllocator. */
+    /* DATA: output axon bit index. VOLTAGE: membrane voltage base index. */
     optional uint32 axon_bit_idx = 4;
+    optional OutputKind kind = 5;
 }
 
 message Shape {
@@ -58,6 +64,7 @@ message InputTensorMappings {
 
 message OutputTensorMappings {
     repeated OutputTensorMapping items = 1;
+    optional uint32 target_lcn = 2;
 }
 
 message ThreadIOMapping {

--- a/paibox/backendv2/proto/compile_artifacts_pb2.py
+++ b/paibox/backendv2/proto/compile_artifacts_pb2.py
@@ -20,7 +20,7 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x17\x63ompile_artifacts.proto\x12\tbackendv2"P\n\nCoreOffset\x12\x0f\n\x02xy\x18\x01 \x01(\x05H\x00\x88\x01\x01\x12\x0e\n\x01x\x18\x02 \x01(\x05H\x01\x88\x01\x01\x12\x0e\n\x01y\x18\x03 \x01(\x05H\x02\x88\x01\x01\x42\x05\n\x03_xyB\x04\n\x02_xB\x04\n\x02_y"O\n\tCopyCount\x12\x0f\n\x02xy\x18\x01 \x01(\x05H\x00\x88\x01\x01\x12\x0e\n\x01x\x18\x02 \x01(\x05H\x01\x88\x01\x01\x12\x0e\n\x01y\x18\x03 \x01(\x05H\x02\x88\x01\x01\x42\x05\n\x03_xyB\x04\n\x02_xB\x04\n\x02_y"\xca\x02\n\nInputEntry\x12\x15\n\x08\x65lem_idx\x18\x01 \x01(\rH\x00\x88\x01\x01\x12*\n\x0b\x63ore_offset\x18\x02 \x01(\x0b\x32\x15.backendv2.CoreOffset\x12(\n\ncopy_count\x18\x03 \x01(\x0b\x32\x14.backendv2.CopyCount\x12\x1a\n\rtick_relative\x18\x04 \x01(\rH\x01\x88\x01\x01\x12\x16\n\taddr_axon\x18\x05 \x01(\rH\x02\x88\x01\x01\x12\x17\n\ntarget_lcn\x18\x06 \x01(\rH\x03\x88\x01\x01\x12\x14\n\x07\x63opy_id\x18\x07 \x01(\rH\x04\x88\x01\x01\x12\x16\n\tbit_width\x18\x08 \x01(\rH\x05\x88\x01\x01\x42\x0b\n\t_elem_idxB\x10\n\x0e_tick_relativeB\x0c\n\n_addr_axonB\r\n\x0b_target_lcnB\n\n\x08_copy_idB\x0c\n\n_bit_width"\xa5\x01\n\x0bOutputEntry\x12\x15\n\x08\x65lem_idx\x18\x01 \x01(\rH\x00\x88\x01\x01\x12\x14\n\x07\x63opy_id\x18\x02 \x01(\rH\x01\x88\x01\x01\x12\x16\n\tbit_width\x18\x03 \x01(\rH\x02\x88\x01\x01\x12\x19\n\x0c\x61xon_bit_idx\x18\x04 \x01(\rH\x03\x88\x01\x01\x42\x0b\n\t_elem_idxB\n\n\x08_copy_idB\x0c\n\n_bit_widthB\x0f\n\r_axon_bit_idx"\x15\n\x05Shape\x12\x0c\n\x04size\x18\x01 \x03(\x05"k\n\x12InputTensorMapping\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1f\n\x05shape\x18\x02 \x01(\x0b\x32\x10.backendv2.Shape\x12&\n\x07\x65ntries\x18\x03 \x03(\x0b\x32\x15.backendv2.InputEntry"m\n\x13OutputTensorMapping\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1f\n\x05shape\x18\x02 \x01(\x0b\x32\x10.backendv2.Shape\x12\'\n\x07\x65ntries\x18\x03 \x03(\x0b\x32\x16.backendv2.OutputEntry"C\n\x13InputTensorMappings\x12,\n\x05items\x18\x01 \x03(\x0b\x32\x1d.backendv2.InputTensorMapping"E\n\x14OutputTensorMappings\x12-\n\x05items\x18\x01 \x03(\x0b\x32\x1e.backendv2.OutputTensorMapping"\xda\x01\n\x0fThreadIOMapping\x12\x16\n\tthread_id\x18\x01 \x01(\rH\x00\x88\x01\x01\x12/\n\x10root_core_offset\x18\x02 \x01(\x0b\x32\x15.backendv2.CoreOffset\x12\x36\n\x0einput_mappings\x18\x03 \x01(\x0b\x32\x1e.backendv2.InputTensorMappings\x12\x38\n\x0foutput_mappings\x18\x04 \x01(\x0b\x32\x1f.backendv2.OutputTensorMappingsB\x0c\n\n_thread_id"8\n\tIOMapping\x12+\n\x07threads\x18\x01 \x03(\x0b\x32\x1a.backendv2.ThreadIOMapping"\x80\x01\n\x0c\x43onfigFrames\x12\r\n\x05words\x18\x01 \x03(\r\x12\x35\n\nword_order\x18\x02 \x01(\x0e\x32!.backendv2.ConfigFrames.WordOrder"*\n\tWordOrder\x12\x0e\n\nHIGH_FIRST\x10\x00\x12\r\n\tLOW_FIRST\x10\x01"\x84\x01\n\x10\x43ompileArtifacts\x12\x16\n\x0eschema_version\x18\x01 \x01(\r\x12(\n\nio_mapping\x18\x02 \x01(\x0b\x32\x14.backendv2.IOMapping\x12.\n\rconfig_frames\x18\x03 \x01(\x0b\x32\x17.backendv2.ConfigFramesb\x06proto3'
+    b'\n\x17\x63ompile_artifacts.proto\x12\tbackendv2"P\n\nCoreOffset\x12\x0f\n\x02xy\x18\x01 \x01(\x05H\x00\x88\x01\x01\x12\x0e\n\x01x\x18\x02 \x01(\x05H\x01\x88\x01\x01\x12\x0e\n\x01y\x18\x03 \x01(\x05H\x02\x88\x01\x01\x42\x05\n\x03_xyB\x04\n\x02_xB\x04\n\x02_y"O\n\tCopyCount\x12\x0f\n\x02xy\x18\x01 \x01(\x05H\x00\x88\x01\x01\x12\x0e\n\x01x\x18\x02 \x01(\x05H\x01\x88\x01\x01\x12\x0e\n\x01y\x18\x03 \x01(\x05H\x02\x88\x01\x01\x42\x05\n\x03_xyB\x04\n\x02_xB\x04\n\x02_y"\xca\x02\n\nInputEntry\x12\x15\n\x08\x65lem_idx\x18\x01 \x01(\rH\x00\x88\x01\x01\x12*\n\x0b\x63ore_offset\x18\x02 \x01(\x0b\x32\x15.backendv2.CoreOffset\x12(\n\ncopy_count\x18\x03 \x01(\x0b\x32\x14.backendv2.CopyCount\x12\x1a\n\rtick_relative\x18\x04 \x01(\rH\x01\x88\x01\x01\x12\x16\n\taddr_axon\x18\x05 \x01(\rH\x02\x88\x01\x01\x12\x17\n\ntarget_lcn\x18\x06 \x01(\rH\x03\x88\x01\x01\x12\x14\n\x07\x63opy_id\x18\x07 \x01(\rH\x04\x88\x01\x01\x12\x16\n\tbit_width\x18\x08 \x01(\rH\x05\x88\x01\x01\x42\x0b\n\t_elem_idxB\x10\n\x0e_tick_relativeB\x0c\n\n_addr_axonB\r\n\x0b_target_lcnB\n\n\x08_copy_idB\x0c\n\n_bit_width"\x89\x02\n\x0bOutputEntry\x12\x15\n\x08\x65lem_idx\x18\x01 \x01(\rH\x00\x88\x01\x01\x12\x14\n\x07\x63opy_id\x18\x02 \x01(\rH\x01\x88\x01\x01\x12\x16\n\tbit_width\x18\x03 \x01(\rH\x02\x88\x01\x01\x12\x19\n\x0c\x61xon_bit_idx\x18\x04 \x01(\rH\x03\x88\x01\x01\x12\x34\n\x04kind\x18\x05 \x01(\x0e\x32!.backendv2.OutputEntry.OutputKindH\x04\x88\x01\x01"#\n\nOutputKind\x12\x08\n\x04\x44\x41TA\x10\x00\x12\x0b\n\x07VOLTAGE\x10\x01\x42\x0b\n\t_elem_idxB\n\n\x08_copy_idB\x0c\n\n_bit_widthB\x0f\n\r_axon_bit_idxB\x07\n\x05_kind"\x15\n\x05Shape\x12\x0c\n\x04size\x18\x01 \x03(\x05"k\n\x12InputTensorMapping\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1f\n\x05shape\x18\x02 \x01(\x0b\x32\x10.backendv2.Shape\x12&\n\x07\x65ntries\x18\x03 \x03(\x0b\x32\x15.backendv2.InputEntry"m\n\x13OutputTensorMapping\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1f\n\x05shape\x18\x02 \x01(\x0b\x32\x10.backendv2.Shape\x12\'\n\x07\x65ntries\x18\x03 \x03(\x0b\x32\x16.backendv2.OutputEntry"C\n\x13InputTensorMappings\x12,\n\x05items\x18\x01 \x03(\x0b\x32\x1d.backendv2.InputTensorMapping"m\n\x14OutputTensorMappings\x12-\n\x05items\x18\x01 \x03(\x0b\x32\x1e.backendv2.OutputTensorMapping\x12\x17\n\ntarget_lcn\x18\x02 \x01(\rH\x00\x88\x01\x01\x42\r\n\x0b_target_lcn"\xda\x01\n\x0fThreadIOMapping\x12\x16\n\tthread_id\x18\x01 \x01(\rH\x00\x88\x01\x01\x12/\n\x10root_core_offset\x18\x02 \x01(\x0b\x32\x15.backendv2.CoreOffset\x12\x36\n\x0einput_mappings\x18\x03 \x01(\x0b\x32\x1e.backendv2.InputTensorMappings\x12\x38\n\x0foutput_mappings\x18\x04 \x01(\x0b\x32\x1f.backendv2.OutputTensorMappingsB\x0c\n\n_thread_id"8\n\tIOMapping\x12+\n\x07threads\x18\x01 \x03(\x0b\x32\x1a.backendv2.ThreadIOMapping"\x80\x01\n\x0c\x43onfigFrames\x12\r\n\x05words\x18\x01 \x03(\r\x12\x35\n\nword_order\x18\x02 \x01(\x0e\x32!.backendv2.ConfigFrames.WordOrder"*\n\tWordOrder\x12\x0e\n\nHIGH_FIRST\x10\x00\x12\r\n\tLOW_FIRST\x10\x01"\x84\x01\n\x10\x43ompileArtifacts\x12\x16\n\x0eschema_version\x18\x01 \x01(\r\x12(\n\nio_mapping\x18\x02 \x01(\x0b\x32\x14.backendv2.IOMapping\x12.\n\rconfig_frames\x18\x03 \x01(\x0b\x32\x17.backendv2.ConfigFramesb\x06proto3'
 )
 
 _globals = globals()
@@ -35,25 +35,27 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_INPUTENTRY"]._serialized_start = 202
     _globals["_INPUTENTRY"]._serialized_end = 532
     _globals["_OUTPUTENTRY"]._serialized_start = 535
-    _globals["_OUTPUTENTRY"]._serialized_end = 700
-    _globals["_SHAPE"]._serialized_start = 702
-    _globals["_SHAPE"]._serialized_end = 723
-    _globals["_INPUTTENSORMAPPING"]._serialized_start = 725
-    _globals["_INPUTTENSORMAPPING"]._serialized_end = 832
-    _globals["_OUTPUTTENSORMAPPING"]._serialized_start = 834
-    _globals["_OUTPUTTENSORMAPPING"]._serialized_end = 943
-    _globals["_INPUTTENSORMAPPINGS"]._serialized_start = 945
-    _globals["_INPUTTENSORMAPPINGS"]._serialized_end = 1012
-    _globals["_OUTPUTTENSORMAPPINGS"]._serialized_start = 1014
-    _globals["_OUTPUTTENSORMAPPINGS"]._serialized_end = 1083
-    _globals["_THREADIOMAPPING"]._serialized_start = 1086
-    _globals["_THREADIOMAPPING"]._serialized_end = 1304
-    _globals["_IOMAPPING"]._serialized_start = 1306
-    _globals["_IOMAPPING"]._serialized_end = 1362
-    _globals["_CONFIGFRAMES"]._serialized_start = 1365
-    _globals["_CONFIGFRAMES"]._serialized_end = 1493
-    _globals["_CONFIGFRAMES_WORDORDER"]._serialized_start = 1451
-    _globals["_CONFIGFRAMES_WORDORDER"]._serialized_end = 1493
-    _globals["_COMPILEARTIFACTS"]._serialized_start = 1496
-    _globals["_COMPILEARTIFACTS"]._serialized_end = 1628
+    _globals["_OUTPUTENTRY"]._serialized_end = 800
+    _globals["_OUTPUTENTRY_OUTPUTKIND"]._serialized_start = 700
+    _globals["_OUTPUTENTRY_OUTPUTKIND"]._serialized_end = 735
+    _globals["_SHAPE"]._serialized_start = 802
+    _globals["_SHAPE"]._serialized_end = 823
+    _globals["_INPUTTENSORMAPPING"]._serialized_start = 825
+    _globals["_INPUTTENSORMAPPING"]._serialized_end = 932
+    _globals["_OUTPUTTENSORMAPPING"]._serialized_start = 934
+    _globals["_OUTPUTTENSORMAPPING"]._serialized_end = 1043
+    _globals["_INPUTTENSORMAPPINGS"]._serialized_start = 1045
+    _globals["_INPUTTENSORMAPPINGS"]._serialized_end = 1112
+    _globals["_OUTPUTTENSORMAPPINGS"]._serialized_start = 1114
+    _globals["_OUTPUTTENSORMAPPINGS"]._serialized_end = 1223
+    _globals["_THREADIOMAPPING"]._serialized_start = 1226
+    _globals["_THREADIOMAPPING"]._serialized_end = 1444
+    _globals["_IOMAPPING"]._serialized_start = 1446
+    _globals["_IOMAPPING"]._serialized_end = 1502
+    _globals["_CONFIGFRAMES"]._serialized_start = 1505
+    _globals["_CONFIGFRAMES"]._serialized_end = 1633
+    _globals["_CONFIGFRAMES_WORDORDER"]._serialized_start = 1591
+    _globals["_CONFIGFRAMES_WORDORDER"]._serialized_end = 1633
+    _globals["_COMPILEARTIFACTS"]._serialized_start = 1636
+    _globals["_COMPILEARTIFACTS"]._serialized_end = 1768
 # @@protoc_insertion_point(module_scope)

--- a/paibox/backendv2/proto/compile_artifacts_pb2.pyi
+++ b/paibox/backendv2/proto/compile_artifacts_pb2.pyi
@@ -76,6 +76,7 @@ class InputEntry(_message.Message):
 
 class OutputEntry(_message.Message):
     __slots__ = ("elem_idx", "copy_id", "bit_width", "axon_bit_idx", "kind")
+
     class OutputKind(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
         __slots__ = ()
         DATA: _ClassVar[OutputEntry.OutputKind]
@@ -186,6 +187,7 @@ class IOMapping(_message.Message):
 
 class ConfigFrames(_message.Message):
     __slots__ = ("words", "word_order")
+
     class WordOrder(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
         __slots__ = ()
         HIGH_FIRST: _ClassVar[ConfigFrames.WordOrder]

--- a/paibox/backendv2/proto/compile_artifacts_pb2.pyi
+++ b/paibox/backendv2/proto/compile_artifacts_pb2.pyi
@@ -75,21 +75,31 @@ class InputEntry(_message.Message):
     ) -> None: ...
 
 class OutputEntry(_message.Message):
-    __slots__ = ("elem_idx", "copy_id", "bit_width", "axon_bit_idx")
+    __slots__ = ("elem_idx", "copy_id", "bit_width", "axon_bit_idx", "kind")
+    class OutputKind(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+        __slots__ = ()
+        DATA: _ClassVar[OutputEntry.OutputKind]
+        VOLTAGE: _ClassVar[OutputEntry.OutputKind]
+
+    DATA: OutputEntry.OutputKind
+    VOLTAGE: OutputEntry.OutputKind
     ELEM_IDX_FIELD_NUMBER: _ClassVar[int]
     COPY_ID_FIELD_NUMBER: _ClassVar[int]
     BIT_WIDTH_FIELD_NUMBER: _ClassVar[int]
     AXON_BIT_IDX_FIELD_NUMBER: _ClassVar[int]
+    KIND_FIELD_NUMBER: _ClassVar[int]
     elem_idx: int
     copy_id: int
     bit_width: int
     axon_bit_idx: int
+    kind: OutputEntry.OutputKind
     def __init__(
         self,
         elem_idx: _Optional[int] = ...,
         copy_id: _Optional[int] = ...,
         bit_width: _Optional[int] = ...,
         axon_bit_idx: _Optional[int] = ...,
+        kind: _Optional[_Union[OutputEntry.OutputKind, str]] = ...,
     ) -> None: ...
 
 class Shape(_message.Message):
@@ -137,11 +147,15 @@ class InputTensorMappings(_message.Message):
     ) -> None: ...
 
 class OutputTensorMappings(_message.Message):
-    __slots__ = ("items",)
+    __slots__ = ("items", "target_lcn")
     ITEMS_FIELD_NUMBER: _ClassVar[int]
+    TARGET_LCN_FIELD_NUMBER: _ClassVar[int]
     items: _containers.RepeatedCompositeFieldContainer[OutputTensorMapping]
+    target_lcn: int
     def __init__(
-        self, items: _Optional[_Iterable[_Union[OutputTensorMapping, _Mapping]]] = ...
+        self,
+        items: _Optional[_Iterable[_Union[OutputTensorMapping, _Mapping]]] = ...,
+        target_lcn: _Optional[int] = ...,
     ) -> None: ...
 
 class ThreadIOMapping(_message.Message):
@@ -172,7 +186,6 @@ class IOMapping(_message.Message):
 
 class ConfigFrames(_message.Message):
     __slots__ = ("words", "word_order")
-
     class WordOrder(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
         __slots__ = ()
         HIGH_FIRST: _ClassVar[ConfigFrames.WordOrder]

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -762,10 +762,6 @@ class RoutingGroup(
 
         print(f"\nAllocating neurons for Routing Group {self.name}...")
         prefix = "    "
-        if self.nodes is not None and self.input_nodes is not None:
-            node = list(self.nodes)[0]
-            # print(f"kernel weight from node {node.name}:\n", node.weights[0])
-
         weights = get_raw_weights(self.raw_elems, self.input_list)
 
         # print(f"weight of routing group {self.name}:\n", weights)
@@ -809,9 +805,6 @@ class RoutingGroup(
             # print(f"Neu of this group: {[str(item[0]) for item in group_items]}")
             print(f"{prefix}allocating core_block[{i}] ({len(group_items)} neurons)...")
             frontend_core_conf, backend_core_conf = key
-            # Initialize the first core for the current group
-            current_core = OfflineCorePlacementV2(frontend_core_conf, backend_core_conf)
-
             self.last_full_attrs = None
             self.place_neurons_optimal(
                 frontend_core_conf,
@@ -852,7 +845,6 @@ class RoutingGroup(
                 # mostly each neu_placement contains only one raw_neu
                 # for folded neuron placement, it may contain multiple raw_neus
                 # but we only need to set dest_info for the first raw_neu
-                main_neu = neu_placement.raw_neus[0]
                 dest_info = self.get_detail_dest(
                     neu_placement.raw_neus, self_coord=core_placement.coord
                 )
@@ -963,6 +955,8 @@ class InputGroup(Group, SourceGroup[InputElem, InNode]):
 
 
 class OutputAxonAllocator:
+    MAX_AXON_BIT = FANIN_BASE * (1 << LCN_EX.LCN_128X.value) - 1
+
     def __init__(self):
         self.axon_infos: list[tuple[int, SourceElem]] = []
         self.used_bits: set[int] = set()
@@ -976,7 +970,8 @@ class OutputAxonAllocator:
 
     def free_to_store_32bit(self, start: int) -> bool:
         for i in range(4):
-            if start + i * 8 in self.used_bits:
+            axon_bit = start + i * 8
+            if axon_bit > self.MAX_AXON_BIT or axon_bit in self.used_bits:
                 return False
         return True
 
@@ -990,6 +985,11 @@ class OutputAxonAllocator:
         elif elem.output_bit_num == 32:
             candidate_bit = self.lowest_free_bit
             while True:
+                if candidate_bit > self.MAX_AXON_BIT:
+                    raise ValueError(
+                        f"Cannot allocate 32-bit output for element {elem}: "
+                        "output axon space is exhausted."
+                    )
                 if self.free_to_store_32bit(candidate_bit):
                     axon_bit = candidate_bit
                     for i in range(4):
@@ -1004,9 +1004,9 @@ class OutputAxonAllocator:
             raise ValueError(
                 f"Unsupported output bit num {elem.output_bit_num} for element {elem}."
             )
-        if axon_bit >= FANIN_BASE * (2**LCN_EX.LCN_128X.value):
+        if axon_bit > self.MAX_AXON_BIT:
             raise ValueError(
-                f"Axon bit {axon_bit} allocated for element {elem} exceeds the maximum supported axon bit {FANIN_BASE * (2**LCN_EX.LCN_128X.value)}."
+                f"Axon bit {axon_bit} allocated for element {elem} exceeds the maximum supported axon bit {self.MAX_AXON_BIT}."
             )
         return axon_bit
 

--- a/tests/backendv2/test_mapper.py
+++ b/tests/backendv2/test_mapper.py
@@ -94,6 +94,7 @@ def _export_graph_proto(export_root: Path, case_name: str, model, sample) -> Pat
 
     return export_dir / "proto" / "config.pb"
 
+
 @pytest.fixture(scope="module")
 def ensure_backendv2_debug_dir(request, tmp_path_factory):
     if is_ci_env():
@@ -196,6 +197,7 @@ def test_export_proto_marks_voltage_outputs_and_base_addresses(
     for entry in entries:
         lanes = {entry.axon_bit_idx + 8 * i for i in range(4)}
         assert len(lanes) == 4
+
 
 def test_export_artifacts_all_platforms_when_requested(ensure_backendv2_debug_dir):
     export_dir = _export_simple_cnn(

--- a/tests/backendv2/test_mapper.py
+++ b/tests/backendv2/test_mapper.py
@@ -4,12 +4,19 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import torch
+from paicorelib import LCN_EX
+from torch import nn
 
 from paibox.backendv2.mapper import Mapper
 from paibox.backendv2.proto import PROTO_SCHEMA_VERSION
-from paibox.backendv2.proto.compile_artifacts_pb2 import CompileArtifacts, ConfigFrames
+from paibox.backendv2.proto.compile_artifacts_pb2 import (
+    CompileArtifacts,
+    ConfigFrames,
+    OutputEntry,
+)
 from paibox.paiir import compile_to_paiir
-from tests.paiir.conftest import SimpleCNN, make_img_3ch_8x8
+from tests.paiir.conftest import ANNClassifier, SimpleCNN, make_img_3ch_8x8
 from tests.utils import is_ci_env
 
 DEBUG_EXPORT_ROOT = Path(__file__).with_name("debug") / "mapper_proto_export"
@@ -26,8 +33,8 @@ def _export_simple_cnn_proto(export_root: Path, word_order: str) -> Path:
     mapper.compile(
         graph,
         export_dir,
-        target_platform="x86",  # type: ignore[arg-type]
-        word_order=word_order,
+        target_platform="x86",
+        word_order=word_order,  # type: ignore[arg-type]
         debug=True,
     )
 
@@ -59,6 +66,33 @@ def _export_simple_cnn(
 
     return export_dir
 
+
+class ConvPotential(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(1, 1, 1, bias=False)
+
+    def forward(self, x):
+        return self.conv(x)
+
+
+def _load_compile_artifacts(pb_path: Path) -> CompileArtifacts:
+    artifacts = CompileArtifacts()
+    artifacts.ParseFromString(pb_path.read_bytes())
+    return artifacts
+
+
+def _export_graph_proto(export_root: Path, case_name: str, model, sample) -> Path:
+    export_dir = export_root / case_name
+    if export_dir.exists():
+        shutil.rmtree(export_dir)
+    export_dir.mkdir(parents=True, exist_ok=True)
+
+    graph = compile_to_paiir(model.eval(), sample, strict=True)
+    mapper = Mapper()
+    mapper.compile(graph, export_dir, target_platform="x86", debug=True)
+
+    return export_dir / "proto" / "config.pb"
 
 @pytest.fixture(scope="module")
 def ensure_backendv2_debug_dir(request, tmp_path_factory):
@@ -94,8 +128,7 @@ def test_export_proto_real_workflow_keeps_pb_and_json(
     assert (proto_dir / "compile_artifacts_pb2.py").exists()
     assert (proto_dir / "compile_artifacts_pb2.pyi").exists()
 
-    artifacts = CompileArtifacts()
-    artifacts.ParseFromString(pb_path.read_bytes())
+    artifacts = _load_compile_artifacts(pb_path)
 
     assert artifacts.schema_version == PROTO_SCHEMA_VERSION
     assert len(artifacts.io_mapping.threads) == 1
@@ -108,6 +141,61 @@ def test_export_proto_real_workflow_keeps_pb_and_json(
     assert len(payload["configFrames"]["words"]) > 0
     assert len(payload["ioMapping"]["threads"]) == 1
 
+
+def test_export_proto_marks_data_outputs_and_target_lcn(
+    ensure_backendv2_debug_dir,
+):
+    pb_path = _export_graph_proto(
+        ensure_backendv2_debug_dir,
+        "data_output_kind",
+        ANNClassifier(),
+        make_img_3ch_8x8(),
+    )
+
+    artifacts = _load_compile_artifacts(pb_path)
+    output_mappings = artifacts.io_mapping.threads[0].output_mappings
+
+    assert output_mappings.target_lcn == LCN_EX.LCN_128X.value
+    assert output_mappings.HasField("target_lcn")
+    assert len(output_mappings.items) == 1
+
+    entries = list(output_mappings.items[0].entries)
+    assert entries
+    assert {entry.kind for entry in entries} == {OutputEntry.DATA}
+    assert all(entry.HasField("kind") for entry in entries)
+    assert all(entry.bit_width <= 8 for entry in entries)
+
+
+def test_export_proto_marks_voltage_outputs_and_base_addresses(
+    ensure_backendv2_debug_dir,
+):
+    model = ConvPotential()
+    with torch.no_grad():
+        model.conv.weight.fill_(1)
+
+    pb_path = _export_graph_proto(
+        ensure_backendv2_debug_dir,
+        "voltage_output_kind",
+        model,
+        torch.ones(1, 1, 3, 3),
+    )
+
+    artifacts = _load_compile_artifacts(pb_path)
+    output_mappings = artifacts.io_mapping.threads[0].output_mappings
+
+    assert output_mappings.target_lcn == LCN_EX.LCN_128X.value
+    assert len(output_mappings.items) == 1
+
+    entries = list(output_mappings.items[0].entries)
+    assert entries
+    assert {entry.kind for entry in entries} == {OutputEntry.VOLTAGE}
+    assert all(entry.bit_width == 32 for entry in entries)
+
+    bases = [entry.axon_bit_idx for entry in entries[:10]]
+    assert bases == [0, 1, 2, 3, 4, 5, 6, 7, 32]
+    for entry in entries:
+        lanes = {entry.axon_bit_idx + 8 * i for i in range(4)}
+        assert len(lanes) == 4
 
 def test_export_artifacts_all_platforms_when_requested(ensure_backendv2_debug_dir):
     export_dir = _export_simple_cnn(

--- a/tests/backendv2/test_output_axon_allocator.py
+++ b/tests/backendv2/test_output_axon_allocator.py
@@ -1,0 +1,38 @@
+import pytest
+
+from paibox.backendv2.routing import OutputAxonAllocator
+
+
+class _Elem:
+    def __init__(self, bit_width: int, name: str = "elem") -> None:
+        self.output_bit_num = bit_width
+        self.name = name
+
+    def __repr__(self) -> str:
+        return self.name
+
+
+def test_allocate_voltage_base_addresses_follow_bank_layout():
+    allocator = OutputAxonAllocator()
+
+    bases = [allocator.allocate(_Elem(32, f"v{i}")) for i in range(10)]
+
+    assert bases == [0, 1, 2, 3, 4, 5, 6, 7, 32, 33]
+    assert {0, 8, 16, 24, 32, 40, 48, 56}.issubset(allocator.used_bits)
+
+
+def test_allocate_data_last_address_is_valid():
+    allocator = OutputAxonAllocator()
+    allocator.lowest_free_bit = allocator.MAX_AXON_BIT
+
+    axon_bit = allocator.allocate(_Elem(8, "last_data"))
+
+    assert axon_bit == allocator.MAX_AXON_BIT
+
+
+def test_allocate_voltage_rejects_lane_overflow():
+    allocator = OutputAxonAllocator()
+    allocator.lowest_free_bit = allocator.MAX_AXON_BIT
+
+    with pytest.raises(ValueError, match="exhausted"):
+        allocator.allocate(_Elem(32, "overflow_voltage"))


### PR DESCRIPTION
## Summary
- add `OutputEntry.kind` and `OutputTensorMappings.target_lcn` to backendv2 proto export
- export per-entry `DATA` / `VOLTAGE` semantics from `signal_semantics.output_domain`
- tighten 32-bit output axon allocation bounds for voltage outputs
- document application-side voltage output encoding and work frame II decoding
