### PR TITLE
Feat(paiir): support optional-act `AccumulateOp` fusion

### DIFF
--- a/docs/paiir_backend_guide.md
+++ b/docs/paiir_backend_guide.md
@@ -153,6 +153,12 @@ PyTorch 模型
 PAIIRGraph (backend-ready，可交付后端)
 ```
 
+`PotentialAddOp` 是可部署膜电位加/减的中间表示。若其输入全部来自单消费者 compute path，`fuse_to_offline_cores()` 会进一步把它吸收到 `AccumulateOp`：
+
+- `CompOps -> PotentialAddOp -> ActivationOp` 融合为 `AccumulateOp(act=...)`
+- `CompOps -> PotentialAddOp` 融合为 `AccumulateOp(act=None)`，输出仍是膜电位
+- 不能安全融合的膜电位加/减仍保留为 `PotentialAddOp`
+
 ### 一站式编译接口
 
 `compile_to_paiir()` 封装了上述全部流程：
@@ -297,8 +303,8 @@ PAIIRNode (基类，自动分配唯一 name)
 └── OpNode (算子基类，携带 TensorLayout 元信息)
     ├── OfflineCoreOp (离线核，映射到芯片核心)
     │   ├── SequentialOp      — comp -> act（最常见）
-    │   ├── AccumulateOp      — comps -> add/sub -> act（多路径融合）
-    │   ├── PotentialAddOp             — 纯加法/减法（输出膜电位，无激活）
+    │   ├── AccumulateOp      — comps -> add/sub -> optional act（多路径融合）
+    │   ├── PotentialAddOp    — 膜电位加法/减法（输出膜电位）
     │   ├── StandaloneCompOp  — 纯计算（融合前的中间状态）
     │   └── StandaloneActOp   — 纯激活（融合前的中间状态）
     ├── TransformOp     — 路由变换（layout / shape，非核操作，不占用核资源）
@@ -308,7 +314,7 @@ PAIIRNode (基类，自动分配唯一 name)
     └── CPUOp           — CPU 回退（占位符，仅 v2.5）
 ```
 
-融合后的正常图中主要出现 `SequentialOp`、`AccumulateOp`、`PotentialAddOp`、`TransformOp`、`PadOp`、`ConcatOp` 等算子。`StandaloneCompOp` 和 `StandaloneActOp` 通常在融合后不再独立存在，但在以下场景中仍可能保留：
+融合后的正常图中主要出现 `SequentialOp`、`AccumulateOp`、`PotentialAddOp`、`TransformOp`、`PadOp`、`ConcatOp` 等算子。`AccumulateOp.act` 可为 `None`；此时该核执行多路 compute 后直接输出膜电位。`PotentialAddOp` 仍表示显式膜电位加/减，但当它的输入都是可融合 compute path 且没有多消费者约束时，会被 `AccumulateOp` 吸收。`StandaloneCompOp` 和 `StandaloneActOp` 通常在融合后不再独立存在，但在以下场景中仍可能保留：
 
 前端表达层还可能出现 `GeneralAddOp`，用于忠实表示 PyTorch 的通用 `add/sub` 语义；但它不属于 backend-ready 子集。只要图是通过 `compile_to_paiir()` 生成的，`validate_deployable_graph()` 会确保这类表达层节点已经被收紧或拒绝。
 
@@ -436,6 +442,7 @@ class TensorLayout:
 
 - `output_domain` 是 frontend graph 语义的 source of truth
 - 对 `OfflineCoreOp`，backend-visible `neuron_params.output_type` 应与 `output_domain` 保持一致
+- `AccumulateOp(act=None)` 必须输出 `POTENTIAL`，且 `lut_data` 为 `None`
 - `validate_compiled_graph()` 会把这种一致性当作 compiled-graph 契约的一部分来检查
 - 因此后端若消费离线核节点，读取 `neuron_params.output_type` 时可以假设它已经与前端传播得到的 `output_domain` 对齐，而不需要自己再为 `StandaloneCompOp` / `StandaloneActOp` / `AccumulateOp` 等节点重复推断 VALUE/POTENTIAL 语义
 
