### PR TITLE
Feat(paiir): output-layer `AvgPool` sum/count approximation

### DIFF
--- a/docs/paiir_backend_guide.md
+++ b/docs/paiir_backend_guide.md
@@ -192,20 +192,20 @@ graph = compile_to_paiir(model, x, compile_config=cfg, strict=False)
 
 `compile_to_paiir` 完整参数：
 
-| 参数                         | 类型                            | 说明                                                |
-| ---------------------------- | ------------------------------- | --------------------------------------------------- |
-| `model`                      | `nn.Module`                     | PyTorch 模型                                        |
-| `*sample_inputs`             | `Tensor`                        | 示例输入（batch_size 必须为 1），用于推断形状和维度 |
-| `tick_duration`              | `int \| None`                   | 显式全局工作时长，`0` 表示常开；默认 None           |
-| `auto_reset`                 | `bool \| None`                  | 显式控制工作周期结束后是否自动复位；默认 None       |
-| `input_formats`              | `dict[str, DataFormat] \| None` | 按 InputNode 名指定输入数据格式                     |
-| `compile_config`             | `CompileConfig \| None`         | 配置对象（关键字参数优先级更高）                    |
-| `concrete_args`              | `dict[str, Any] \| None`        | 传递给 `fx.Tracer.trace` 的具体参数                 |
-| `strict`                     | `bool`                          | True = 遇到不支持的算子时报错；False = 警告并跳过   |
-| `enable_avgpool_calibration` | `bool \| None`                  | 是否启用共享核 AvgPool+LIF 阈值细化，默认关闭       |
-| `enable_split_avgpool_lif`   | `bool \| None`                  | 是否允许条件式 AvgPool+LIF 分核部署，默认关闭       |
-| `enable_delayed_avgpool_division` | `bool \| None`             | 是否启用 AvgPool 延迟除法改写，默认开启             |
-| `output_approx`              | `"default" \| "sum_approx_if_avgpool" \| None` | 输出边界近似策略，默认保持标准策略 |
+| 参数                              | 类型                                           | 说明                                                |
+| --------------------------------- | ---------------------------------------------- | --------------------------------------------------- |
+| `model`                           | `nn.Module`                                    | PyTorch 模型                                        |
+| `*sample_inputs`                  | `Tensor`                                       | 示例输入（batch_size 必须为 1），用于推断形状和维度 |
+| `tick_duration`                   | `int \| None`                                  | 显式全局工作时长，`0` 表示常开；默认 None           |
+| `auto_reset`                      | `bool \| None`                                 | 显式控制工作周期结束后是否自动复位；默认 None       |
+| `input_formats`                   | `dict[str, DataFormat] \| None`                | 按 InputNode 名指定输入数据格式                     |
+| `compile_config`                  | `CompileConfig \| None`                        | 配置对象（关键字参数优先级更高）                    |
+| `concrete_args`                   | `dict[str, Any] \| None`                       | 传递给 `fx.Tracer.trace` 的具体参数                 |
+| `strict`                          | `bool`                                         | True = 遇到不支持的算子时报错；False = 警告并跳过   |
+| `enable_avgpool_calibration`      | `bool \| None`                                 | 是否启用共享核 AvgPool+LIF 阈值细化，默认关闭       |
+| `enable_split_avgpool_lif`        | `bool \| None`                                 | 是否允许条件式 AvgPool+LIF 分核部署，默认关闭       |
+| `enable_delayed_avgpool_division` | `bool \| None`                                 | 是否启用 AvgPool 延迟除法改写，默认开启             |
+| `output_approx`                   | `"default" \| "sum_approx_if_avgpool" \| None` | 输出边界近似策略，默认保持标准策略                  |
 
 `tick_duration=None` / `auto_reset=None` 表示未显式指定时序策略。此时 ANN 模式计算核默认 `tick_duration=1`、`tick_initial=1`，SNN 模式计算核默认 `tick_duration=0`、`tick_initial=0`。通过关键字参数或 `CompileConfig` 显式传入的 `tick_duration` / `auto_reset` 优先于 ANN/SNN 模式默认；关键字参数优先级高于 `CompileConfig`。
 

--- a/docs/paiir_backend_guide.md
+++ b/docs/paiir_backend_guide.md
@@ -84,6 +84,8 @@ register_module(MyQuantConv, to_canonical_conv)
 
 SpikingJelly `activation_based.layer` wrapper 是另一类前端入口。当前支持的 wrapper 包括 `layer.Conv1d/2d`、`layer.Linear`、`layer.MaxPool1d/2d`、`layer.AvgPool1d/2d`、`layer.AdaptiveAvgPool1d/2d`、`layer.Flatten`；这些 wrapper 会按对应普通模块路径进入 PAIIR。注意这里讨论的是 SpikingJelly `activation_based.layer` 模块内实际存在的 wrapper；原生 `torch.nn` 模块支持属于另一类入口。
 
+普通 `AvgPool1d/2d` 与 `MaxPool1d/2d` 当前不支持 `ceil_mode=True`。该属性会导致后端部署语义不成立，因此 lowering 阶段统一抛出 `UnsupportedOpError`，不走 `strict=False` 的 warning/bypass 路径。通过 `register_module(...)` 返回的 canonical pooling 模块也遵循同一硬错误规则。
+
 ### 自定义神经元或 LUT 激活
 
 `register_neuron(...)` 是面向神经元/激活的兼容入口。converter 可以返回 `CoreNeuronV25`，也可以返回 `LutActivation`；后者会被包装为 `ANNNodeV25(lut)`。
@@ -141,13 +143,17 @@ PyTorch 模型
     │
     ▼  ⑥ propagate_data_format()    — 两阶段数据格式推理（输出/权重 → 输入传播）
     │
-    ▼  ⑦ assign_tick_params()       — 基于 DAG 深度分配时序参数
+    ▼  ⑦ rewrite_delayed_avgpool_division() — 可选 AvgPool 延迟除法改写
     │
-    ▼  ⑧ calibrate_avgpool_thresholds() — 可选 AvgPool 阈值细化
+    ▼  ⑧ rewrite_standalone_avgpools() — standalone AvgPool 后处理，含输出边界近似
     │
-    ▼  ⑨ validate_compiled_graph()  — 编译完成后的结构/元信息校验
+    ▼  ⑨ assign_tick_params()       — 基于 DAG 深度分配时序参数
     │
-    ▼  ⑩ validate_deployable_graph() — backend-ready 子集与契约校验
+    ▼  ⑩ calibrate_avgpool_thresholds() — 可选 AvgPool 阈值细化
+    │
+    ▼  ⑪ validate_compiled_graph()  — 编译完成后的结构/元信息校验
+    │
+    ▼  ⑫ validate_deployable_graph() — backend-ready 子集与契约校验
     │
     ▼
 PAIIRGraph (backend-ready，可交付后端)
@@ -198,8 +204,31 @@ graph = compile_to_paiir(model, x, compile_config=cfg, strict=False)
 | `strict`                     | `bool`                          | True = 遇到不支持的算子时报错；False = 警告并跳过   |
 | `enable_avgpool_calibration` | `bool \| None`                  | 是否启用共享核 AvgPool+LIF 阈值细化，默认关闭       |
 | `enable_split_avgpool_lif`   | `bool \| None`                  | 是否允许条件式 AvgPool+LIF 分核部署，默认关闭       |
