### PR TITLE
Feat(paiir): carry delayed AvgPool code ranges

### DIFF
--- a/paibox/paiir/pipeline/avgpool/delayed_division.py
+++ b/paibox/paiir/pipeline/avgpool/delayed_division.py
@@ -23,31 +23,40 @@ from paicorelib import OfflineNeuRegLim
 from ...ir.core_neuron import ANNNodeV25, CoreNeuronV25
 from ...ir.graph import PAIIRGraph
 from ...ir.ir_base import OutputNode, PAIIRNode
-from ...ir.lut_activation import LutActivation, LutCustom
+from ...ir.lut_activation import LutActivation
 from ...ir.op_node import SequentialOp, StandaloneActOp, StandaloneCompOp
 from ..data_format import fits_value_code_range
 from ..graph_utils import (
     collect_effective_value_code_ranges,
     is_format_transparent_routing_node,
 )
-from .utils import build_sum_pool, get_avgpool_divisor, get_pool_window_size, is_avgpool
+from .utils import (
+    ValueCodeRange,
+    build_range_identity_lut,
+    build_sum_pool,
+    get_avgpool_divisor,
+    get_pool_window_size,
+    is_avgpool,
+)
 
 __all__ = ["rewrite_delayed_avgpool_division"]
 
 
 _INT32_MIN = torch.iinfo(torch.int32).min
 _INT32_MAX = torch.iinfo(torch.int32).max
-_INT8_MIN = torch.iinfo(torch.int8).min
-_INT8_MAX = torch.iinfo(torch.int8).max
-_UINT8_MAX = torch.iinfo(torch.uint8).max
+
+
+@dataclass(frozen=True, slots=True)
+class _DelayedAvgPoolCarrier:
+    name: str
+    code_range: ValueCodeRange
 
 
 @dataclass(frozen=True, slots=True)
 class _DelayedDivisionPlan:
-    avgpool_names: tuple[str, ...]
+    avgpool_carriers: tuple[_DelayedAvgPoolCarrier, ...]
     endpoint_name: str
     pending_divisor: int
-    carrier_signed: bool
 
 
 def rewrite_delayed_avgpool_division(graph: PAIIRGraph) -> PAIIRGraph:
@@ -80,7 +89,7 @@ def rewrite_delayed_avgpool_division(graph: PAIIRGraph) -> PAIIRGraph:
             continue
 
         _apply_delayed_division_plan(rewritten, graph, plan)
-        handled_avgpools.update(plan.avgpool_names)
+        handled_avgpools.update(carrier.name for carrier in plan.avgpool_carriers)
         changed = True
 
     return rewritten if changed else graph