@@ -480,7 +487,7 @@ raw_weights: list[Tensor] | None = op.weights
 ```
 
 - `SequentialOp`：若 `comp` 自带显式参数（如 Conv / Linear），返回 `[weight_tensor]`（int8）；池化返回 `None`
-- `AccumulateOp`：返回 `[w0, w1, ...]`（int8），与 `comps` 一一对应；若任一 comp 无显式参数则返回 `None`
+- `AccumulateOp`：返回 `[w0, w1, ...]`（int8），与 `comps` 一一对应；无论 `act` 是否存在，权重路径都按 `comps/signs` 解释；若任一 comp 无显式参数则返回 `None`
 - `PotentialAddOp`：返回 `None`
 - `StandaloneActOp`：返回 `None`
 

--- a/paibox/paiir/ir/op_node.py
+++ b/paibox/paiir/ir/op_node.py
@@ -1,13 +1,13 @@
 """Operator IR nodes for chip deployment.
 
 Each :class:`OfflineCoreOp` represents a computation unit that maps to a single
-chip offline core (v2.0 or v2.5): a compute operation plus a neuron / activation.
-The IR is version-agnostic; the backend handles target-specific lowering.
+chip offline core (v2.0 or v2.5): compute, activation, or both. The IR is
+version-agnostic; the backend handles target-specific lowering.
 
 Node types:
 
 - :class:`SequentialOp` -- compute -> neuron/lut
-- :class:`AccumulateOp` -- multi-path compute -> add/sub -> neuron/lut
+- :class:`AccumulateOp` -- multi-path compute -> add/sub -> optional neuron/lut
 - :class:`StandaloneCompOp` -- compute only (potential output)
 - :class:`StandaloneActOp` -- neuron/lut only
 - routing ops such as :class:`TransformOp`, :class:`ConcatOp`, and
@@ -403,27 +403,28 @@ class SequentialOp(OfflineCoreOp):
 
 
 class AccumulateOp(OfflineCoreOp):
-    """Multi-path accumulation: comps -> add/sub -> activation.
+    """Multi-path accumulation: comps -> add/sub -> optional activation.
 
     Accumulates outputs of multiple compute operations with per-path signs,
-    then feeds the result into a neuron / activation.
-    E.g. ``Conv_a(x1) + Conv_b(x2) -> LIFNodeV25``.
+    then optionally feeds the result into a neuron / activation.
+    E.g. ``Conv_a(x1) + Conv_b(x2) -> LIFNodeV25`` or
+    ``Linear_a(x1) + Linear_b(x2)`` as a potential-domain output.
 
     Args:
         comps: List of compute operations (one per input path).
-        act: Neuron or LUT activation.
+        act: Optional neuron or LUT activation.
         op_signs: Per-path sign. ``(1, 1)`` = add, ``(1, -1)`` = subtract.
 
     The public constructor derives semantic core parameters from ``comps`` and
-    ``act``. Advanced callers that need to preserve prepared compile-time
-    state should construct the node normally, then call
+    optional ``act``. Advanced callers that need to preserve prepared
+    compile-time state should construct the node normally, then call
     :meth:`OfflineCoreOp.override_compile_state`.
     """
 
     def __init__(
         self,
         comps: Sequence[nn.Module],
-        act: CoreNeuronV25,
+        act: CoreNeuronV25 | None,
         op_signs: tuple[int, ...] | None = None,
     ) -> None:
         if op_signs is None:
@@ -434,7 +435,8 @@ class AccumulateOp(OfflineCoreOp):
             )
 
         core_params = OfflineCoreParams()
-        core_params.snn_mode = act.snn_mode
+        if act is not None:
+            core_params.snn_mode = act.snn_mode
         core_params.pooling_mode = _get_pooling_mode(comps[0])
 
         super().__init__(core_params)
@@ -449,6 +451,8 @@ class AccumulateOp(OfflineCoreOp):
             acc = term if acc is None else acc + term
 
         assert acc is not None, "AccumulateOp requires at least one input"
+        if self.act is None:
+            return acc
         return self.act(_prepare_act_input(self.act, acc))
 
     @property
@@ -478,6 +482,8 @@ class AccumulateOp(OfflineCoreOp):
     @property
     def lut_data(self) -> LutData | None:
         """LUT table data for backend export."""
+        if self.act is None:
+            return None
         return self.act.export_lut()
 
     @property
@@ -490,13 +496,24 @@ class AccumulateOp(OfflineCoreOp):
                 term = sign * b
                 fused_bias = term if fused_bias is None else fused_bias + term
 
+        if self.act is None:
+            return self._with_domain_derived_output_type(
+                NeuronParams(
+                    leak_v=fused_bias if fused_bias is not None else 0.0,
+                    output_type=OutputType.POTENTIAL,
+                )
+            )
+
         return self._with_domain_derived_output_type(
             self.act.to_neuron_params(bias=fused_bias)
         )
 
     def extra_repr(self) -> str:
         ops = ", ".join(type(op).__name__ for op in self.comps)
-        return f"{super().extra_repr()}, comps=[{ops}], signs={self.signs}, act={type(self.act).__name__}"
+        act_repr = "None" if self.act is None else type(self.act).__name__
+        return (
+            f"{super().extra_repr()}, comps=[{ops}], signs={self.signs}, act={act_repr}"
+        )
 
 
 class ConcatOp(RoutingOp):

--- a/paibox/paiir/pipeline/passes.py
+++ b/paibox/paiir/pipeline/passes.py
@@ -460,36 +460,38 @@ def fuse_to_offline_cores(
 
     for name in graph.topo_sort():
         node = graph.nodes[name]
-        if not isinstance(node, StandaloneActOp):
-            continue
         if name in consumed:
             continue
 
-        result = _try_handle_avgpool_activation(
-            graph,
-            name,
-            consumed,
-            node_remap,
-            enable_split_avgpool_lif=enable_split_avgpool_lif,
-            enable_avgpool_calibration=enable_avgpool_calibration,
-        )
-        if result is not None:
-            if isinstance(result, list):
-                for fused in result:
-                    fused_nodes[fused.name] = fused
-            else:
+        if isinstance(node, StandaloneActOp):
+            result = _try_handle_avgpool_activation(
+                graph,
+                name,
+                consumed,
+                node_remap,
+                enable_split_avgpool_lif=enable_split_avgpool_lif,
+                enable_avgpool_calibration=enable_avgpool_calibration,
+            )
+            if result is not None:
+                if isinstance(result, list):
+                    for fused in result:
+                        fused_nodes[fused.name] = fused
+                else:
+                    fused_nodes[result.name] = result
+                continue
+
+            result = _try_fuse_sequential(graph, name, consumed, node_remap)
+            if result is not None:
                 fused_nodes[result.name] = result
-            continue
+                continue
 
-        result = _try_fuse_sequential(graph, name, consumed, node_remap)
-        if result is not None:
-            fused_nodes[result.name] = result
-            continue
-
-        result = _try_fuse_accumulate(graph, name, consumed, node_remap, port_remap)
-        if result is not None:
-            fused_nodes[result.name] = result
-            continue
+        if isinstance(node, PotentialAddOp):
+            # Accumulate fusion is anchored at the add node because the
+            # activation stage is optional: comp paths may feed either
+            # ``PotentialAddOp -> StandaloneActOp`` or a bare ``PotentialAddOp``.
+            result = _try_fuse_accumulate(graph, name, consumed, node_remap, port_remap)
+            if result is not None:
+                fused_nodes[result.name] = result
 
     new_graph = PAIIRGraph(graph.name)
     for name in graph.topo_sort():
@@ -540,31 +542,78 @@ def _try_fuse_sequential(
 
 def _try_fuse_accumulate(
     graph: PAIIRGraph,
-    act_name: str,
+    add_name: str,
     consumed: set[str],
     node_remap: dict[str, str],
     port_remap: dict[str, int],
 ) -> AccumulateOp | None:
-    """Try to fuse ``CompOps -> PotentialAddOp -> ActivationOp``."""
-    act_node = graph.nodes[act_name]
-    assert isinstance(act_node, StandaloneActOp)
+    """Try to fuse ``CompOps -> PotentialAddOp -> optional ActivationOp``.
 
-    preds = graph.predecessors(act_name)
-    if len(preds) != 1:
-        return None
-
-    add_name = preds[0]
-    if add_name in consumed:
-        return None
-
+    The add node is the stable anchor for both activated and no-activation
+    forms.  When the add's sole successor is a standalone activation, that
+    activation becomes ``AccumulateOp.act``; otherwise the fused node emits
+    membrane potential directly.
+    """
     add_node = graph.nodes[add_name]
-    if not isinstance(add_node, PotentialAddOp):
+    assert isinstance(add_node, PotentialAddOp)
+
+    successors = graph.successors(add_name)
+    if len(successors) != 1:
         return None
 
-    if len(graph.successors(add_name)) != 1:
+    succ_name = successors[0]
+    succ_node = graph.nodes[succ_name]
+    act: CoreNeuronV25 | None = None
+    output_layouts = add_node.output_layouts
+    consumed_successor: str | None = None
+
+    if isinstance(succ_node, StandaloneActOp):
+        if succ_name in consumed:
+            return None
+        if graph.predecessors(succ_name) != [add_name]:
+            return None
+
+        act = succ_node.act
+        output_layouts = succ_node.output_layouts
+        consumed_successor = succ_name
+
+    materialized = _materialize_accumulate_from_potential_add(
+        graph, add_name, add_node, act, consumed, node_remap, port_remap
+    )
+    if materialized is None:
         return None
 
+    fused, _ = materialized
+    fused.output_layouts = output_layouts
+
+    if consumed_successor is not None:
+        consumed.add(consumed_successor)
+        node_remap[consumed_successor] = fused.name
+
+    return fused
+
+
+def _materialize_accumulate_from_potential_add(
+    graph: PAIIRGraph,
+    add_name: str,
+    add_node: PotentialAddOp,
+    act: CoreNeuronV25 | None,
+    consumed: set[str],
+    node_remap: dict[str, str],
+    port_remap: dict[str, int],
+) -> tuple[AccumulateOp, list[str]] | None:
+    """Create an ``AccumulateOp`` from a deployable potential-add pattern.
+
+    This helper validates the shared structural requirements for both
+    activation and no-activation accumulation: every add predecessor must be a
+    single-use ``StandaloneCompOp``, and the predecessor count must match the
+    signed add paths.  On success it also records consumed comp/add nodes and
+    port remaps for edge rebuilding.  The caller owns output-layout selection
+    and optional activation-consumer remapping.
+    """
     comp_preds = graph.predecessors(add_name)
+    if len(comp_preds) != len(add_node.signs):
+        return None
     if any(p in consumed for p in comp_preds):
         return None
     if not all(isinstance(graph.nodes[p], StandaloneCompOp) for p in comp_preds):
@@ -573,25 +622,20 @@ def _try_fuse_accumulate(
         return None
 
     comps = [graph.nodes[p].comp for p in comp_preds]  # type: ignore[union-attr]
-    op_signs = add_node.signs
-
-    fused = AccumulateOp(comps=comps, act=act_node.act, op_signs=op_signs)
+    fused = AccumulateOp(comps, act, add_node.signs)
     fused_input_layouts = []
     for p in comp_preds:
         fused_input_layouts.extend(graph.nodes[p].input_layouts)  # type: ignore[union-attr]
     fused.input_layouts = tuple(fused_input_layouts)
-    fused.output_layouts = act_node.output_layouts
 
-    consumed.add(act_name)
     consumed.add(add_name)
-    node_remap[act_name] = fused.name
     node_remap[add_name] = fused.name
     for i, p in enumerate(comp_preds):
         consumed.add(p)
         node_remap[p] = fused.name
         port_remap[p] = i
 
-    return fused
+    return fused, comp_preds
 
 
 def _rebuild_edges(

--- a/tests/paiir/ir/test_op_node.py
+++ b/tests/paiir/ir/test_op_node.py
@@ -177,6 +177,21 @@ class TestAccumulateOp:
         out = op(x1, x2)
         assert out.shape == (1, 8)
 
+    def test_without_activation_emits_potential_sum(self):
+        linear_a = nn.Linear(2, 2, bias=False)
+        linear_b = nn.Linear(2, 2, bias=False)
+        with torch.no_grad():
+            linear_a.weight.copy_(torch.eye(2))
+            linear_b.weight.copy_(2 * torch.eye(2))
+
+        op = AccumulateOp(comps=[linear_a, linear_b], act=None, op_signs=(1, -1))
+        x1 = torch.tensor([[3.0, 4.0]])
+        x2 = torch.tensor([[1.0, 2.0]])
+
+        assert torch.equal(op(x1, x2), torch.tensor([[1.0, 0.0]]))
+        assert op.lut_data is None
+        assert op.neuron_params.output_type is OutputType.POTENTIAL
+
     def test_sign_length_mismatch(self):
         with pytest.raises(ValueError, match="op_signs"):
             AccumulateOp(comps=[nn.Linear(4, 8)], act=IFNodeV25(), op_signs=(1, -1))

--- a/tests/paiir/pipeline/test_passes.py
+++ b/tests/paiir/pipeline/test_passes.py
@@ -505,32 +505,34 @@ class TestGeneralAddChainFlattening:
         assert len(compiled.input_nodes()) == 3
 
     @pytest.mark.parametrize(
-        ("model_cls", "expected_signs"),
+        ("model", "expected_signs"),
         [(SubtractLeftChain, (1, -1, 1)), (SubtractRightChain, (1, 1, -1))],
         ids=["a_minus_b_plus_c", "a_plus_b_minus_c"],
     )
-    def test_chain_signs_are_preserved(self, model_cls, expected_signs):
-        compiled = compile_to_paiir(model_cls(), make_vec_8d())
+    def test_chain_signs_are_preserved(self, model, expected_signs):
+        compiled = compile_to_paiir(model(), make_vec_8d())
 
         accum = self._single_accumulate(compiled)
         assert accum.signs == expected_signs
 
     @pytest.mark.parametrize(
-        ("model_cls", "expected_signs"),
-        [
-            (NoActivationAddChain, (1, 1, 1)),
-            (NoActivationSubtractChain, (1, -1, 1)),
-        ],
+        ("model", "expected_signs"),
+        [(NoActivationAddChain, (1, 1, 1)), (NoActivationSubtractChain, (1, -1, 1))],
         ids=["add", "subtract"],
     )
-    def test_no_activation_chain_compiles_to_nary_potential_add(
-        self, model_cls, expected_signs
+    def test_no_activation_chain_compiles_to_potential_accumulate(
+        self, model, expected_signs
     ):
-        compiled = compile_to_paiir(model_cls(), make_vec_8d())
+        compiled = compile_to_paiir(model(), make_vec_8d())
 
-        add = self._single_potential_add(compiled)
-        assert add.signs == expected_signs
-        assert len(find_nodes(compiled, StandaloneCompOp)) == 3
+        accum = self._single_accumulate(compiled)
+        assert accum.act is None
+        assert accum.signs == expected_signs
+        assert len(accum.comps) == 3
+        assert find_nodes(compiled, StandaloneCompOp) == []
+        assert accum.signal_semantics.output_domain is SignalDomain.POTENTIAL
+        assert accum.core_params.output_sign is DataSign.SIGNED
+        assert accum.core_params.output_width is DataWidth.WIDTH_32BIT
 
     @pytest.mark.parametrize("transform_kind", ["view", "reshape", "flatten"])
     def test_shape_preserving_order_preserving_operand_transform_flattens(
@@ -571,20 +573,18 @@ class TestGeneralAddChainFlattening:
         self._assert_not_accumulated(model, x)
 
     @pytest.mark.parametrize(
-        "model_cls",
+        "model",
         [MultiConsumerMiddleAdd, MultiConsumerTransformOperand],
         ids=["middle_add", "transform_operand"],
     )
-    def test_multi_consumer_chain_member_does_not_flatten(self, model_cls):
-        flattened = self._assert_binary_add_chain_not_flattened(
-            model_cls(), make_vec_8d()
-        )
+    def test_multi_consumer_chain_member_does_not_flatten(self, model):
+        flattened = self._assert_binary_add_chain_not_flattened(model(), make_vec_8d())
         assert all(
             node.coeffs == (1, 1) for node in find_nodes(flattened, GeneralAddOp)
         )
 
     @pytest.mark.parametrize(
-        "model_cls",
+        "model",
         [
             ConstOperandChain,
             BroadcastOperandChain,
@@ -593,8 +593,8 @@ class TestGeneralAddChainFlattening:
         ],
         ids=["const", "broadcast", "repeated_producer", "non_unit_coeff"],
     )
-    def test_unsupported_operand_form_does_not_flatten(self, model_cls):
-        _, add_nodes = self._flattened_add_nodes(model_cls(), make_vec_8d())
+    def test_unsupported_operand_form_does_not_flatten(self, model):
+        _, add_nodes = self._flattened_add_nodes(model(), make_vec_8d())
 
         assert len(add_nodes) == 2
         assert all(len(node.operands) == 2 for node in add_nodes)
@@ -1813,7 +1813,7 @@ class TestSignalSemantics:
         assert out.signal_semantics.output_domain == SignalDomain.VALUE
         assert out.signal_semantics.known_code_range is None
 
-    def test_potential_add_from_residual_comp_propagates_potential_domain(self):
+    def test_accumulate_without_activation_propagates_potential_domain(self):
         class MembraneAdd(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -1828,10 +1828,11 @@ class TestSignalSemantics:
 
         propagate_signal_semantics(fused)
 
-        add = find_first(fused, PotentialAddOp)
+        accum = find_first(fused, AccumulateOp)
         out = fused.output_nodes()[0]
-        assert add.signal_semantics.output_domain == SignalDomain.POTENTIAL
-        assert add.signal_semantics.known_code_range is None
+        assert accum.act is None
+        assert accum.signal_semantics.output_domain == SignalDomain.POTENTIAL
+        assert accum.signal_semantics.known_code_range is None
         assert out.signal_semantics.output_domain == SignalDomain.POTENTIAL
         assert out.signal_semantics.known_code_range is None
 


### PR DESCRIPTION
## Summary
- generalize `AccumulateOp` so activation is optional and no-act paths emit membrane potential
- fuse `CompOps -> PotentialAddOp` into `AccumulateOp(act=None)` while preserving activated accumulate fusion
- document optional-act accumulate semantics and add focused PAIIR tests