+| `enable_delayed_avgpool_division` | `bool \| None`             | 是否启用 AvgPool 延迟除法改写，默认开启             |
+| `output_approx`              | `"default" \| "sum_approx_if_avgpool" \| None` | 输出边界近似策略，默认保持标准策略 |
 
 `tick_duration=None` / `auto_reset=None` 表示未显式指定时序策略。此时 ANN 模式计算核默认 `tick_duration=1`、`tick_initial=1`，SNN 模式计算核默认 `tick_duration=0`、`tick_initial=0`。通过关键字参数或 `CompileConfig` 显式传入的 `tick_duration` / `auto_reset` 优先于 ANN/SNN 模式默认；关键字参数优先级高于 `CompileConfig`。
+
+### 输出边界 AvgPool 近似
+
+`output_approx="sum_approx_if_avgpool"` 是显式 opt-in 的输出层策略。它只处理直接流向 `OutputNode` 的 `AvgPool1d/2d`，允许中间存在格式透明 routing 节点；SpikingJelly `VotingLayer` lowering 后得到的 `AvgPool1d` 也属于这一类。
+
+满足条件时，输出层 `AvgPool` 会被改写为：
+
+```text
+SequentialOp(SumPool1d/2d, ANNNodeV25(identity LUT))
+```
+
+后端看到的是普通 VALUE-domain 离线核输出，数据格式由 identity LUT 的输出范围推导。例如 `VotingLayer(10)` 的输出可成为范围 `[0, 10]` 的 `u4 DATA`。但这个输出不再是原始平均值，而是未归一化的 sum/count。
+
+当前 CPU 侧责任没有结构化写入 PAIIR 图或 proto。编译期会通过 `OutputApproxWarning` 明确提示：
+
+- 原输出层节点和原算子类型
+- 实际导出形式，例如 `SumPool1d + identity LUT`
+- 导出 code range 和 DATA bit width
+- 应用侧 CPU 需要除以 logical divisor 恢复平均值，或按任务语义累计 count 后再做 `argmax`
+
+后续如果引入可部署的 `CPUOp` 或导出侧 CPU task 描述，应把这段 divide/accumulate 职责从 warning 提升为结构化图/导出元数据。
 
 ### 分步编译
 

--- a/docs/user_quickstart.md
+++ b/docs/user_quickstart.md
@@ -188,6 +188,7 @@ uv run python -c "import torch, spikingjelly, paicorelib, numba, paibox; print('
 - `nn.Dropout`、`nn.Identity` 会在 lowering 早期被擦除
 - `layer.Dropout`、`layer.Dropout2d` 也会在 lowering 早期被擦除
 - `nn.BatchNorm1d`、`nn.BatchNorm2d` 当前按 bypass 处理，不应把它们当成部署后仍需要的独立硬件语义
+- 普通 `AvgPool1d/2d` 与 `MaxPool1d/2d` 当前不支持 `ceil_mode=True`；这类设置会直接报 `UnsupportedOpError`，不会因为 `strict=False` 被旁路
 
 如果模型里出现 unsupported op：
 
@@ -332,6 +333,7 @@ print("frame_dir:", output_dir)
 | `enable_avgpool_calibration`      | 共享核 `AvgPool + LIF` 阈值细化开关                     |
 | `enable_split_avgpool_lif`        | 条件式 `AvgPool + LIF` 分核部署开关                     |
 | `enable_delayed_avgpool_division` | AvgPool 延迟除法改写开关，默认开启                      |
+| `output_approx`                   | 输出层近似策略，默认 `"default"`                        |
 
 优先级为：
 
@@ -393,6 +395,33 @@ graph = compile_to_paiir(model, sample_input, strict=False)
 - 看结构、看 warning、做前端兼容性排查
 
 不要把 `strict=False` 的返回图直接视为可部署图。
+
+### 7.5 输出层 AvgPool 近似策略
+
+默认 `output_approx="default"` 不改变标准输出策略。对于输出层 `AvgPool1d/2d`，如果默认路径需要把平均池化降级为多数脉冲输出，编译期会发出 `OutputApproxWarning`，提醒该输出已不再是原始浮点/整数平均值。
+
+如果应用侧希望保留“计数”语义，可以显式启用：
+
+```python
+graph = compile_to_paiir(
+    model,
+    sample_input,
+    output_approx="sum_approx_if_avgpool",
+)
+```
+
+该策略只作用于直接流向图输出边界的 `AvgPool1d/2d`，包括由 SpikingJelly `VotingLayer` lowering 得到的 `AvgPool1d`。满足条件时，前端会把输出层平均池化导出为：
+
+```text
+AvgPool -> SumPool + identity LUT
+```
+
+这意味着芯片侧输出的是未除以 divisor 的 sum/count，而不是原始平均值。应用侧 CPU 必须按任务语义继续处理：
+
+- 若需要恢复平均值，除以 warning 中给出的 logical divisor
+- 若分类任务只关心多 tick 累计后的 `argmax`，可直接累计 count 后再做 `argmax`
+
+该策略当前要求输出层池化窗口完整、无 padding、输入为 VALUE 域且可推导精确 code range，并且 sum/count 范围能放入 8-bit VALUE 数据路径。策略生效时会发出 `OutputApproxWarning`，其中包含原节点、导出形式、导出范围、数据格式和 CPU 侧责任。当前 CPU 后处理责任只通过 warning 和文档表达，还没有作为结构化 CPU task 写入导出产物。
 
 ## 8. 自定义激活 / 自定义 neuron / 自定义模块
 

--- a/paibox/paiir/exceptions.py
+++ b/paibox/paiir/exceptions.py
@@ -5,6 +5,7 @@ from ..exceptions import PAIBoxError, PAIBoxWarning
 __all__ = [
     "GraphCleanupWarning",
     "GraphValidationError",
+    "OutputApproxWarning",
     "PAIIRError",
     "PAIIRWarning",
     "UnsupportedFusionError",
@@ -86,6 +87,12 @@ class UnsupportedOpWarning(PAIIRWarning):
             f"Encountered {len(unsupported_ops)} unsupported operator(s), "
             f"which will be bypassed (data flow will skip these nodes):\n{ops_list}"
         )
+
+
+class OutputApproxWarning(PAIIRWarning):
+    """Warning emitted when an output-boundary op changes exported semantics."""
+
+    pass
 
 
 class GraphValidationError(PAIIRError):

--- a/paibox/paiir/lowering/converter.py
+++ b/paibox/paiir/lowering/converter.py
@@ -177,6 +177,17 @@ def _has_nonzero_padding(padding: Any) -> bool:
     return int(padding) != 0
 
 
+def _describe_ceil_mode_pooling_issue(m: nn.Module) -> str | None:
+    """Describe pooling ceil windows that cannot enter deployable PAIIR."""
+    if not isinstance(m, (nn.AvgPool1d, nn.AvgPool2d, nn.MaxPool1d, nn.MaxPool2d)):
+        return None
+
+    if m.ceil_mode:
+        return f"nn.Module '{type(m).__name__}' with ceil_mode=True"
+
+    return None
+
+
 def _describe_avgpool_lowering_issue(m: nn.Module) -> str | None:
     if not isinstance(m, (nn.AvgPool1d, nn.AvgPool2d)):
         return None
