### PR TITLE
Refactor(paiir): PAIIR timing config to `timesteps` & `auto_reset`

### DIFF
--- a/docs/paiir_backend_guide.md
+++ b/docs/paiir_backend_guide.md
@@ -179,14 +179,14 @@ graph = compile_to_paiir(model, torch.randn(1, 3, 32, 32))
 graph = compile_to_paiir(
     model,
     torch.randn(1, 3, 32, 32),
-    tick_duration=100,       # 每核工作时长（0 = 常开）
-    auto_reset=True,         # 工作周期结束后自动复位神经元状态
+    timesteps=100,           # 一次样本/一次推理的时间步数
+    auto_reset=True,         # 每 100 个有效工作步自动复位神经元状态
 )
 
 # 使用 CompileConfig + 关键字覆盖
 from paibox.paiir import CompileConfig
 
-cfg = CompileConfig(tick_duration=100, auto_reset=True)
+cfg = CompileConfig(timesteps=100, auto_reset=True)
 graph = compile_to_paiir(model, x, compile_config=cfg, strict=False)
 ```
 
@@ -196,8 +196,8 @@ graph = compile_to_paiir(model, x, compile_config=cfg, strict=False)
 | --------------------------------- | ---------------------------------------------- | --------------------------------------------------- |
 | `model`                           | `nn.Module`                                    | PyTorch 模型                                        |
 | `*sample_inputs`                  | `Tensor`                                       | 示例输入（batch_size 必须为 1），用于推断形状和维度 |
-| `tick_duration`                   | `int \| None`                                  | 显式全局工作时长，`0` 表示常开；默认 None           |
-| `auto_reset`                      | `bool \| None`                                 | 显式控制工作周期结束后是否自动复位；默认 None       |
+| `timesteps`                       | `int`                                          | 一次样本/一次推理的时间步数，默认 1，必须为正整数   |
+| `auto_reset`                      | `bool`                                         | 是否按 `timesteps` 自动复位，默认 True              |
 | `input_formats`                   | `dict[str, DataFormat] \| None`                | 按 InputNode 名指定输入数据格式                     |
 | `compile_config`                  | `CompileConfig \| None`                        | 配置对象（关键字参数优先级更高）                    |
 | `concrete_args`                   | `dict[str, Any] \| None`                       | 传递给 `fx.Tracer.trace` 的具体参数                 |
@@ -207,7 +207,7 @@ graph = compile_to_paiir(model, x, compile_config=cfg, strict=False)
 | `enable_delayed_avgpool_division` | `bool \| None`                                 | 是否启用 AvgPool 延迟除法改写，默认开启             |
 | `output_approx`                   | `"default" \| "sum_approx_if_avgpool" \| None` | 输出边界近似策略，默认保持标准策略                  |
 
-`tick_duration=None` / `auto_reset=None` 表示未显式指定时序策略。此时 ANN 模式计算核默认 `tick_duration=1`、`tick_initial=1`，SNN 模式计算核默认 `tick_duration=0`、`tick_initial=0`。通过关键字参数或 `CompileConfig` 显式传入的 `tick_duration` / `auto_reset` 优先于 ANN/SNN 模式默认；关键字参数优先级高于 `CompileConfig`。
+默认 `timesteps=1`、`auto_reset=True`，且当前不按 ANN/SNN mode 区分时序配置。公开参数映射到底层硬件 tick 字段的规则为：`auto_reset=True` 时 `tick_duration=0`、`tick_initial=timesteps`；`auto_reset=False` 时 `tick_duration=timesteps`、`tick_initial=0`。通过关键字参数或 `CompileConfig` 显式传入的 `timesteps` / `auto_reset` 优先于内置默认值；关键字参数优先级高于 `CompileConfig`。
 
 ### 输出边界 AvgPool 近似
 
@@ -270,7 +270,7 @@ propagate_signal_domain(graph)
 propagate_data_format(graph)
 
 # ⑦ 时序参数分配（原地填充 tick_start / tick_duration / tick_initial）
-assign_tick_params(graph, tick_duration=100, auto_reset=True)
+assign_tick_params(graph, timesteps=100, auto_reset=True)
 
 # ⑧ 可选：共享核 AvgPool+LIF 阈值细化
 calibrate_avgpool_thresholds(graph)
@@ -501,7 +501,7 @@ cp.output_width: DataWidth        # 输出位宽
 cp.weight_sign: DataSign          # 权重符号
 cp.weight_width: DataWidth        # 权重位宽
 
-# 时序参数（由 assign_tick_params 填充）
+# 内部硬件时序参数（由 assign_tick_params 从公开 timesteps/auto_reset 映射后填充）
 cp.tick_start: int | None         # 启动时刻（第几个 sync_all）
 cp.tick_duration: int             # 工作时长（0 = 常开）
 cp.tick_initial: int              # 自动复位周期（0 = 不复位）

--- a/docs/user_quickstart.md
+++ b/docs/user_quickstart.md
@@ -324,8 +324,8 @@ print("frame_dir:", output_dir)
 | 参数                              | 作用                                                    |
 | --------------------------------- | ------------------------------------------------------- |
 | `*sample_inputs`                  | 示例输入，参与 shape/dims 推断，`batch_size` 必须为 `1` |
-| `tick_duration`                   | 显式全局工作时长，`0` 表示常开；不传则使用模式默认      |
-| `auto_reset`                      | 显式控制工作周期结束后是否自动复位；不传则使用模式默认  |
+| `timesteps`                       | 一次样本/一次推理的时间步数，默认 `1`，必须为正整数     |
+| `auto_reset`                      | 是否按 `timesteps` 自动复位，默认 `True`                |
 | `input_formats`                   | 按 `InputNode` 名称指定输入数据格式                     |
 | `compile_config`                  | 统一承载默认配置                                        |
 | `concrete_args`                   | 固定 FX tracing 时的非 Tensor 参数                      |
@@ -341,7 +341,7 @@ print("frame_dir:", output_dir)
 显式关键字参数 > CompileConfig > 内置默认值
 ```
 