@@ -110,7 +119,7 @@ def _analyze_delayed_division_chain(
 
     code_min, code_max = code_ranges[0]
     pending_divisor = 1
-    avgpool_names: list[str] = []
+    avgpool_carriers: list[_DelayedAvgPoolCarrier] = []
     current_name = start_name
 
     while True:
@@ -130,7 +139,9 @@ def _analyze_delayed_division_chain(
             if not fits_value_code_range(code_min, code_max):
                 return None
 
-            avgpool_names.append(current_name)
+            avgpool_carriers.append(
+                _DelayedAvgPoolCarrier(current_name, (code_min, code_max))
+            )
             current_name = succs[0]
             continue
 
@@ -141,7 +152,7 @@ def _analyze_delayed_division_chain(
             current_name = succs[0]
             continue
 
-        if not avgpool_names:
+        if not avgpool_carriers:
             return None
 
         if not _is_supported_endpoint_node(current):
@@ -151,10 +162,9 @@ def _analyze_delayed_division_chain(
             return None
 
         return _DelayedDivisionPlan(
-            avgpool_names=tuple(avgpool_names),
+            avgpool_carriers=tuple(avgpool_carriers),
             endpoint_name=current_name,
             pending_divisor=pending_divisor,
-            carrier_signed=code_min < 0,
         )
 
 
@@ -167,11 +177,12 @@ def _apply_delayed_division_plan(
     the graph topology stays stable. The terminal node is then deep-copied and
     rewritten in-place to absorb the accumulated divisor.
     """
-    for avgpool_name in plan.avgpool_names:
+    for carrier in plan.avgpool_carriers:
+        avgpool_name = carrier.name
         avgpool_node = graph.nodes[avgpool_name]
         assert isinstance(avgpool_node, StandaloneCompOp)
         assert is_avgpool(avgpool_node.comp)
-        replacement = _build_exact_sum_carrier(avgpool_node.comp, plan.carrier_signed)
+        replacement = _build_exact_sum_carrier(avgpool_node.comp, carrier.code_range)
         replacement.name = avgpool_name
         replacement.input_layouts = avgpool_node.input_layouts
         replacement.output_layouts = avgpool_node.output_layouts
@@ -184,23 +195,11 @@ def _apply_delayed_division_plan(
 
 
 def _build_exact_sum_carrier(
-    comp: nn.AvgPool1d | nn.AvgPool2d, signed: bool
+    comp: nn.AvgPool1d | nn.AvgPool2d, code_range: ValueCodeRange
 ) -> SequentialOp:
     """Build the exact-sum carrier that replaces one standalone AvgPool."""
     sum_pool = build_sum_pool(comp)
-    return SequentialOp(sum_pool, ANNNodeV25(_build_identity_lut(signed)))
-
-
-def _build_identity_lut(signed: bool) -> LutCustom:
-    """Build the 8-bit identity LUT used to carry exact sum-domain codes."""
-    if signed:
-        thresholds = torch.arange(_INT8_MIN, _INT8_MAX + 1, dtype=torch.int32)
-        values = torch.arange(_INT8_MIN, _INT8_MAX + 1, dtype=torch.int8)
-        return LutCustom(thresholds, values, output_sign=1, is_float=False)
-
-    thresholds = torch.arange(_UINT8_MAX + 1, dtype=torch.int32)
-    values = torch.arange(_UINT8_MAX + 1, dtype=torch.uint8)
-    return LutCustom(thresholds, values, output_sign=0, is_float=False)
+    return SequentialOp(sum_pool, ANNNodeV25(build_range_identity_lut(code_range)))
 
 
 def _is_source_transparent_node(node: PAIIRNode) -> bool:

--- a/paibox/paiir/pipeline/avgpool/standalone_rewrite.py
+++ b/paibox/paiir/pipeline/avgpool/standalone_rewrite.py
@@ -27,7 +27,13 @@ from ..graph_utils import (
     is_format_transparent_routing_node,
     is_standalone_maxpool,
 )
-from .utils import build_sum_pool, get_avgpool_divisor, get_pool_window_size, is_avgpool
+from .utils import (
+    build_range_identity_lut,
+    build_sum_pool,
+    get_avgpool_divisor,
+    get_pool_window_size,
+    is_avgpool,
+)
 
 __all__ = ["rewrite_standalone_avgpools"]
 
@@ -172,7 +178,7 @@ def _build_output_sum_approx_avgpool(
         return None
 
     sum_pool = build_sum_pool(node.comp)
-    act = ANNNodeV25(_build_range_identity_lut(code_range))
+    act = ANNNodeV25(build_range_identity_lut(code_range))
     replacement = SequentialOp(sum_pool, act)
     replacement.name = node_name
 
@@ -281,20 +287,6 @@ def _build_binary_majority_avgpool(comp: nn.AvgPool1d | nn.AvgPool2d) -> Sequent
         thres_neg_mode=ThresholdNegMode.FLOOR, leak_v=-(threshold - 1), thres_neg=0
     )
     return SequentialOp(sum_pool, act)
-
-
-def _build_range_identity_lut(code_range: tuple[int, int]) -> LutCustom:
-    """Build a 256-entry identity LUT whose output codes stay inside *code_range*."""
-    code_min, code_max = code_range
-    codes = torch.arange(code_min, code_max + 1, dtype=torch.int32)
-    pad_count = 256 - codes.numel()
-    if pad_count < 0:
-        raise ValueError(f"identity LUT code range too large: {code_range}")
-    if pad_count:
-        pad = torch.full((pad_count,), code_max, dtype=torch.int32)
-        codes = torch.cat((codes, pad))
-
-    return LutCustom(codes, codes, output_sign=1 if code_min < 0 else 0, is_float=False)
 
 
 def _warn_output_majority_fallback(

--- a/paibox/paiir/pipeline/avgpool/utils.py
+++ b/paibox/paiir/pipeline/avgpool/utils.py
@@ -3,11 +3,15 @@
 import math
 from typing import TypeAlias, TypeGuard
 
+import torch
 import torch.nn as nn
 
+from ...ir.lut_activation import LutCustom
 from ...nn import SumPool1d, SumPool2d
 
 __all__ = [
+    "ValueCodeRange",
+    "build_range_identity_lut",
     "build_sum_pool",
     "get_avgpool_divisor",
     "get_pool_window_size",
@@ -17,6 +21,21 @@ __all__ = [
 
 
 PoolWindowModule: TypeAlias = nn.AvgPool1d | nn.AvgPool2d | SumPool1d | SumPool2d
+ValueCodeRange: TypeAlias = tuple[int, int]
+
+
+def build_range_identity_lut(code_range: ValueCodeRange) -> LutCustom:
+    """Build a 256-entry identity LUT over a known integer code range."""
+    code_min, code_max = code_range
+    codes = torch.arange(code_min, code_max + 1, dtype=torch.int32)
+    pad_count = 256 - codes.numel()
+    if pad_count < 0:
+        raise ValueError(f"identity LUT code range too large: {code_range}")
+    if pad_count:
+        pad = torch.full((pad_count,), code_max, dtype=torch.int32)
+        codes = torch.cat((codes, pad))
+
+    return LutCustom(codes, codes, output_sign=1 if code_min < 0 else 0, is_float=False)
 
 
 def is_avgpool(comp: nn.Module) -> TypeGuard[nn.AvgPool1d | nn.AvgPool2d]:

--- a/tests/paiir/pipeline/avgpool/test_delayed_division.py
+++ b/tests/paiir/pipeline/avgpool/test_delayed_division.py
@@ -1,10 +1,13 @@
 import pytest
 import torch
+from paicorelib import DataSign, DataWidth
+from spikingjelly.activation_based import neuron
 from torch import nn
 
 from paibox.paiir import ANNNodeV25, IFNodeV25, LIFNodeV25, compile_to_paiir
 from paibox.paiir.ir.lut_activation import LutCustom
 from paibox.paiir.ir.op_node import SequentialOp, StandaloneCompOp
+from paibox.paiir.ir.signal_domain import SignalDomain
 from paibox.paiir.lowering.converter import register_neuron
 from paibox.paiir.nn import SumPool2d
 
@@ -29,6 +32,26 @@ class ClampUint4(nn.Module):
 class IdentityUint8(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return torch.clamp(torch.floor(x), 0, 255)
+
+
+class SpikeAvgPoolConvIF(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(1, 1, 1, bias=False)
+        self.spike = neuron.IFNode(v_threshold=1.0)
+        self.pool = nn.AvgPool2d(2)
+        self.conv2 = nn.Conv2d(1, 1, 1, bias=False)
+        self.out_if = IFNodeV25(v_threshold=2.0)
+
+        with torch.no_grad():
+            self.conv1.weight.fill_(1)
+            self.conv2.weight.fill_(1)
+
+    def forward(self, x):
+        x = self.spike(self.conv1(x))
+        x = self.pool(x)
+        x = self.conv2(x)
+        return self.out_if(x)
 
 
 @pytest.fixture(autouse=True)
@@ -204,6 +227,14 @@ def _find_sumpool_nodes(graph) -> list[SequentialOp]:
     ]
 
 
+def _find_successor(graph, node: SequentialOp) -> SequentialOp:
+    succ_names = graph.successors(node.name)
+    assert len(succ_names) == 1
+    succ = graph.nodes[succ_names[0]]
+    assert isinstance(succ, SequentialOp)
+    return succ
+
+
 def _find_standalone_pool_nodes(
     graph, pool_type: type[nn.Module]
 ) -> list[StandaloneCompOp]:
@@ -235,8 +266,17 @@ def test_default_delayed_division_rewrites_low_range_avgpool_chain() -> None:
     sumpools = _find_sumpool_nodes(graph)
 
     assert len(sumpools) == 1
-    assert sumpools[0].act.lut is not None
-    assert sumpools[0].act.lut.thresholds[1].item() == 1
+    sumpool = sumpools[0]
+    assert sumpool.act.lut is not None
+    assert sumpool.act.lut.thresholds[1].item() == 1
+    assert sumpool.signal_semantics.output_domain is SignalDomain.VALUE
+    assert sumpool.signal_semantics.known_code_range == (0, 135)
+    assert sumpool.core_params.output_sign == DataSign.UNSIGNED
+    assert sumpool.core_params.output_width == DataWidth.WIDTH_8BIT
+
+    successor = _find_successor(graph, sumpool)
+    assert successor.core_params.input_sign == DataSign.UNSIGNED
+    assert successor.core_params.input_width == DataWidth.WIDTH_8BIT
     _run_and_compare(LowRangeAvgPoolConvLUT(), sample)
 
 
@@ -319,8 +359,40 @@ def test_delayed_division_supports_avgpool_chain_into_if_with_leak_v() -> None:
     )
 
     graph = _compile_graph(LowRangeAvgPoolAvgPoolConvIF(), sample)
-    assert len(_find_sumpool_nodes(graph)) == 2
+    sumpools = _find_sumpool_nodes(graph)
+    assert len(sumpools) == 2
+    assert [node.signal_semantics.known_code_range for node in sumpools] == [
+        (0, 60),
+        (0, 240),
+    ]
+    assert all(
+        node.core_params.output_width == DataWidth.WIDTH_8BIT for node in sumpools
+    )
+    successor = _find_successor(graph, sumpools[-1])
+    assert successor.act.thres_pos == 64.0
+    assert torch.allclose(successor.comp.bias, torch.tensor([16.0]))
     _run_and_compare(LowRangeAvgPoolAvgPoolConvIF(), sample)
+
+
+def test_delayed_division_uses_narrow_range_lut_for_spike_avgpool2d() -> None:
+    sample = torch.ones((1, 1, 4, 4), dtype=torch.int32)
+
+    graph = _compile_graph(SpikeAvgPoolConvIF(), sample)
+    sumpools = _find_sumpool_nodes(graph)
+
+    assert len(sumpools) == 1
+    sumpool = sumpools[0]
+    assert sumpool.signal_semantics.output_domain is SignalDomain.VALUE
+    assert sumpool.signal_semantics.known_code_range == (0, 4)
+    assert sumpool.core_params.output_sign == DataSign.UNSIGNED
+    assert sumpool.core_params.output_width == DataWidth.WIDTH_4BIT
+    assert sumpool.act.lut is not None
+    assert int(sumpool.act.lut.lut_values.max().item()) == 4
+
+    successor = _find_successor(graph, sumpool)
+    assert successor.core_params.input_sign == DataSign.UNSIGNED
+    assert successor.core_params.input_width == DataWidth.WIDTH_4BIT
+    _run_and_compare(SpikeAvgPoolConvIF(), sample)
 
 
 def test_delayed_division_supports_avgpool_chain_into_lif() -> None:


### PR DESCRIPTION
## Summary

- Preserve exact sum-domain code ranges for delayed AvgPool replacement carriers.
- Reuse a shared range identity LUT helper for delayed-division carriers and standalone AvgPool output sum/count rewrite.
- Allow narrow data-format inference such as `u4` for `IF -> SumPool2d(2,2) -> LUT`.
- Add regression coverage for carrier range metadata, successor input width, chained AvgPool scaling, and spike-like AvgPool2d output width.