@@ -203,6 +214,8 @@ def _describe_maxpool_lowering_issue(m: nn.Module) -> str | None:
 
     if m.return_indices:
         return f"nn.Module '{type(m).__name__}' with return_indices=True"
+
+    return None
 
 
 def _normalize_static_padding(value: Any) -> tuple[int, ...] | None:
@@ -377,6 +390,12 @@ def _ensure_supported_canonical_module(
             "register_module converter must return a builtin canonical module "
             "supported by PAIIR lowering, "
             f"got unsupported {type(canonical).__name__}"
+        )
+
+    # Canonical converters must not smuggle unsupported pool geometry into IR.
+    if (ceil_issue := _describe_ceil_mode_pooling_issue(canonical)) is not None:
+        raise UnsupportedOpError(
+            module_type.__name__, f"canonical module: {ceil_issue}"
         )
 
     if (avgpool_issue := _describe_avgpool_lowering_issue(canonical)) is not None:
@@ -1303,6 +1322,11 @@ def _apply_module_lowering_rule(
             paiir_graph, ctx, node, ir_node, input_nodes_override=reshape_override
         )
         return True
+
+    # This is a hard frontend boundary: letting strict=False bypass the pool
+    # would produce a graph that no longer represents the deployment model.
+    if (ceil_issue := _describe_ceil_mode_pooling_issue(torch_module)) is not None:
+        raise UnsupportedOpError(node.name, ceil_issue)
 
     if (mod_type := type(torch_module)) in _USER_MODULE_MAP:
         ir_node = module_map[mod_type](torch_module)