-未显式传入时，ANN 模式计算核导出为单步工作并自动复位，即 `tick_duration=1`、`tick_initial=1`；SNN 模式计算核持续工作且不自动复位，即 `tick_duration=0`、`tick_initial=0`。一旦通过 `compile_to_paiir(...)` 关键字参数或 `CompileConfig` 显式传入 `tick_duration` / `auto_reset`，该显式策略优先于 ANN/SNN 模式默认；`tick_duration=0` 表示持续工作。
+默认 `timesteps=1`、`auto_reset=True`，不区分 ANN/SNN 模式。公开参数会映射到底层计算核 tick 字段：`auto_reset=True` 时导出 `tick_duration=0`、`tick_initial=timesteps`；`auto_reset=False` 时导出 `tick_duration=timesteps`、`tick_initial=0`。公开 API 不使用 `tick_duration=0` 表示推理长度，`tick_duration` 仅作为底层硬件字段出现在导出元数据中。
 
 ### 7.1 多输入模型
 
@@ -613,7 +613,7 @@ mapper.compile(
 - `OutputTensorMapping.tick` 是该输出 tensor 最终实际生产者计算核的时序。
 - `ThreadIOMapping.core_ticks` 按物理计算核列出 `core_offset/tick/nodes`，不包含全局信号空核。
 
-`TickParams.tick_duration=0` 表示持续工作，`tick_duration>0` 表示工作 N 个时间步；`tick_initial=0` 表示不自动复位。若同一个输入或输出 tensor 推导出多个不同 tick，导出阶段会报错，应用侧不应假定可以静默合并。
+`TickParams` 是内部硬件字段语义，不是公开 `timesteps` 参数语义。`TickParams.tick_duration=0` 表示持续工作，`tick_duration>0` 表示工作 N 个时间步；`tick_initial=0` 表示不自动复位。若同一个输入或输出 tensor 推导出多个不同 tick，导出阶段会报错，应用侧不应假定可以静默合并。
 
 ### 9.6 `config.pb` 里的 I/O 数据类型元数据
 

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -38,10 +38,15 @@ class Mapper:
         self.timesteps: int = 1
 
     def _resolve_timesteps(self, pai_graph: PAIIRGraph, timesteps: int | None) -> int:
-        """Resolve the application runtime length used by output metadata."""
+        """Resolve the application runtime length used by output metadata.
 
-        def _collect_output_durations() -> set[int]:
-            durations: set[int] = set()
+        Auto-reset graphs export ``tick_duration=0`` and carry the public
+        runtime length in ``tick_initial``, so inference must check
+        ``tick_initial`` before falling back to finite ``tick_duration``.
+        """
+
+        def _collect_output_timesteps() -> set[int]:
+            inferred: set[int] = set()
             visited: set[str] = set()
             pending = [
                 pred_name
@@ -57,20 +62,22 @@ class Mapper:
 
                 node = pai_graph.nodes[name]
                 if isinstance(node, OfflineCoreOp):
-                    tick_duration = node.core_params.tick_duration
-                    if tick_duration > 0:
-                        durations.add(tick_duration)
+                    cp = node.core_params
+                    if cp.tick_initial > 0:
+                        inferred.add(cp.tick_initial)
+                    elif cp.tick_duration > 0:
+                        inferred.add(cp.tick_duration)
                     continue
 
                 pending.extend(pai_graph.predecessors(name))
 
-            return durations
+            return inferred
 
         if timesteps is not None:
             resolved = int(timesteps)
         else:
-            output_durations = _collect_output_durations()
-            resolved = next(iter(output_durations)) if len(output_durations) == 1 else 1
+            output_timesteps = _collect_output_timesteps()
+            resolved = next(iter(output_timesteps)) if len(output_timesteps) == 1 else 1
 
         if resolved <= 0:
             raise ValueError(f"'timesteps' must be positive, got {resolved}.")
@@ -266,8 +273,10 @@ class Mapper:
                 writes 32-bit words as binary literals, while ``"hex"``
                 writes hexadecimal literals.
             timesteps: Application-side inference sequence length. When
-                ``None``, a finite and consistent output ``tick_duration`` is
-                used; otherwise defaults to ``1``.
+                ``None``, a finite and consistent output ``tick_initial`` from
+                automatic-reset graphs is used first; otherwise a finite and
+                consistent output ``tick_duration`` is used. If neither is
+                available, it defaults to ``1``.
             target_platform: Platform-specific artifact set to emit.
                 ``"x86"`` exports ``.npy`` frame arrays, ``"riscv"`` exports
                 C headers, and ``"all"`` exports both. When ``debug=True``,

--- a/paibox/backendv2/proto/README.md
+++ b/paibox/backendv2/proto/README.md
@@ -207,9 +207,9 @@ message CoreTick {
 
 `CoreOffset` 表示目标 core 的相对偏移；`CopyCount` 表示 AER 多播复制数量。二者都使用 2.5芯片帧格式中的 `XY/X/Y` 三轴概念，但语义不同：`core_offset` 表示目标位置，`copy_count` 表示复制范围。
 
-`TickParams` 对应 2.5 计算核的 `tick_start/tick_duration/tick_initial` 参数。`tick_duration=0` 表示持续工作；`tick_initial=0` 表示不自动复位。`CoreTick.tick` 是该物理计算核的 tick 参数，`CoreTick.nodes` 是部署到同一个物理计算核上的 PAIIR 节点名列表。
+`TickParams` 对应 2.5 计算核的 `tick_start/tick_duration/tick_initial` 内部硬件参数；它不同于前端公开编译参数 `timesteps`。`tick_duration=0` 表示持续工作；`tick_initial=0` 表示不自动复位。`CoreTick.tick` 是该物理计算核的 tick 参数，`CoreTick.nodes` 是部署到同一个物理计算核上的 PAIIR 节点名列表。
 
-`RuntimeParams.timesteps` 是应用推理序列长度；`tick_depth` 是该 thread 输出 producer 的最大 `tick_start`；`sync_steps = tick_depth + timesteps - 1` 是推荐外部同步步数。`sync_steps` 只描述主机视角的同步控制长度，不参与输出层 `target_lcn` 选择；输出层 `target_lcn` 由实际输出 axon 地址容量反推，优先保留更多本地 timestep 位。输出帧中的 timestep 是输出层本地运行时步。`decode_mode=STREAM` 表示最终 `target_lcn` 的 timestep 位宽可区分运行时步；`STEP` 表示需要应用分步推理、分步解码，或只能进行 warning 级 best-effort 序列解码。
+`RuntimeParams.timesteps` 是应用推理序列长度。后端未显式接收 `Mapper.compile(..., timesteps=...)` 时，会优先从自动复位图的 `tick_initial` 推导；不能在 `auto_reset=True` 场景依赖 `tick_duration>0` 推导运行长度。`tick_depth` 是该 thread 输出 producer 的最大 `tick_start`；`sync_steps = tick_depth + timesteps - 1` 是推荐外部同步步数。`sync_steps` 只描述主机视角的同步控制长度，不参与输出层 `target_lcn` 选择；输出层 `target_lcn` 由实际输出 axon 地址容量反推，优先保留更多本地 timestep 位。输出帧中的 timestep 是输出层本地运行时步。`decode_mode=STREAM` 表示最终 `target_lcn` 的 timestep 位宽可区分运行时步；`STEP` 表示需要应用分步推理、分步解码，或只能进行 warning 级 best-effort 序列解码。
 
 `DataType.Code` 描述普通 DATA payload 的码字类型。`UINT*` / `INT*` 中的数字表示逻辑位宽；`INT*` 按 two's complement 解释。`NOT_SET` 只作为默认值，应用侧不应把它当成有效 DATA 类型。`VOLTAGE` 输出不设置 `dtype`，固定按 `int32` 膜电平解释。
 

--- a/paibox/paiir/ir/calc_params.py
+++ b/paibox/paiir/ir/calc_params.py
@@ -89,7 +89,8 @@ class OfflineCoreParams:
     Describes the operating mode, data format, and timing configuration
     of a single offline core.
 
-    Timing parameters:
+    Timing parameters are internal hardware fields. Public compile APIs use
+    ``timesteps`` and ``auto_reset`` and map those values onto these fields.
 
     - ``tick_start``: Which sync_all to start working at. ``None`` means
       auto-assigned by :func:`~paibox.paiir.pipeline.passes.assign_tick_params`.

--- a/paibox/paiir/ir/graph.py
+++ b/paibox/paiir/ir/graph.py
@@ -634,7 +634,7 @@ class PAIIRGraph:
         for correct simulation. Call before running simulation to catch
         configuration errors early.
 
-        Required parameters:
+        Required internal hardware tick parameters:
         - ``tick_start``: Must be set (not None)
         - ``tick_duration``: Must be non-negative
         - ``tick_initial``: Must be non-negative
@@ -768,9 +768,10 @@ class PAIIRGraph:
         """Execute one time step (one sync_all cycle) through the graph.
 
         Advances the internal simulation step counter by 1. Each
-        :class:`OfflineCoreOp` is active only within its
-        ``[tick_start, tick_start + tick_duration)`` window; inactive nodes
-        output zero without updating neuron state.
+        :class:`OfflineCoreOp` is active only within its internal hardware
+        tick window. ``tick_duration=0`` means no finite stop; otherwise the
+        active window is ``[tick_start, tick_start + tick_duration)``.
+        Inactive nodes output zero without updating neuron state.
 
         Execution order mirrors the chip's sync_all protocol:
 

--- a/paibox/paiir/pipeline/compile.py
+++ b/paibox/paiir/pipeline/compile.py
@@ -21,10 +21,14 @@ conversion pipeline:
 
 Use :func:`compile_to_paiir` for a one-step compilation, or call the
 individual passes directly for fine-grained control.
+
+Public timing configuration uses ``timesteps`` and ``auto_reset``. The
+lowering pipeline maps those values to internal ``tick_duration`` /
+``tick_initial`` core fields before backend export.
 """
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Final, TypeVar, cast
 
 from torch import Tensor, nn
 
@@ -51,20 +55,46 @@ from .rewrite_phase import RewritePass, run_fixed_point_rewrite_phase
 __all__ = ["compile_to_paiir", "CompileConfig"]
 
 
+_T = TypeVar("_T")
+
+
+class _UnsetArg:
+    """Sentinel type for keyword arguments whose omitted state matters."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "<UNSET>"
+
+
+# Distinguish omitted keywords from explicit invalid/default values so
+# CompileConfig defaults and explicit keyword overrides can coexist.
+_UNSET_ARG: Final = _UnsetArg()
+
+
+def _resolve_config_arg(value: _T | _UnsetArg, config_value: _T) -> _T:
+    """Use the config value only when the keyword argument was omitted."""
+    if value is _UNSET_ARG:
+        return config_value
+    return cast(_T, value)
+
+
 @dataclass
 class CompileConfig:
     """Global configuration defaults for :func:`compile_to_paiir`.
 
-    Keyword arguments passed directly to :func:`compile_to_paiir` override the
-    matching values in this object when they are not ``None``.
+    Keyword arguments passed directly to :func:`compile_to_paiir` override
+    matching values in this object when those keywords are explicitly provided.
 
     Attributes:
-        tick_duration: Global work duration for every compute core. ``None``
-            uses the execution-mode default; ``0`` keeps cores always active;
-            a positive value activates each core for that many sync steps.
-        auto_reset: Global automatic-reset policy. ``None`` uses the
-            execution-mode default; true resets state at finite work-window
-            boundaries; false leaves state externally controlled.
+        timesteps: Application-side inference sequence length. It must be a
+            positive integer. When automatic reset is enabled, the compiled
+            cores stay active and reset every ``timesteps`` active ticks. When
+            automatic reset is disabled, the compiled cores work for exactly
+            ``timesteps`` ticks and leave reset control to the caller.
+        auto_reset: Whether compiled cores automatically reinitialise neuron
+            state every ``timesteps`` active ticks. The same timing policy is
+            applied to all offline cores; it does not branch by ANN/SNN mode.
         input_formats: Optional data-format overrides keyed by ``InputNode``
             name. Each value is a ``(DataSign, DataWidth)`` pair.
         enable_avgpool_calibration: Enable experimental threshold calibration
@@ -81,8 +111,8 @@ class CompileConfig:
             to task semantics.
     """
 
-    tick_duration: int | None = None
-    auto_reset: bool | None = None
+    timesteps: int = 1
+    auto_reset: bool = True
     input_formats: dict[str, DataFormat] | None = None
     enable_avgpool_calibration: bool = False
     enable_split_avgpool_lif: bool = False
@@ -93,8 +123,8 @@ class CompileConfig:
 def compile_to_paiir(
     model: nn.Module,
     *sample_inputs: Tensor,
-    tick_duration: int | None = None,
-    auto_reset: bool | None = None,
+    timesteps: int | _UnsetArg = _UNSET_ARG,
+    auto_reset: bool | _UnsetArg = _UNSET_ARG,
     input_formats: dict[str, DataFormat] | None = None,
     compile_config: CompileConfig | None = None,
     concrete_args: dict[str, Any] | None = None,
@@ -117,14 +147,16 @@ def compile_to_paiir(
         *sample_inputs: Example tensors used for FX tracing, shape propagation,
             and dimension propagation. The current deployment path expects
             batch size 1.
-        tick_duration: Global work duration for compute cores. ``None`` means
-            use the execution-mode default. ``0`` means always active, and a
-            positive value means active for that many time steps.
-        auto_reset: Global automatic-reset policy. ``None`` means use the
-            execution-mode default. When true and ``tick_duration > 0``,
-            ``tick_initial`` is set to ``tick_duration``; when
-            ``tick_duration == 0``, ``tick_initial`` remains ``0`` because an
-            always-active core has no finite reset boundary.
+        timesteps: Application-side inference sequence length. It must be a
+            positive integer and defaults to ``1`` through ``CompileConfig``.
+            With ``auto_reset=True``, cores stay active
+            (``tick_duration=0``) and reinitialise every ``timesteps`` active
+            ticks (``tick_initial=timesteps``). With ``auto_reset=False``,
+            cores work for ``timesteps`` ticks (``tick_duration=timesteps``)
+            with reset control left to the caller (``tick_initial=0``).
+        auto_reset: Whether compiled cores automatically reinitialise state
+            every ``timesteps`` active ticks. Defaults to ``True`` through
+            ``CompileConfig`` and applies uniformly to ANN and SNN mode cores.
         input_formats: Optional data-format overrides keyed by ``InputNode``
             name.
         compile_config: Optional object containing global defaults. Explicit
@@ -152,11 +184,9 @@ def compile_to_paiir(
 
     Timing defaults:
         If neither keyword arguments nor ``compile_config`` specify timing,
-        ANN-mode cores default to one active step with automatic reset
-        (``tick_duration=1``, ``tick_initial=1``), while SNN-mode cores default
-        to continuous work without automatic reset (``tick_duration=0``,
-        ``tick_initial=0``). Explicit global timing parameters take priority
-        over these execution-mode defaults.
+        ``timesteps`` defaults to ``1`` and ``auto_reset`` defaults to
+        ``True``. This exports all offline cores with ``tick_duration=0`` and
+        ``tick_initial=1``. The same policy applies to ANN and SNN mode cores.
 
     Pipeline:
 
@@ -183,8 +213,8 @@ def compile_to_paiir(
     13. :func:`validate_deployable_graph` -- ensure no frontend-only IR remains
     """
     cfg = compile_config or CompileConfig()
-    _tick_duration = tick_duration if tick_duration is not None else cfg.tick_duration
-    _auto_reset = auto_reset if auto_reset is not None else cfg.auto_reset
+    _timesteps = _resolve_config_arg(timesteps, cfg.timesteps)
+    _auto_reset = _resolve_config_arg(auto_reset, cfg.auto_reset)
     _input_formats = input_formats if input_formats is not None else cfg.input_formats
     _enable_avgpool_calibration = (
         enable_avgpool_calibration
@@ -219,7 +249,7 @@ def compile_to_paiir(
         _post_fusion_rewrite_passes(_enable_delayed_avgpool_division, _output_approx),
     )
 
-    assign_tick_params(graph, _tick_duration, _auto_reset)
+    assign_tick_params(graph, _timesteps, _auto_reset)
 
     if _enable_avgpool_calibration:
         calibrate_avgpool_thresholds(graph)

--- a/paibox/paiir/pipeline/passes.py
+++ b/paibox/paiir/pipeline/passes.py
@@ -1937,18 +1937,27 @@ def _get_node_act(node: OfflineCoreOp) -> CoreNeuronV25 | None:
 
 
 def assign_tick_params(
-    graph: PAIIRGraph,
-    tick_duration: int | None = None,
-    auto_reset: bool | None = None,
+    graph: PAIIRGraph, timesteps: int = 1, auto_reset: bool = True
 ) -> None:
     """Assign timing parameters on every :class:`OfflineCoreOp`.
 
-    Without explicit timing policy, ANN-mode cores use one work step with
-    automatic reset while SNN-mode cores run continuously. Explicit global
-    timing parameters take priority over compute-mode defaults.
+    ``timesteps`` is the public, application-side inference length and must be
+    positive. It is mapped to the internal core timing fields uniformly for all
+    offline cores, independent of ANN/SNN mode:
+
+    - ``auto_reset=True`` keeps cores continuously active
+      (``tick_duration=0``) and reinitialises state every ``timesteps`` active
+      ticks (``tick_initial=timesteps``).
+    - ``auto_reset=False`` makes cores work for ``timesteps`` ticks
+      (``tick_duration=timesteps``) and leaves reset control to the caller
+      (``tick_initial=0``).
     """
-    if tick_duration is not None and tick_duration < 0:
-        raise ValueError(f"'tick_duration' must be non-negative, got {tick_duration}")
+    if not isinstance(timesteps, int) or isinstance(timesteps, bool):
+        raise TypeError(f"'timesteps' must be a positive integer, got {timesteps!r}")
+    if timesteps <= 0:
+        raise ValueError(f"'timesteps' must be positive, got {timesteps}")
+    if not isinstance(auto_reset, bool):
+        raise TypeError(f"'auto_reset' must be a bool, got {auto_reset!r}")
 
     depth: dict[str, int] = {}
     for name in graph.topo_sort():
@@ -1970,18 +1979,11 @@ def assign_tick_params(
 
         cp.tick_start = depth[name]
 
-        if tick_duration is not None:
-            cp.tick_duration = tick_duration
-        elif cp.snn_mode == SNNMode.ANN:
-            cp.tick_duration = 1
-        else:
+        if auto_reset:
             cp.tick_duration = 0
-
-        node_auto_reset = auto_reset
-        if node_auto_reset is None:
-            node_auto_reset = cp.snn_mode == SNNMode.ANN
-        cp.tick_initial = (
-            cp.tick_duration if node_auto_reset and cp.tick_duration > 0 else 0
-        )
+            cp.tick_initial = timesteps
+        else:
+            cp.tick_duration = timesteps
+            cp.tick_initial = 0
 
         cp.validate_tick_params()

--- a/tests/backendv2/test_mapper.py
+++ b/tests/backendv2/test_mapper.py
@@ -418,7 +418,7 @@ def test_output_lcn_uses_timesteps_not_external_sync_steps(
         "output_lcn_uses_timesteps",
         ANNClassifier(),
         make_img_3ch_8x8(),
-        tick_duration=1,
+        timesteps=1,
         auto_reset=False,
     )
 
@@ -459,7 +459,7 @@ def test_export_proto_exports_ann_io_ticks_and_core_ticks(
     assert thread.runtime.sync_steps == expected_tick_depth
     assert thread.runtime.decode_mode == RuntimeParams.STREAM
     _assert_core_ticks_match_mapper(thread, mapper)
-    _assert_thread_tick_duration_initial(thread, (1, 1))
+    _assert_thread_tick_duration_initial(thread, (0, 1))
 
 
 def test_export_proto_exports_explicit_ann_tick_policy(
@@ -470,7 +470,7 @@ def test_export_proto_exports_explicit_ann_tick_policy(
         "ann_explicit_tick_metadata",
         ANNClassifier(),
         make_img_3ch_8x8(),
-        tick_duration=6,
+        timesteps=6,
         auto_reset=False,
     )
 
@@ -495,7 +495,13 @@ def test_mapper_rejects_timesteps_exceeding_finite_tick_duration(
         shutil.rmtree(export_dir)
     export_dir.mkdir(parents=True, exist_ok=True)
 
-    graph = compile_to_paiir(ANNClassifier().eval(), make_img_3ch_8x8(), strict=True)
+    graph = compile_to_paiir(
+        ANNClassifier().eval(),
+        make_img_3ch_8x8(),
+        strict=True,
+        timesteps=1,
+        auto_reset=False,
+    )
     mapper = Mapper()
 
     with pytest.raises(ValueError, match="exceeds finite tick_duration"):
@@ -584,38 +590,36 @@ def test_export_proto_exports_input_dtype_from_consumer_format(
 
 
 @pytest.mark.parametrize(
-    ("tick_duration", "auto_reset", "expected_initial"),
-    [(7, True, 7), (7, False, 0), (0, True, 0)],
-    ids=["finite_reset", "finite_no_reset", "always_on"],
+    ("timesteps", "auto_reset", "expected_tick"),
+    [(7, True, (0, 7)), (7, False, (7, 0))],
+    ids=["auto_reset", "manual_reset"],
 )
 def test_export_proto_exports_snn_tick_policy(
-    ensure_backendv2_debug_dir, tick_duration, auto_reset, expected_initial
+    ensure_backendv2_debug_dir, timesteps, auto_reset, expected_tick
 ):
     pb_path, output_source_names, mapper = _export_graph_proto_with_context(
         ensure_backendv2_debug_dir,
-        f"snn_tick_metadata_{tick_duration}_{auto_reset}",
+        f"snn_tick_metadata_{timesteps}_{auto_reset}",
         SNNTwoLayer(),
         make_img_3ch_8x8(),
-        tick_duration=tick_duration,
+        timesteps=timesteps,
         auto_reset=auto_reset,
     )
 
     artifacts = _load_compile_artifacts(pb_path)
     thread = artifacts.io_mapping.threads[0]
-    expected = (tick_duration, expected_initial)
 
     assert {mapping.name for mapping in thread.output_mappings.items} == (
         output_source_names
     )
-    expected_timesteps = tick_duration if tick_duration > 0 else 1
     expected_tick_depth = max(
         mapping.tick.tick_start for mapping in thread.output_mappings.items
     )
-    assert thread.runtime.timesteps == expected_timesteps
+    assert thread.runtime.timesteps == timesteps
     assert thread.runtime.tick_depth == expected_tick_depth
-    assert thread.runtime.sync_steps == expected_tick_depth + expected_timesteps - 1
+    assert thread.runtime.sync_steps == expected_tick_depth + timesteps - 1
     _assert_core_ticks_match_mapper(thread, mapper)
-    _assert_thread_tick_duration_initial(thread, expected)
+    _assert_thread_tick_duration_initial(thread, expected_tick)
 
 
 def test_export_artifacts_all_platforms_when_requested(ensure_backendv2_debug_dir):

--- a/tests/paiir/pipeline/avgpool/test_delayed_division.py
+++ b/tests/paiir/pipeline/avgpool/test_delayed_division.py
@@ -161,22 +161,23 @@ def _reset_stateful_modules(model: nn.Module) -> None:
 def _compile_graph(
     model: nn.Module,
     sample_input: torch.Tensor,
-    tick_duration: int | None = None,
-    auto_reset: bool | None = None,
+    timesteps: int = 1,
+    auto_reset: bool = True,
     **kwargs,
 ):
     return compile_to_paiir(
         model.eval(),
         sample_input.to(torch.float32),
-        tick_duration=tick_duration,
+        timesteps=timesteps,
         auto_reset=auto_reset,
         **kwargs,
     )
 
 
 def _run_and_compare(model: nn.Module, sample_input: torch.Tensor, **kwargs) -> None:
-    # These tests compare operator values, so keep all ANN cores continuously active.
-    graph = _compile_graph(model, sample_input, tick_duration=0, auto_reset=False)
+    # These tests compare operator values, so use the default continuously active
+    # auto-reset policy for compiled cores.
+    graph = _compile_graph(model, sample_input)
     _reset_stateful_modules(model)
     graph.reset()
 

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -769,32 +769,24 @@ class TestTickParams:
             assert node.core_params.tick_start >= 1
 
     @pytest.mark.parametrize(
-        "tick_duration, auto_reset, expected_duration, expected_initial",
+        "kwargs, expected_duration, expected_initial",
         [
-            (None, None, 1, 1),
-            (100, None, 100, 100),
-            (None, False, 1, 0),
-            (100, False, 100, 0),
-            (0, True, 0, 0),
+            ({}, 0, 1),
+            ({"auto_reset": False}, 1, 0),
+            ({"timesteps": 7}, 0, 7),
+            ({"timesteps": 7, "auto_reset": False}, 7, 0),
         ],
         ids=[
-            "default",
-            "duration_only",
-            "auto_reset_only",
-            "reset_disabled",
-            "always_on",
+            "default_auto_reset",
+            "manual_reset_default_timesteps",
+            "multi_step_auto_reset",
+            "multi_step_manual_reset",
         ],
     )
-    def test_tick_duration_and_auto_reset(
-        self, tick_duration, auto_reset, expected_duration, expected_initial
+    def test_timesteps_and_auto_reset_mapping(
+        self, kwargs, expected_duration, expected_initial
     ):
-        """ANN defaults to one tick but explicit timing kwargs have priority."""
-        kwargs = {}
-        if tick_duration is not None:
-            kwargs["tick_duration"] = tick_duration
-        if auto_reset is not None:
-            kwargs["auto_reset"] = auto_reset
-
+        """Public timesteps/auto_reset map to internal core tick parameters."""
         sample_input = make_img_3ch_8x8()
         graph = compile_to_paiir(ANNClassifier(), sample_input, **kwargs)
 
@@ -802,12 +794,18 @@ class TestTickParams:
             assert node.core_params.tick_duration == expected_duration
             assert node.core_params.tick_initial == expected_initial
 
+    @pytest.mark.parametrize("timesteps", [0, -1], ids=["zero", "negative"])
+    def test_invalid_timesteps_raises(self, timesteps):
+        """compile_to_paiir rejects non-positive public timesteps."""
+        with pytest.raises(ValueError, match="timesteps.*positive"):
+            compile_to_paiir(ANNClassifier(), make_img_3ch_8x8(), timesteps=timesteps)
+
 
 class TestCompileConfig:
     """CompileConfig and parameter precedence."""
 
     def test_config_applies(self):
-        config = CompileConfig(tick_duration=50, auto_reset=False)
+        config = CompileConfig(timesteps=50, auto_reset=False)
         sample_input = make_img_3ch_8x8()
         graph = compile_to_paiir(ANNClassifier(), sample_input, compile_config=config)
 
@@ -817,19 +815,34 @@ class TestCompileConfig:
 
     def test_explicit_kwarg_overrides_config(self):
 
-        config = CompileConfig(tick_duration=50, auto_reset=False)
+        config = CompileConfig(timesteps=50, auto_reset=False)
         sample_input = make_img_3ch_8x8()
         graph = compile_to_paiir(
             ANNClassifier(),
             sample_input,
-            tick_duration=100,
+            timesteps=100,
             auto_reset=True,
             compile_config=config,
         )
 
         for node in offline_nodes(graph):
-            assert node.core_params.tick_duration == 100
+            assert node.core_params.tick_duration == 0
             assert node.core_params.tick_initial == 100
+
+    def test_explicit_default_timing_kwarg_overrides_config(self):
+        config = CompileConfig(timesteps=50, auto_reset=False)
+        sample_input = make_img_3ch_8x8()
+        graph = compile_to_paiir(
+            ANNClassifier(),
+            sample_input,
+            timesteps=1,
+            auto_reset=True,
+            compile_config=config,
+        )
+
+        for node in offline_nodes(graph):
+            assert node.core_params.tick_duration == 0
+            assert node.core_params.tick_initial == 1
 
 
 class TestStrictMode:

--- a/tests/paiir/pipeline/test_graph_simulation.py
+++ b/tests/paiir/pipeline/test_graph_simulation.py
@@ -97,7 +97,7 @@ class VotingLayerSimulation(nn.Module):
 
 
 def _compile_snn(
-    tick_duration: int = 0,
+    timesteps: int = 1,
     auto_reset: bool = True,
     bias: bool = False,
     bipolar: bool = False,
@@ -105,8 +105,8 @@ def _compile_snn(
     """Compile a single-layer SNN with deterministic weights.
 
     Args:
-        tick_duration: Activity duration for the core. 0 for always active.
-        auto_reset: Whether to auto-reset neuron state.
+        timesteps: Public inference sequence length passed to compile_to_paiir.
+        auto_reset: Whether compiled cores should auto-reset every timesteps.
         bias: Whether to include bias in the conv layer.
         bipolar: If True, use bipolar input spikes {-1, 0, 1}.
     """
@@ -119,7 +119,7 @@ def _compile_snn(
 
     x_compile = torch.randn(1, 3, 8, 8)
     graph = compile_to_paiir(
-        model, x_compile, tick_duration=tick_duration, auto_reset=auto_reset
+        model, x_compile, timesteps=timesteps, auto_reset=auto_reset
     )
     return graph, _make_snn_input(bipolar=bipolar)
 
@@ -178,39 +178,44 @@ class TestTickActivityWindow:
 class TestTickInitial:
     """Tests for tick_initial semantics (state reset behavior)."""
 
-    def test_ann_tick_initial_defaults_to_one(self) -> None:
-        """ANN cores default to tick_initial=1 (stateless per step)."""
+    def test_ann_tick_initial_defaults_to_timesteps(self) -> None:
+        """Default public timing keeps ANN cores active and resets every step."""
         graph, _, _ = _compile_ann()
         for node in find_nodes(graph, OfflineCoreOp):
-            assert node.core_params.tick_duration == 1
+            assert node.core_params.tick_duration == 0
             assert node.core_params.tick_initial == 1
 
-    def test_ann_runs_for_one_tick(self) -> None:
-        """ANN cores are active for one step, then leave the work window."""
+    def test_ann_default_runs_continuously(self) -> None:
+        """Default ANN cores stay active because public auto_reset uses duration 0."""
         graph, x, _ = _compile_ann()
+        offline_ops = find_nodes(graph, OfflineCoreOp)
+        assert offline_ops
 
         out1 = graph.step(x)
         out2 = graph.step(x)
 
         assert torch.is_tensor(out1)
         assert torch.is_tensor(out2)
-        assert torch.all(out2 == 0)
+        for op in offline_ops:
+            assert graph._active_counts[op.name] == 2
 
-    def test_snn_tick_initial_equals_duration_when_auto_reset(self) -> None:
-        """SNN with auto_reset=True has tick_initial=tick_duration."""
-        graph, _ = _compile_snn(tick_duration=4, auto_reset=True)
+    def test_snn_tick_initial_equals_timesteps_when_auto_reset(self) -> None:
+        """auto_reset=True maps timesteps to tick_initial and duration to 0."""
+        graph, _ = _compile_snn(timesteps=4, auto_reset=True)
         seq_ops = find_nodes(graph, SequentialOp)
+        assert seq_ops[0].core_params.tick_duration == 0
         assert seq_ops[0].core_params.tick_initial == 4
 
-    def test_snn_tick_initial_zero_when_no_auto_reset(self) -> None:
-        """SNN with auto_reset=False has tick_initial=0."""
-        graph, _ = _compile_snn(tick_duration=0, auto_reset=False)
+    def test_snn_tick_duration_equals_timesteps_when_no_auto_reset(self) -> None:
+        """auto_reset=False maps timesteps to finite tick_duration."""
+        graph, _ = _compile_snn(timesteps=4, auto_reset=False)
         seq_ops = find_nodes(graph, SequentialOp)
+        assert seq_ops[0].core_params.tick_duration == 4
         assert seq_ops[0].core_params.tick_initial == 0
 
     def test_snn_auto_reset_behavior(self) -> None:
         """SNN neuron state resets after tick_initial active steps."""
-        graph, x = _compile_snn(tick_duration=4, auto_reset=True, bipolar=True)
+        graph, x = _compile_snn(timesteps=4, auto_reset=True, bipolar=True)
         seq_ops = find_nodes(graph, SequentialOp)
         op = seq_ops[0]
 
@@ -224,11 +229,11 @@ class TestTickInitial:
         assert v.abs().sum() > 0
 
         graph.step(x)
-        assert graph._active_counts[op.name] == 4
+        assert graph._active_counts[op.name] == 5
 
     def test_snn_state_accumulates_without_auto_reset(self) -> None:
         """SNN membrane potential accumulates when auto_reset=False."""
-        graph, x = _compile_snn(tick_duration=0, auto_reset=False, bipolar=True)
+        graph, x = _compile_snn(timesteps=8, auto_reset=False, bipolar=True)
         seq_ops = find_nodes(graph, SequentialOp)
         op = seq_ops[0]
 
@@ -245,7 +250,7 @@ class TestSNNSimulation:
 
     def test_voltage_accumulates(self) -> None:
         """Neuron membrane potential changes across steps."""
-        graph, x = _compile_snn(tick_duration=0, auto_reset=False, bipolar=True)
+        graph, x = _compile_snn(timesteps=8, auto_reset=False, bipolar=True)
         seq_ops = find_nodes(graph, SequentialOp)
         op = seq_ops[0]
 
@@ -261,7 +266,7 @@ class TestSNNSimulation:
 
     def test_reset_clears_all_state(self) -> None:
         """graph.reset() clears sim_step, active_counts, and neuron state."""
-        graph, x = _compile_snn(tick_duration=0, auto_reset=False)
+        graph, x = _compile_snn(timesteps=8, auto_reset=False)
         seq_ops = find_nodes(graph, SequentialOp)
         op = seq_ops[0]
         init_v = op.act.init_v

--- a/tests/paiir/pipeline/test_passes.py
+++ b/tests/paiir/pipeline/test_passes.py
@@ -783,65 +783,53 @@ class TestAssignTickParams:
         tick_starts = sorted([n.core_params.tick_start for n in seq_nodes])  # type: ignore
         assert tick_starts[0] < tick_starts[1]
 
-    @pytest.mark.parametrize(
-        "tick_duration, expected",
-        [(0, 0), (100, 100)],
-        ids=["default_always_working", "global_override"],
-    )
-    def test_tick_duration(self, fused_snn, tick_duration, expected):
-        """tick_duration: default (0) or graph-level override applied to all nodes."""
-        assign_tick_params(fused_snn, tick_duration=tick_duration)
+    def test_default_timesteps_auto_reset_mapping(self, fused_snn):
+        """Default user timing maps to always-active cores with one-step reset."""
+        assign_tick_params(fused_snn)
 
         for node in fused_snn.nodes.values():
-            if isinstance(node, SequentialOp):
-                assert node.core_params.tick_duration == expected
-
-    def test_ann_tick_duration_and_initial_default_to_one(self, fused_ann):
-        """ANN-mode cores work for one tick and reset by default."""
-        ann_nodes = [
-            node
-            for node in fused_ann.nodes.values()
-            if isinstance(node, OfflineCoreOp)
-            and node.core_params.snn_mode == SNNMode.ANN
-        ]
-        assert ann_nodes
-
-        assign_tick_params(fused_ann)
-
-        for node in ann_nodes:
-            assert node.core_params.tick_duration == 1
-            assert node.core_params.tick_initial == 1
-
-    def test_ann_tick_params_respect_explicit_policy(self, fused_ann):
-        """Explicit global timing policy has priority for ANN cores."""
-        ann_nodes = [
-            node
-            for node in fused_ann.nodes.values()
-            if isinstance(node, OfflineCoreOp)
-            and node.core_params.snn_mode == SNNMode.ANN
-        ]
-        assert ann_nodes
-
-        assign_tick_params(fused_ann, tick_duration=100, auto_reset=False)
-
-        for node in ann_nodes:
-            assert node.core_params.tick_duration == 100
-            assert node.core_params.tick_initial == 0
+            if isinstance(node, OfflineCoreOp):
+                assert node.core_params.tick_duration == 0
+                assert node.core_params.tick_initial == 1
 
     @pytest.mark.parametrize(
-        "tick_duration, auto_reset, expected_initial",
-        [(100, True, 100), (0, True, 0), (100, False, 0)],
-        ids=["reset_with_duration", "reset_always_working", "no_reset"],
+        "graph_fixture", ["fused_snn", "fused_ann"], ids=["snn_mode", "ann_mode"]
     )
-    def test_auto_reset(self, fused_snn, tick_duration, auto_reset, expected_initial):
-        """auto_reset controls tick_initial derivation from tick_duration."""
-        assign_tick_params(
-            fused_snn, tick_duration=tick_duration, auto_reset=auto_reset
-        )
+    @pytest.mark.parametrize(
+        "timesteps, auto_reset, expected_duration, expected_initial",
+        [
+            (1, True, 0, 1),
+            (1, False, 1, 0),
+            (7, True, 0, 7),
+            (7, False, 7, 0),
+        ],
+        ids=[
+            "default_step_auto_reset",
+            "default_step_manual_reset",
+            "multi_step_auto_reset",
+            "multi_step_manual_reset",
+        ],
+    )
+    def test_timesteps_auto_reset_mapping_is_mode_independent(
+        self,
+        request,
+        graph_fixture,
+        timesteps,
+        auto_reset,
+        expected_duration,
+        expected_initial,
+    ):
+        """timesteps/auto_reset maps identically for ANN and SNN mode cores."""
+        graph = request.getfixturevalue(graph_fixture)
+        assign_tick_params(graph, timesteps=timesteps, auto_reset=auto_reset)
 
-        for node in fused_snn.nodes.values():
-            if isinstance(node, SequentialOp):
-                assert node.core_params.tick_initial == expected_initial
+        offline_ops = [
+            node for node in graph.nodes.values() if isinstance(node, OfflineCoreOp)
+        ]
+        assert offline_ops
+        for node in offline_ops:
+            assert node.core_params.tick_duration == expected_duration
+            assert node.core_params.tick_initial == expected_initial
 
     def test_residual_tick_start(self):
         """Residual (AccumulateOp) gets correct tick_start."""
@@ -943,14 +931,25 @@ class TestAssignTickParams:
         assert act.core_params.tick_start == 1
 
     @pytest.mark.parametrize(
-        "tick_duration",
-        [-1],
-        ids=["negative_graph_duration"],
+        "timesteps", [0, -1], ids=["zero_timesteps", "negative_timesteps"]
     )
-    def test_negative_param_raises(self, fused_snn, tick_duration):
-        """Negative global tick parameters raise ValueError immediately."""
-        with pytest.raises(ValueError, match="tick_duration.*non-negative"):
-            assign_tick_params(fused_snn, tick_duration=tick_duration)
+    def test_invalid_timesteps_value_raises(self, fused_snn, timesteps):
+        """Non-positive public timesteps raise before writing core timing."""
+        with pytest.raises(ValueError, match="timesteps.*positive"):
+            assign_tick_params(fused_snn, timesteps=timesteps)
+
+    @pytest.mark.parametrize(
+        "timesteps", [None, True, 1.5], ids=["none", "bool", "float"]
+    )
+    def test_invalid_timesteps_type_raises(self, fused_snn, timesteps):
+        """timesteps must be a real positive integer, not None/bool/float."""
+        with pytest.raises(TypeError, match="timesteps.*positive integer"):
+            assign_tick_params(fused_snn, timesteps=timesteps)
+
+    def test_invalid_auto_reset_type_raises(self, fused_snn):
+        """auto_reset is a required boolean policy when explicitly provided."""
+        with pytest.raises(TypeError, match="auto_reset.*bool"):
+            assign_tick_params(fused_snn, auto_reset=None)
 
     def test_validate_tick_params_unassigned(self):
         """validate_tick_params raises if tick_start is still None."""


### PR DESCRIPTION
## Summary

- replace public PAIIR compile timing config with `timesteps` / `auto_reset`
- map auto-reset graphs to `tick_duration=0`, `tick_initial=timesteps`
- infer backendv2 runtime timesteps from `tick_initial` before finite `tick_duration`
- update timing tests, graph simulation expectations, and user-facing docs