--- a/paibox/paiir/nn/functional.py
+++ b/paibox/paiir/nn/functional.py
@@ -61,7 +61,7 @@ def sumpool1d(
     else:
         L_out = (L_in - effective_k) // s + 1
 
-    unfolded = F.unfold(input.unsqueeze(2), (1, k), (1, d), (1, s))
+    unfolded = F.unfold(input.unsqueeze(2), (1, k), (1, d), (0, 0), (1, s))
     unfolded = unfolded.view(input.shape[0], channels, k, -1)
     summed = unfolded.sum(dim=2).view(input.shape[0], channels, L_out)
     return summed.squeeze(0) if squeeze_batch else summed
@@ -149,7 +149,7 @@ def sumpool2d(
 
     # Use fold/unfold for efficient computation
     # unfold: (N, C, H, W) -> (N, C*kH*kW, H_out*W_out)
-    unfolded = F.unfold(input, (kH, kW), (dH, dW), (sH, sW))
+    unfolded = F.unfold(input, (kH, kW), (dH, dW), (0, 0), (sH, sW))
 
     # Reshape to separate channel and window dimensions
     # (N, C*kH*kW, L) -> (N, C, kH*kW, L)

--- a/paibox/paiir/pipeline/avgpool/delayed_division.py
+++ b/paibox/paiir/pipeline/avgpool/delayed_division.py
@@ -22,13 +22,12 @@ from paicorelib import OfflineNeuRegLim
 
 from ...ir.core_neuron import ANNNodeV25, CoreNeuronV25
 from ...ir.graph import PAIIRGraph
-from ...ir.ir_base import InputNode, OutputNode, PAIIRNode
+from ...ir.ir_base import OutputNode, PAIIRNode
 from ...ir.lut_activation import LutActivation, LutCustom
-from ...ir.op_node import OfflineCoreOp, SequentialOp, StandaloneActOp, StandaloneCompOp
-from ...ir.signal_domain import SignalDomain
+from ...ir.op_node import SequentialOp, StandaloneActOp, StandaloneCompOp
 from ..data_format import fits_value_code_range
 from ..graph_utils import (
-    collect_effective_predecessor_values,
+    collect_effective_value_code_ranges,
     is_format_transparent_routing_node,
 )
 from .utils import build_sum_pool, get_avgpool_divisor, get_pool_window_size, is_avgpool
@@ -103,7 +102,9 @@ def _analyze_delayed_division_chain(
     Those are only equal for the common ``divisor == window_size`` case, so the
     pass keeps them separate to handle ``divisor_override`` correctly.
     """
-    code_ranges = _collect_effective_source_code_ranges(graph, start_name)
+    code_ranges = collect_effective_value_code_ranges(
+        graph, start_name, passthrough=_is_source_transparent_node
+    )
     if len(code_ranges) != 1:
         return None
 
@@ -200,46 +201,6 @@ def _build_identity_lut(signed: bool) -> LutCustom:
     thresholds = torch.arange(_UINT8_MAX + 1, dtype=torch.int32)
     values = torch.arange(_UINT8_MAX + 1, dtype=torch.uint8)
     return LutCustom(thresholds, values, output_sign=0, is_float=False)
-
-
-def _collect_effective_source_code_ranges(
-    graph: PAIIRGraph, node_name: str
-) -> list[tuple[int, int]]:
-    """Collect code ranges from effective VALUE-domain producers upstream."""
-    return collect_effective_predecessor_values(
-        graph,
-        node_name,
-        _resolve_effective_source_code_ranges,
-        _is_source_transparent_node,
-    )
-
-
-def _resolve_effective_source_code_ranges(
-    node: PAIIRNode, _node_name: str
-) -> list[tuple[int, int]] | None:
-    if _is_source_transparent_node(node):
-        return None
-
-    if isinstance(node, InputNode):
-        code_range = node.signal_semantics.known_code_range
-        return [] if code_range is None else [code_range]
-
-    code_range = _get_effective_output_code_range(node)
-    if code_range is not None:
-        return [code_range]
-
-    if isinstance(node, OfflineCoreOp):
-        return []
-
-    return None
-
-
-def _get_effective_output_code_range(node: PAIIRNode) -> tuple[int, int] | None:
-    if not isinstance(node, OfflineCoreOp):
-        return None
-    if node.signal_semantics.output_domain is not SignalDomain.VALUE:
-        return None
-    return node.signal_semantics.known_code_range
 
 
 def _is_source_transparent_node(node: PAIIRNode) -> bool:

--- a/paibox/paiir/pipeline/avgpool/standalone_rewrite.py
+++ b/paibox/paiir/pipeline/avgpool/standalone_rewrite.py
@@ -1,17 +1,29 @@
-"""Standalone AvgPool rewrite modes."""
+"""Standalone AvgPool rewrite modes.
+
+This pass handles AvgPool nodes that remain after normal core fusion. Most
+rewrites preserve the original graph semantics. The output-boundary
+``sum_approx_if_avgpool`` mode is explicit because it changes the exported
+value from an average to an unnormalized sum/count for host-side handling.
+"""
+
+import warnings
+from typing import Literal, TypeAlias
 
 import torch
 from paicorelib import DataSign, DataWidth, SNNMode, ThresholdNegMode
 from torch import nn
 
+from ...exceptions import OutputApproxWarning
 from ...ir.core_neuron import ANNNodeV25, IFNodeV25
 from ...ir.graph import PAIIRGraph
 from ...ir.ir_base import InputNode, OutputNode, PAIIRNode
 from ...ir.lut_activation import LutCustom
 from ...ir.op_node import OfflineCoreOp, SequentialOp, StandaloneActOp, StandaloneCompOp
 from ...ir.signal_domain import SignalDomain
+from ..data_format import DataFormat, fits_value_code_range, infer_output_format
 from ..graph_utils import (
     collect_effective_predecessor_values,
+    collect_effective_value_code_ranges,
     is_format_transparent_routing_node,
     is_standalone_maxpool,
 )
@@ -19,16 +31,29 @@ from .utils import build_sum_pool, get_avgpool_divisor, get_pool_window_size, is
 
 __all__ = ["rewrite_standalone_avgpools"]
 
+OutputApprox: TypeAlias = Literal["default", "sum_approx_if_avgpool"]
+_OUTPUT_APPROX_MODES: tuple[str, ...] = ("default", "sum_approx_if_avgpool")
 
-def rewrite_standalone_avgpools(graph: PAIIRGraph) -> PAIIRGraph:
-    """Rewrite standalone AvgPool nodes according to *mode*.
+
+def rewrite_standalone_avgpools(
+    graph: PAIIRGraph, output_approx: OutputApprox = "default"
+) -> PAIIRGraph:
+    """Rewrite standalone AvgPool nodes according to the selected policy.
 
     This pass expects graph-wide signal-domain and data-format propagation to
     have already run once. It inspects each standalone AvgPool node's resolved
     input format and its effective upstream producer modes, and rewrites only
     the cases whose source semantics are known well enough to preserve exactly.
-    All other standalone AvgPool nodes are left unchanged.
+
+    ``output_approx="sum_approx_if_avgpool"`` additionally allows eligible
+    output-layer AvgPool nodes to export sums/counts instead of averages. All
+    unsupported or unsafe AvgPool nodes are left unchanged.
     """
+    if output_approx not in _OUTPUT_APPROX_MODES:
+        supported = ", ".join(_OUTPUT_APPROX_MODES)
+        raise ValueError(
+            f"unsupported output_approx={output_approx!r}; supported: {supported}"
+        )
 
     rewritten = graph.clone_shallow()
     changed = False
@@ -38,7 +63,7 @@ def rewrite_standalone_avgpools(graph: PAIIRGraph) -> PAIIRGraph:
         if not (isinstance(node, StandaloneCompOp) and is_avgpool(node.comp)):
             continue
 
-        replacement = _rewrite_avgpool_node(graph, name, node)
+        replacement = _rewrite_avgpool_node(graph, name, node, output_approx)
         if replacement is None:
             continue
 
@@ -51,9 +76,22 @@ def rewrite_standalone_avgpools(graph: PAIIRGraph) -> PAIIRGraph:
 
 
 def _rewrite_avgpool_node(
-    graph: PAIIRGraph, node_name: str, node: StandaloneCompOp
+    graph: PAIIRGraph,
+    node_name: str,
+    node: StandaloneCompOp,
+    output_approx: OutputApprox,
 ) -> SequentialOp | None:
+    """Return a deployable replacement for one standalone AvgPool, if safe."""
     assert is_avgpool(node.comp)
+
+    output_boundary = _resolve_output_boundary(graph, node_name)
+    if (
+        output_approx == "sum_approx_if_avgpool"
+        and output_boundary is not None
+        and (replacement := _build_output_sum_approx_avgpool(graph, node_name, node))
+        is not None
+    ):
+        return replacement
 
     source_modes = _collect_effective_source_modes(graph, node_name)
     if len(source_modes) != 1:
@@ -68,7 +106,10 @@ def _rewrite_avgpool_node(
     ):
         if get_avgpool_divisor(node.comp) != get_pool_window_size(node.comp):
             return None
-        return _build_binary_majority_avgpool(node.comp)
+        replacement = _build_binary_majority_avgpool(node.comp)
+        if output_boundary is not None:
+            _warn_output_majority_fallback(node_name, node, replacement)
+        return replacement
 
     if source_mode is SNNMode.ANN and input_format[1] == DataWidth.WIDTH_8BIT:
         return _build_exact_ann_avgpool(node.comp, input_format)
@@ -76,9 +117,92 @@ def _rewrite_avgpool_node(
     return None
 
 
+def _resolve_output_boundary(graph: PAIIRGraph, node_name: str) -> str | None:
+    """Return the terminal OutputNode for a single transparent output path."""
+    current_name = node_name
+
+    while True:
+        succs = graph.successors(current_name)
+        if len(succs) != 1:
+            return None
+
+        succ_name = succs[0]
+        succ = graph.nodes[succ_name]
+        if isinstance(succ, OutputNode):
+            return succ_name
+
+        if not is_format_transparent_routing_node(succ):
+            return None
+
+        if len(graph.predecessors(succ_name)) != 1:
+            return None
+        current_name = succ_name
+
+
+def _build_output_sum_approx_avgpool(
+    graph: PAIIRGraph, node_name: str, node: StandaloneCompOp
+) -> SequentialOp | None:
+    """Build the explicit output-layer sum/count approximation.
+
+    The replacement keeps the chip-side value in the integer sum domain:
+    ``AvgPool(x)`` becomes ``SumPool(x) + identity LUT``. This is only valid for
+    full, non-padded windows with a known VALUE-domain input range that fits the
+    deployable 8-bit data path. The caller emits an ``OutputApproxWarning`` so
+    the application knows it must divide by the logical divisor or accumulate
+    counts before applying task-level decisions such as ``argmax``.
+    """
+    assert is_avgpool(node.comp)
+
+    if not _has_exact_full_pool_windows(node.comp):
+        return None
+
+    code_ranges = collect_effective_value_code_ranges(graph, node_name)
+    if len(code_ranges) != 1:
+        return None
+
+    input_min, input_max = code_ranges[0]
+    window_size = get_pool_window_size(node.comp)
+    code_range = input_min * window_size, input_max * window_size
+    code_min, code_max = code_range
+    if code_min > code_max:
+        return None
+    if not fits_value_code_range(code_min, code_max):
+        return None
+    if code_max - code_min + 1 > 256:
+        return None
+
+    sum_pool = build_sum_pool(node.comp)
+    act = ANNNodeV25(_build_range_identity_lut(code_range))
+    replacement = SequentialOp(sum_pool, act)
+    replacement.name = node_name
+
+    data_format = _format_data_format(infer_output_format(act))
+    exported_form = f"{type(sum_pool).__name__} + identity LUT"
+    logical_divisor = get_avgpool_divisor(node.comp)
+    cpu_responsibility = (
+        f"divide by divisor {logical_divisor} to recover average, or accumulate "
+        "counts before argmax"
+    )
+    # TODO(cpu-runtime): when PAIIR/backend can export explicit CPU postprocess
+    # tasks, attach this divide/accumulate responsibility to the graph instead
+    # of communicating it only through a warning.
+    warnings.warn(
+        (
+            f"Output-layer node '{node_name}' ({type(node.comp).__name__}) is "
+            f"exported as {exported_form}; exported range={code_range}, "
+            f"format={data_format}. Original AvgPool average is replaced by an "
+            f"unnormalized sum/count. CPU side must {cpu_responsibility}."
+        ),
+        OutputApproxWarning,
+        stacklevel=3,
+    )
+    return replacement
+
+
 def _collect_effective_source_modes(
     graph: PAIIRGraph, node_name: str
 ) -> frozenset[SNNMode]:
+    """Collect effective upstream execution modes through transparent nodes."""
     modes = collect_effective_predecessor_values(
         graph, node_name, _resolve_effective_source_modes, _is_source_transparent_node
     )
@@ -105,6 +229,7 @@ def _resolve_effective_source_modes(
 
 
 def _get_effective_value_source_mode(node: PAIIRNode) -> SNNMode | None:
+    """Return the execution mode of a VALUE-producing offline core."""
     if not isinstance(node, OfflineCoreOp):
         return None
 
@@ -129,7 +254,19 @@ def _is_source_transparent_node(node: PAIIRNode) -> bool:
     )
 
 
+def _has_exact_full_pool_windows(comp: nn.AvgPool1d | nn.AvgPool2d) -> bool:
+    """Return whether each output aggregates exactly one full unpadded window."""
+    if comp.ceil_mode:
+        return False
+
+    padding = comp.padding
+    if isinstance(padding, int):
+        return padding == 0
+    return all(p == 0 for p in padding)
+
+
 def _build_binary_majority_avgpool(comp: nn.AvgPool1d | nn.AvgPool2d) -> SequentialOp:
+    """Build the default SNN binary-majority fallback for spike AvgPool."""
     window_size = get_pool_window_size(comp)
     divisor = get_avgpool_divisor(comp)
     if divisor != window_size:
@@ -144,6 +281,52 @@ def _build_binary_majority_avgpool(comp: nn.AvgPool1d | nn.AvgPool2d) -> Sequent
         thres_neg_mode=ThresholdNegMode.FLOOR, leak_v=-(threshold - 1), thres_neg=0
     )
     return SequentialOp(sum_pool, act)
+
+
+def _build_range_identity_lut(code_range: tuple[int, int]) -> LutCustom:
+    """Build a 256-entry identity LUT whose output codes stay inside *code_range*."""
+    code_min, code_max = code_range
+    codes = torch.arange(code_min, code_max + 1, dtype=torch.int32)
+    pad_count = 256 - codes.numel()
+    if pad_count < 0:
+        raise ValueError(f"identity LUT code range too large: {code_range}")
+    if pad_count:
+        pad = torch.full((pad_count,), code_max, dtype=torch.int32)
+        codes = torch.cat((codes, pad))
+
+    return LutCustom(codes, codes, output_sign=1 if code_min < 0 else 0, is_float=False)
+
+
+def _warn_output_majority_fallback(
+    node_name: str, node: StandaloneCompOp, replacement: SequentialOp
+) -> None:
+    """Warn that the default output-layer fallback exports majority spikes."""
+    data_format = _format_data_format(infer_output_format(replacement.act))
+    code_range = (0, 1)
+    warnings.warn(
+        (
+            f"Output-layer node '{node_name}' ({type(node.comp).__name__}) is "
+            f"exported as {type(replacement.comp).__name__} + IFNodeV25; "
+            f"exported range={code_range}, format={data_format}. Default "
+            "output-layer AvgPool fallback emits majority spikes rather than the "
+            "original average; use output_approx='sum_approx_if_avgpool' to export "
+            "counts when the input range is supported. CPU side must interpret the "
+            "result as majority spike output."
+        ),
+        OutputApproxWarning,
+        stacklevel=3,
+    )
+
+
+def _format_data_format(data_format: DataFormat) -> str:
+    sign, width = data_format
+    prefix = "s" if sign is DataSign.SIGNED else "u"
+    width_name = width.name
+    if width_name.startswith("WIDTH_") and width_name.endswith("BIT"):
+        bits = width_name.removeprefix("WIDTH_").removesuffix("BIT")
+    else:
+        bits = str(width)
+    return f"{prefix}{bits} DATA"
 
 
 def _build_exact_ann_avgpool(

--- a/paibox/paiir/pipeline/compile.py
+++ b/paibox/paiir/pipeline/compile.py
@@ -31,6 +31,7 @@ from torch import Tensor, nn
 from ..ir.graph import PAIIRGraph
 from ..lowering.converter import torch_to_paiir
 from .avgpool import rewrite_delayed_avgpool_division, rewrite_standalone_avgpools
+from .avgpool.standalone_rewrite import OutputApprox
 from .data_format import DataFormat
 from .layout_chain_canonicalization import canonicalize_layout_chains
 from .layout_cross_node_elision import commute_pre_activation_transforms
@@ -56,6 +57,28 @@ class CompileConfig:
 
     Keyword arguments passed directly to :func:`compile_to_paiir` override the
     matching values in this object when they are not ``None``.
+
+    Attributes:
+        tick_duration: Global work duration for every compute core. ``None``
+            uses the execution-mode default; ``0`` keeps cores always active;
+            a positive value activates each core for that many sync steps.
+        auto_reset: Global automatic-reset policy. ``None`` uses the
+            execution-mode default; true resets state at finite work-window
+            boundaries; false leaves state externally controlled.
+        input_formats: Optional data-format overrides keyed by ``InputNode``
+            name. Each value is a ``(DataSign, DataWidth)`` pair.
+        enable_avgpool_calibration: Enable experimental threshold calibration
+            for shared-core AvgPool+LIF deployments.
+        enable_split_avgpool_lif: Enable experimental split-core deployment
+            for supported AvgPool+LIF chains.
+        enable_delayed_avgpool_division: Rewrite eligible AvgPool chains to
+            keep integer sums and materialize division at a later exact endpoint.
+        output_approx: Output-boundary approximation strategy. ``"default"``
+            keeps the standard policy; ``"sum_approx_if_avgpool"`` exports
+            eligible output-layer AvgPool nodes as unnormalized
+            ``SumPool + identity LUT`` counts and emits ``OutputApproxWarning``.
+            The application CPU must divide or accumulate those counts according
+            to task semantics.
     """
 
     tick_duration: int | None = None
@@ -64,6 +87,7 @@ class CompileConfig:
     enable_avgpool_calibration: bool = False
     enable_split_avgpool_lif: bool = False
     enable_delayed_avgpool_division: bool = True
+    output_approx: OutputApprox = "default"
 
 
 def compile_to_paiir(
@@ -78,6 +102,7 @@ def compile_to_paiir(
     enable_avgpool_calibration: bool | None = None,
     enable_split_avgpool_lif: bool | None = None,
     enable_delayed_avgpool_division: bool | None = None,
+    output_approx: OutputApprox | None = None,
 ) -> PAIIRGraph:
     """Compile a PyTorch model to a ready-to-deploy :class:`PAIIRGraph`.
 
@@ -116,6 +141,14 @@ def compile_to_paiir(
             split-core deployment.
         enable_delayed_avgpool_division: Optional override for the delayed
             AvgPool division rewrite.
+        output_approx: Optional output-boundary approximation strategy.
+            ``"default"`` preserves the standard rewrite policy.
+            ``"sum_approx_if_avgpool"`` rewrites eligible output-layer
+            ``AvgPool1d`` / ``AvgPool2d`` nodes to unnormalized
+            ``SumPool + identity LUT`` counts and emits an
+            :class:`~paibox.paiir.exceptions.OutputApproxWarning`. CPU-side
+            divide/accumulate postprocessing is currently an application
+            responsibility rather than a structured graph node.
 
     Timing defaults:
         If neither keyword arguments nor ``compile_config`` specify timing,
@@ -168,6 +201,7 @@ def compile_to_paiir(
         if enable_delayed_avgpool_division is not None
         else cfg.enable_delayed_avgpool_division
     )
+    _output_approx = output_approx if output_approx is not None else cfg.output_approx
 
     graph = torch_to_paiir(
         model, *sample_inputs, concrete_args=concrete_args, strict=strict
@@ -182,7 +216,7 @@ def compile_to_paiir(
     graph = _run_post_fusion_rewrite_phase(
         graph,
         _input_formats,
-        _post_fusion_rewrite_passes(_enable_delayed_avgpool_division),
+        _post_fusion_rewrite_passes(_enable_delayed_avgpool_division, _output_approx),
     )
 
     assign_tick_params(graph, _tick_duration, _auto_reset)
@@ -216,7 +250,7 @@ def _run_pre_fusion_rewrite_phase(graph: PAIIRGraph, max_rounds: int = 4) -> PAI
 
 
 def _post_fusion_rewrite_passes(
-    enable_delayed_avgpool_division: bool,
+    enable_delayed_avgpool_division: bool, output_approx: OutputApprox
 ) -> tuple[RewritePass, ...]:
     """Return the ordered post-fusion rewrite passes."""
     passes: list[RewritePass] = []
@@ -227,7 +261,10 @@ def _post_fusion_rewrite_passes(
             )
         )
     passes.append(
-        RewritePass("rewrite_standalone_avgpools", rewrite_standalone_avgpools)
+        RewritePass(
+            "rewrite_standalone_avgpools",
+            lambda graph: rewrite_standalone_avgpools(graph, output_approx),
+        )
     )
     return tuple(passes)
 

--- a/paibox/paiir/pipeline/graph_utils.py
+++ b/paibox/paiir/pipeline/graph_utils.py
@@ -172,6 +172,4 @@ def collect_effective_value_code_ranges(
 
         return None
 
-    return collect_effective_predecessor_values(
-        graph, node_name, resolve, passthrough
-    )
+    return collect_effective_predecessor_values(graph, node_name, resolve, passthrough)

--- a/paibox/paiir/pipeline/graph_utils.py
+++ b/paibox/paiir/pipeline/graph_utils.py
@@ -7,12 +7,14 @@ import torch
 from torch import nn
 
 from ..ir.graph import PAIIRGraph
-from ..ir.ir_base import FormatFlow, PAIIRNode
-from ..ir.op_node import RoutingOp, StandaloneCompOp, TransformOp
+from ..ir.ir_base import FormatFlow, InputNode, PAIIRNode
+from ..ir.op_node import OfflineCoreOp, RoutingOp, StandaloneCompOp, TransformOp
+from ..ir.signal_domain import SignalDomain
 
 __all__ = [
     "collect_effective_predecessor_values",
     "collect_effective_node_values",
+    "collect_effective_value_code_ranges",
     "is_order_preserving_transform_node",
     "is_transform_node",
     "is_format_transparent_routing_node",
@@ -139,3 +141,37 @@ def collect_effective_node_values(
         return values
 
     return []
+
+
+def collect_effective_value_code_ranges(
+    graph: PAIIRGraph,
+    node_name: str,
+    passthrough: Callable[[PAIIRNode], bool] = is_format_transparent_routing_node,
+) -> list[tuple[int, int]]:
+    """Collect known code ranges from effective VALUE-domain sources.
+
+    Traversal starts at the predecessors of ``node_name``. Nodes accepted by
+    ``passthrough`` are treated as format-preserving routing and traversed
+    recursively; ``InputNode`` and VALUE-domain ``OfflineCoreOp`` nodes are the
+    only terminal sources that contribute ranges.
+    """
+
+    def resolve(node: PAIIRNode, _node_name: str) -> list[tuple[int, int]] | None:
+        if passthrough(node):
+            return None
+
+        if isinstance(node, InputNode):
+            code_range = node.signal_semantics.known_code_range
+            return [] if code_range is None else [code_range]
+
+        if isinstance(node, OfflineCoreOp):
+            if node.signal_semantics.output_domain is not SignalDomain.VALUE:
+                return []
+            code_range = node.signal_semantics.known_code_range
+            return [] if code_range is None else [code_range]
+
+        return None
+
+    return collect_effective_predecessor_values(
+        graph, node_name, resolve, passthrough
+    )

--- a/tests/paiir/lowering/test_converter.py
+++ b/tests/paiir/lowering/test_converter.py
@@ -1,6 +1,7 @@
 """Tests for lowering-layer converter behavior."""
 
 import warnings
+from collections.abc import Callable
 
 import pytest
 import torch
@@ -79,6 +80,16 @@ class SupportedNoPaddingCountIncludePadAvgPool2d(nn.Module):
         return self.pool(x)
 
 
+class MaxPoolReturnIndicesValuesOnly(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pool = nn.MaxPool2d(2, return_indices=True)
+
+    def forward(self, x):
+        values, _indices = self.pool(x)
+        return values
+
+
 class TestStrictMode:
     """Test strict mode for unsupported operators."""
 
@@ -117,6 +128,54 @@ class TestStrictMode:
             and isinstance(node.comp, nn.AvgPool2d)
         ]
         assert len(pool_nodes) == 1
+
+    @pytest.mark.parametrize(
+        ("pool_factory", "sample_factory"),
+        [
+            pytest.param(
+                lambda: nn.AvgPool1d(3, stride=2, ceil_mode=True),
+                lambda: torch.randn(1, 3, 8),
+                id="avgpool1d",
+            ),
+            pytest.param(
+                lambda: nn.AvgPool2d(3, stride=2, ceil_mode=True),
+                make_img_3ch_8x8,
+                id="avgpool2d",
+            ),
+            pytest.param(
+                lambda: nn.MaxPool1d(3, stride=2, ceil_mode=True),
+                lambda: torch.randn(1, 3, 8),
+                id="maxpool1d",
+            ),
+            pytest.param(
+                lambda: nn.MaxPool2d(3, stride=2, ceil_mode=True),
+                make_img_3ch_8x8,
+                id="maxpool2d",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("strict", [True, False], ids=["strict", "non_strict"])
+    def test_ceil_mode_pooling_is_hard_error(
+        self,
+        pool_factory: Callable[[], nn.Module],
+        sample_factory: Callable[[], Tensor],
+        strict: bool,
+    ):
+        model = nn.Sequential(pool_factory()).eval()
+
+        with pytest.raises(UnsupportedOpError, match="ceil_mode=True"):
+            torch_to_paiir(model, sample_factory(), strict=strict)
+
+    def test_strict_mode_rejects_maxpool_return_indices(self):
+        model = MaxPoolReturnIndicesValuesOnly()
+        with pytest.raises(UnsupportedOpError, match="return_indices=True"):
+            torch_to_paiir(model, make_img_3ch_8x8(), strict=True)
+
+    def test_non_strict_mode_warns_for_maxpool_return_indices(self):
+        model = MaxPoolReturnIndicesValuesOnly()
+        with pytest.warns(UnsupportedOpWarning, match="return_indices=True"):
+            graph = torch_to_paiir(model, make_img_3ch_8x8(), strict=False)
+        assert len(graph.nodes) > 0
 
 
 class TestPadLowering:
@@ -475,6 +534,16 @@ class TestRegisterCanonicalModule:
         register_module(ExplicitQuantConv, _to_canonical_conv2d)
         with pytest.raises(ValueError, match="already registered"):
             register_module(ExplicitQuantConv, _to_canonical_conv2d)
+
+    def test_register_canonical_module_rejects_ceil_mode_pool(self):
+        class CustomPool(nn.Module):
+            def forward(self, x):
+                return x
+
+        register_module(CustomPool, lambda _: nn.AvgPool2d(3, 2, ceil_mode=True))
+
+        with pytest.raises(UnsupportedOpError, match="ceil_mode=True"):
+            torch_to_paiir(CustomPool().eval(), make_img_3ch_8x8(), strict=False)
 
     def test_register_canonical_module_preempts_unsupported_sj_layer_guard(self):
         class Model(nn.Module):

--- a/tests/paiir/pipeline/avgpool/test_delayed_division.py
+++ b/tests/paiir/pipeline/avgpool/test_delayed_division.py
@@ -158,12 +158,25 @@ def _reset_stateful_modules(model: nn.Module) -> None:
             reset()
 
 
-def _compile_graph(model: nn.Module, sample_input: torch.Tensor, **kwargs):
-    return compile_to_paiir(model.eval(), sample_input.to(torch.float32), **kwargs)
+def _compile_graph(
+    model: nn.Module,
+    sample_input: torch.Tensor,
+    tick_duration: int | None = None,
+    auto_reset: bool | None = None,
+    **kwargs,
+):
+    return compile_to_paiir(
+        model.eval(),
+        sample_input.to(torch.float32),
+        tick_duration=tick_duration,
+        auto_reset=auto_reset,
+        **kwargs,
+    )
 
 
 def _run_and_compare(model: nn.Module, sample_input: torch.Tensor, **kwargs) -> None:
-    graph = _compile_graph(model, sample_input, **kwargs)
+    # These tests compare operator values, so keep all ANN cores continuously active.
+    graph = _compile_graph(model, sample_input, tick_duration=0, auto_reset=False)
     _reset_stateful_modules(model)
     graph.reset()
 

--- a/tests/paiir/pipeline/avgpool/test_standalone_avgpool_rewrite.py
+++ b/tests/paiir/pipeline/avgpool/test_standalone_avgpool_rewrite.py
@@ -1,14 +1,15 @@
 import pytest
 import torch
 from paicorelib import DataSign, DataWidth, ThresholdNegMode
-from spikingjelly.activation_based import neuron as sj
+from spikingjelly.activation_based import layer, neuron
 from torch import nn
 
 from paibox.paiir import ANNNodeV25, IFNodeV25, LutLinear
-from paibox.paiir.exceptions import GraphValidationError
+from paibox.paiir.exceptions import GraphValidationError, OutputApproxWarning
 from paibox.paiir.ir.op_node import SequentialOp, StandaloneCompOp
+from paibox.paiir.ir.signal_domain import SignalDomain
 from paibox.paiir.lowering.converter import register_neuron
-from paibox.paiir.nn import SumPool2d
+from paibox.paiir.nn import SumPool1d, SumPool2d
 from paibox.paiir.pipeline import compile_to_paiir
 from paibox.paiir.pipeline.data_format import infer_output_format
 
@@ -26,7 +27,7 @@ class SpikeStandaloneAvgPool(nn.Module):
     def __init__(self) -> None:
         super().__init__()
         self.conv = nn.Conv2d(1, 1, 1, bias=False)
-        self.if1 = sj.IFNode(v_threshold=1.0)
+        self.if1 = neuron.IFNode(v_threshold=1.0)
         self.pool = nn.AvgPool2d(3, 3)
 
     def forward(self, x):
@@ -47,7 +48,7 @@ class SpikeStandaloneAvgPoolDivisorOverride(nn.Module):
     def __init__(self) -> None:
         super().__init__()
         self.conv = nn.Conv2d(1, 1, 1, bias=False)
-        self.if1 = sj.IFNode(v_threshold=1.0)
+        self.if1 = neuron.IFNode(v_threshold=1.0)
         self.pool = nn.AvgPool2d(3, 3, divisor_override=1)
 
     def forward(self, x):
@@ -69,7 +70,7 @@ class MixedModeStandaloneAvgPool(nn.Module):
     def __init__(self) -> None:
         super().__init__()
         self.conv_snn = nn.Conv2d(1, 1, 1, bias=False)
-        self.if1 = sj.IFNode(v_threshold=1.0)
+        self.if1 = neuron.IFNode(v_threshold=1.0)
         self.conv_ann = nn.Conv2d(1, 1, 1, bias=False)
         self.relu = nn.ReLU()
         self.pool = nn.AvgPool2d(3, 3)
@@ -93,11 +94,42 @@ class ResidualAnnStandaloneAvgPool(nn.Module):
         return self.pool(self.relu(y))
 
 
+class SpikeVotingLayer10(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.if1 = neuron.IFNode(v_threshold=1.0)
+        self.vote = layer.VotingLayer(10, step_mode="s")
+
+    def forward(self, x):
+        return self.vote(self.if1(x))
+
+
+class SpikeAvgPoolThenLinear(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(1, 1, 1, bias=False)
+        self.if1 = neuron.IFNode(v_threshold=1.0)
+        self.pool = nn.AvgPool2d(3, 3)
+        self.linear = nn.Linear(4, 2, bias=False)
+
+    def forward(self, x):
+        y = self.pool(self.if1(self.conv(x)))
+        return self.linear(y.flatten(1))
+
+
 def _find_rewritten_avgpool_seq(graph) -> SequentialOp:
     return next(
         node
         for node in graph.nodes.values()
         if isinstance(node, SequentialOp) and isinstance(node.comp, SumPool2d)
+    )
+
+
+def _find_rewritten_sumpool1d_seq(graph) -> SequentialOp:
+    return next(
+        node
+        for node in graph.nodes.values()
+        if isinstance(node, SequentialOp) and isinstance(node.comp, SumPool1d)
     )
 
 
@@ -136,7 +168,8 @@ def test_binary_majority_specializes_spike_predecessor_avgpool2d() -> None:
     with torch.no_grad():
         model.conv.weight.fill_(1)
 
-    graph = compile_to_paiir(model, torch.zeros(1, 1, 6, 6))
+    with pytest.warns(OutputApproxWarning, match="majority spikes"):
+        graph = compile_to_paiir(model, torch.zeros(1, 1, 6, 6))
     seq = _find_rewritten_avgpool_seq(graph)
 
     assert isinstance(seq.comp, SumPool2d)
@@ -156,7 +189,8 @@ def test_binary_majority_forward_matches_manual_majority_rule() -> None:
     model = SpikeStandaloneAvgPool().eval()
     with torch.no_grad():
         model.conv.weight.fill_(1)
-    graph = compile_to_paiir(model, torch.zeros(1, 1, 6, 6))
+    with pytest.warns(OutputApproxWarning, match="majority spikes"):
+        graph = compile_to_paiir(model, torch.zeros(1, 1, 6, 6))
     seq = _find_rewritten_avgpool_seq(graph)
 
     x = torch.tensor(
@@ -297,3 +331,76 @@ def test_mixed_mode_standalone_avgpool_stays_standalone() -> None:
 
     pool = _find_standalone_avgpool(graph)
     assert isinstance(pool.comp, nn.AvgPool2d)
+
+
+def test_output_voting_layer_default_keeps_majority_fallback() -> None:
+    model = SpikeVotingLayer10().eval()
+
+    with pytest.warns(OutputApproxWarning, match="SumPool1d \\+ IFNodeV25"):
+        graph = compile_to_paiir(model, torch.zeros(1, 110))
+
+    seq = _find_rewritten_sumpool1d_seq(graph)
+    assert isinstance(seq.comp, SumPool1d)
+    assert isinstance(seq.act, IFNodeV25)
+    assert infer_output_format(seq.act) == (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT)
+
+
+def test_output_voting_layer_sum_approx_exports_counts() -> None:
+    model = SpikeVotingLayer10().eval()
+
+    with pytest.warns(OutputApproxWarning, match="SumPool1d \\+ identity LUT"):
+        graph = compile_to_paiir(
+            model, torch.zeros(1, 110), output_approx="sum_approx_if_avgpool"
+        )
+
+    seq = _find_rewritten_sumpool1d_seq(graph)
+    assert isinstance(seq.comp, SumPool1d)
+    assert isinstance(seq.act, ANNNodeV25)
+    assert seq.signal_semantics.output_domain is SignalDomain.VALUE
+    assert seq.signal_semantics.known_code_range == (0, 10)
+    assert seq.core_params.output_sign == DataSign.UNSIGNED
+    assert seq.core_params.output_width == DataWidth.WIDTH_4BIT
+    assert graph.output_nodes()[0].shape == torch.Size((1, 11))
+
+
+def test_output_voting_layer_sum_counts_preserve_time_accumulated_argmax() -> None:
+    model = SpikeVotingLayer10().eval()
+    with pytest.warns(OutputApproxWarning, match="identity LUT"):
+        graph = compile_to_paiir(
+            model, torch.zeros(1, 110), output_approx="sum_approx_if_avgpool"
+        )
+    seq = _find_rewritten_sumpool1d_seq(graph)
+
+    spike_frames = torch.zeros(4, 1, 110, dtype=torch.int32)
+    spike_frames[0, 0, 0:10] = 1
+    spike_frames[1, 0, 10:20] = 1
+    spike_frames[2, 0, 10:20] = 1
+    spike_frames[3, 0, 20:30] = 1
+
+    avgpool = nn.AvgPool1d(10, 10)
+    count_sum = torch.zeros(1, 11, dtype=torch.int64)
+    avg_sum = torch.zeros(1, 11, dtype=torch.float32)
+    for frame in spike_frames:
+        seq.act.reset()
+        count_sum += seq(frame).to(torch.int64)
+        avg_sum += avgpool(frame.to(torch.float32))
+
+    assert torch.equal(count_sum.argmax(dim=1), avg_sum.argmax(dim=1))
+
+
+def test_output_sum_approx_does_not_change_non_output_avgpool_policy() -> None:
+    model = SpikeAvgPoolThenLinear().eval()
+    with torch.no_grad():
+        model.conv.weight.fill_(1)
+        model.linear.weight.fill_(1)
+
+    graph = compile_to_paiir(
+        model,
+        torch.zeros(1, 1, 6, 6),
+        enable_delayed_avgpool_division=False,
+        output_approx="sum_approx_if_avgpool",
+    )
+
+    seq = _find_rewritten_avgpool_seq(graph)
+    assert isinstance(seq.comp, SumPool2d)
+    assert isinstance(seq.act, IFNodeV25)

--- a/tests/paiir/pipeline/avgpool/test_utils.py
+++ b/tests/paiir/pipeline/avgpool/test_utils.py
@@ -43,9 +43,23 @@ class TestAvgPoolUtils:
         )
         assert torch.equal(actual, expected)
 
+    def test_sumpool2d_respects_stride(self):
+        pool = SumPool2d(kernel_size=3, stride=3)
+        x = torch.arange(1, 37, dtype=torch.float32).reshape(1, 1, 6, 6)
+        actual = pool(x)
+        expected = torch.tensor([[[[72.0, 99.0], [234.0, 261.0]]]])
+        assert torch.equal(actual, expected)
+
     def test_sumpool1d_supports_dilation(self):
         pool = SumPool1d(kernel_size=3, stride=1, dilation=2)
         x = torch.arange(1, 8, dtype=torch.float32).reshape(1, 1, 7)
         actual = pool(x)
         expected = torch.tensor([[[9.0, 12.0, 15.0]]])
+        assert torch.equal(actual, expected)
+
+    def test_sumpool1d_respects_stride(self):
+        pool = SumPool1d(kernel_size=10, stride=10)
+        x = torch.arange(1, 111, dtype=torch.float32).reshape(1, 1, 110)
+        actual = pool(x)
+        expected = torch.arange(55, 1101, 100, dtype=torch.float32).reshape(1, 1, 11)
         assert torch.equal(actual, expected)

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -110,6 +110,15 @@ class AvgPool2dWrapper(nn.Module):
         return self.pool(x)
 
 
+class Pool2dWrapper(nn.Module):
+    def __init__(self, pool: nn.Module) -> None:
+        super().__init__()
+        self.pool = pool
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.pool(x)
+
+
 class SpikingJellyLayerCompileSmoke(nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -856,6 +865,30 @@ class TestStrictMode:
             and isinstance(node.comp, nn.AvgPool2d)
         ]
         assert len(pool_nodes) == 1
+
+    @pytest.mark.parametrize(
+        "pool_factory",
+        [
+            pytest.param(
+                lambda: nn.AvgPool2d(3, stride=2, ceil_mode=True),
+                id="avgpool2d",
+            ),
+            pytest.param(
+                lambda: nn.MaxPool2d(3, stride=2, ceil_mode=True),
+                id="maxpool2d",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("strict", [True, False], ids=["strict", "non_strict"])
+    def test_ceil_mode_pooling_is_hard_error(
+        self, pool_factory: Callable[[], nn.Module], strict: bool
+    ):
+        with pytest.raises(UnsupportedOpError, match="ceil_mode=True"):
+            compile_to_paiir(
+                Pool2dWrapper(pool_factory()),
+                make_img_3ch_8x8(),
+                strict=strict,
+            )
 
 
 class FunctionalDirectConv(nn.Module):


### PR DESCRIPTION
## Summary

- Add `output_approx="sum_approx_if_avgpool"` to `compile_to_paiir` so output-layer AvgPool can be exported as `SumPool + identity LUT` with count semantics.
- Move `AvgPool/MaxPool ceil_mode=True` to a frontend hard error in lowering; `strict=False` no longer bypasses it.
- Extract and reuse the effective VALUE code-range collection logic so delayed-division and standalone AvgPool rewrites stay aligned.
- Update the user quickstart and backend guide to document `OutputApproxWarning`, CPU-side postprocessing responsibility, and the `ceil_mode` boundary.