### PR TITLE
bugfix(csc): fix sparse CSC placement metadata

### DIFF
--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -6,10 +6,12 @@ import numpy as np
 from paicorelib import (
     FRAME_DTYPE,
     CoordXY,
+    CSCAccelerateMode,
     DataWidth,
     FrameArrayType,
     OfflineCoreRegV2,
     OfflineFrameGenV2,
+    WeightCompressType,
     find_coordxy_shortest_path,
 )
 
@@ -22,8 +24,6 @@ from .core_config import (
     to_core_reg,
 )
 from .neuron import NeuronPlacement, OfflineNeuronPlacement
-
-# from .routing import RoutingGroup
 from .weight import Weight
 
 
@@ -151,12 +151,33 @@ class OfflineCorePlacementV2(CorePlacement):
             weight_start_address.append(
                 weight_start_address[-1] + weight.n_sram_required
             )
+
+        csc_sparse_full_neus: list[OfflineNeuronPlacement] = []
+        has_nonzero_init_v = False
         for i, neu in enumerate(self.neus):
             weight_idx = self.neu_weight_map[i]
             neu.neu_attrs_part1.weight_address_start = weight_start_address[weight_idx]
             neu.neu_attrs_part1.weight_address_end = (
                 weight_start_address[weight_idx + 1] - 1
             )
+            if (
+                self.default_core_config.csc_accelerate == CSCAccelerateMode.ENABLE
+                and neu.neu_attrs_part2 is not None
+                and neu.neu_attrs_part2.weight_compress == WeightCompressType.SPARSE
+            ):
+                csc_sparse_full_neus.append(neu)
+                if neu.neu_attrs_part2.vjt_initial != 0:
+                    has_nonzero_init_v = True
+
+        if has_nonzero_init_v:
+            self.default_core_config.csc_accelerate = CSCAccelerateMode.DISABLE
+            return
+
+        for neu in csc_sparse_full_neus:
+            if neu.neu_attrs_part2 is not None:
+                neu.neu_attrs_part2.vjt_initial = (
+                    neu.neu_attrs_part1.weight_address_start
+                )
 
     def set_auto_core_config(self) -> None:
         neuron_number = 0

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -9,6 +9,7 @@ from paicorelib import (
     LCN_EX,
     AERPacketZXYCopy,
     CoordXY,
+    CSCAccelerateMode,
     FoldType,
     NeuronType,
     OfflineNeuDestInfoV2,
@@ -348,6 +349,7 @@ class RoutingGroup(
 
         # self.core_blocks: list[CoreBlock] = []
         self.last_full_attrs: OfflineNeuFullAttrsV2Part2 | None = None
+        self.last_full_stored_weight_index: int | None = None
 
         self.n_core_required: int = -1
         self.core_placements: list[CorePlacement] = []
@@ -435,6 +437,7 @@ class RoutingGroup(
                     frontend_core_conf, backend_core_conf
                 )
                 self.last_full_attrs = None  # 换 core 了，之前的 neuron attrs 不算了
+                self.last_full_stored_weight_index = None
                 stored_base_weight.clear()  # 换 core 了，之前存储的 base weight 不算了
             # print(
             #     f"Storing base weight {weight_info.index} in core {id(current_core)} with compression {weight_compress} cost {weight_sram_req} SRAM lines."
@@ -448,9 +451,20 @@ class RoutingGroup(
         # 这个 neu 的 base weight 已经存储过了，直接复用
         stored_weight_index, weight_compress = stored_base_weight[weight_info.index]
         attrs_part2.weight_compress = weight_compress
-        neuron_type = (
-            NeuronType.HALF if attrs_part2 == self.last_full_attrs else NeuronType.FULL
-        )
+        if can_use_half_neuron := (attrs_part2 == self.last_full_attrs):
+            if (
+                current_core.default_core_config.csc_accelerate
+                == CSCAccelerateMode.ENABLE
+                and weight_compress == WeightCompressType.SPARSE
+                and stored_weight_index != self.last_full_stored_weight_index
+            ):
+                # Half neurons still carry their own weight address range in part1.
+                # The unsafe shared field is part2.vjt_initial: with CSC accelerate
+                # it mirrors weight_address_start, so different stored sparse weights
+                # need different full-neuron part2 records.
+                can_use_half_neuron = False
+
+        neuron_type = NeuronType.HALF if can_use_half_neuron else NeuronType.FULL
         output_type = neu.output_type()
 
         weight_skew = weight_info.offset * self.input_bit_num
@@ -478,6 +492,7 @@ class RoutingGroup(
             # print(f"allocate a new core")
             current_core = OfflineCorePlacementV2(frontend_core_conf, backend_core_conf)
             self.last_full_attrs = None  # 换 core 了，之前的 neuron attrs 不算了
+            self.last_full_stored_weight_index = None
             stored_base_weight.clear()  # 换 core 了，之前存储的 base weight 不算了
             return self.try_store_neuron(
                 neu,
@@ -491,6 +506,8 @@ class RoutingGroup(
         else:
             if neuron_type == NeuronType.FULL:
                 self.last_full_attrs = attrs_part2
+                self.last_full_stored_weight_index = stored_weight_index
+
             current_core.neus.append(neu_placement)
             # current_core.weights.append(selected_weight)  # weight 已经存储过了，不需要重复存储
             idx = len(current_core.neus) - 1
@@ -726,6 +743,7 @@ class RoutingGroup(
 
         # current_core = OfflineCorePlacementV2(frontend_core_conf, backend_core_conf)
         self.last_full_attrs = None
+        self.last_full_stored_weight_index = None
         description = f"{prefix}place unfolded neurons"
         for neu, weight_info in track(
             zip(reordered_neus, reordered_infos),
@@ -798,6 +816,7 @@ class RoutingGroup(
             print(f"{prefix}allocating core_block[{i}] ({len(group_items)} neurons)...")
             frontend_core_conf, backend_core_conf = key
             self.last_full_attrs = None
+            self.last_full_stored_weight_index = None
             self.place_neurons_optimal(
                 frontend_core_conf,
                 backend_core_conf,

--- a/tests/backendv2/test_coreplacement.py
+++ b/tests/backendv2/test_coreplacement.py
@@ -1,0 +1,138 @@
+from paicorelib import (
+    CSCAccelerateMode,
+    DataWidth,
+    FoldType,
+    LateralInhibitionMode,
+    LeakAddMode,
+    LeakMultiComparisonOrder,
+    LeakMultiInputMode,
+    LeakMultiMode,
+    NeuronType,
+    OfflineNeuFullAttrsV2Part1,
+    OfflineNeuFullAttrsV2Part2,
+    OutputType,
+    ThresholdNegMode,
+    ThresholdPosMode,
+    WeightCompressType,
+)
+from paicorelib.neuron_defs import ResetMode
+
+from paibox.backendv2.coreplacement import OfflineCorePlacementV2
+from paibox.backendv2.neuron import OfflineNeuronPlacement
+from paibox.backendv2.weight import Weight
+
+
+def _attrs_part1(neuron_type: NeuronType = NeuronType.FULL):
+    return OfflineNeuFullAttrsV2Part1(
+        weight_skew=0,
+        weight_address_start=0,
+        weight_address_end=0,
+        fold_type=FoldType.UNFOLDED,
+        neuron_type=neuron_type,
+        output_type=OutputType.VALUE,
+    )
+
+
+def _attrs_part2(
+    weight_compress: WeightCompressType,
+    vjt_initial: int = 0,
+):
+    return OfflineNeuFullAttrsV2Part2(
+        reset_mode=ResetMode.MODE_NORMAL,
+        reset_v=0,
+        threshold_neg_mode=ThresholdNegMode.FIRE,
+        threshold_pos_mode=ThresholdPosMode.FIRE,
+        threshold_neg=0,
+        threshold_pos=1,
+        lateral_inhibition=LateralInhibitionMode.DISABLE,
+        leak_multi_sequence=LeakMultiComparisonOrder.BEFORE_COMPARE,
+        leak_multi_input=LeakMultiInputMode.DISABLE,
+        leak_multi_mode=LeakMultiMode.DISABLE,
+        leak_add_mode=LeakAddMode.FORWARD,
+        leak_tau=0,
+        leak_v=0,
+        weight_compress=weight_compress,
+        vjt_initial=vjt_initial,
+    )
+
+
+def _placement(
+    *,
+    weight_compress: WeightCompressType,
+    vjt_initial: int = 0,
+    neuron_type: NeuronType = NeuronType.FULL,
+) -> OfflineNeuronPlacement:
+    return OfflineNeuronPlacement(
+        neu=[],
+        attrs_part1=_attrs_part1(neuron_type),
+        attrs_part2=_attrs_part2(weight_compress, vjt_initial),
+    )
+
+
+def _weight(compress_type: WeightCompressType) -> Weight:
+    return Weight(
+        data=[1, 0, 2, 0, 0],
+        compress_type=compress_type,
+        weight_width=DataWidth.WIDTH_8BIT,
+        input_width=DataWidth.WIDTH_8BIT,
+    )
+
+
+def _core_with_single_neuron(
+    neuron: OfflineNeuronPlacement,
+    weight: Weight,
+) -> OfflineCorePlacementV2:
+    core = OfflineCorePlacementV2()
+    core.neus = [neuron]
+    core.weights = [weight]
+    core.neu_weight_map = {0: 0}
+    return core
+
+
+def test_set_weight_address_backfills_vjt_initial_for_csc_sparse_full_neuron():
+    neuron = _placement(weight_compress=WeightCompressType.SPARSE, vjt_initial=0)
+    core = _core_with_single_neuron(neuron, _weight(WeightCompressType.SPARSE))
+
+    core.set_weight_address()
+
+    assert core.default_core_config.csc_accelerate == CSCAccelerateMode.ENABLE
+    assert neuron.neu_attrs_part1.weight_address_start == neuron.n_sram_required
+    assert (
+        neuron.neu_attrs_part2.vjt_initial
+        == neuron.neu_attrs_part1.weight_address_start
+    )
+
+
+def test_set_weight_address_disables_csc_accelerate_for_sparse_nonzero_init_v():
+    neuron = _placement(weight_compress=WeightCompressType.SPARSE, vjt_initial=7)
+    core = _core_with_single_neuron(neuron, _weight(WeightCompressType.SPARSE))
+
+    core.set_weight_address()
+
+    assert core.default_core_config.csc_accelerate == CSCAccelerateMode.DISABLE
+    assert neuron.neu_attrs_part2.vjt_initial == 7
+
+
+def test_set_weight_address_leaves_dense_vjt_initial_unchanged():
+    neuron = _placement(weight_compress=WeightCompressType.DENSE, vjt_initial=0)
+    core = _core_with_single_neuron(neuron, _weight(WeightCompressType.DENSE))
+
+    core.set_weight_address()
+
+    assert core.default_core_config.csc_accelerate == CSCAccelerateMode.ENABLE
+    assert neuron.neu_attrs_part1.weight_address_start == neuron.n_sram_required
+    assert neuron.neu_attrs_part2.vjt_initial == 0
+
+
+def test_set_weight_address_does_not_touch_half_neuron_part2_semantics():
+    neuron = _placement(
+        weight_compress=WeightCompressType.SPARSE,
+        vjt_initial=0,
+        neuron_type=NeuronType.HALF,
+    )
+    core = _core_with_single_neuron(neuron, _weight(WeightCompressType.SPARSE))
+
+    core.set_weight_address()
+
+    assert core.default_core_config.csc_accelerate == CSCAccelerateMode.ENABLE
+    assert neuron.neu_attrs_part2 is None

--- a/tests/backendv2/test_get_weight.py
+++ b/tests/backendv2/test_get_weight.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import numpy as np
 import pytest
 import torch
+from paicorelib import AddPotentialMode, DataWidth, WeightCompressType
 from torch import nn
 from torch.nn import functional as F
 
@@ -12,7 +13,9 @@ from paibox.backendv2.get_weight import (
     adaptive_avgpool2d_weight_matrix,
     adaptive_maxpool1d_weight_matrix,
     adaptive_maxpool2d_weight_matrix,
+    choose_weight_strategy,
     expanded_path_weight_matrix,
+    group_shift_weights_optimized,
 )
 from paibox.backendv2.op_node import CoreOpNode, InNode
 from paibox.paiir.ir.ir_base import InputNode
@@ -218,3 +221,129 @@ def test_expanded_path_weight_matrix_handles_adaptive_pool(case: ExpandedPathCas
 
     assert matrix.shape == case.expected_shape
     assert _active_cols(matrix[case.probe_row]) == case.expected_cols
+
+
+def test_group_shift_weights_default_still_reuses_shifted_base_rows():
+    raw_weights = [
+        np.array([0, 0, 3, 0, 5, 0], dtype=np.int16),
+        np.array([0, 3, 0, 5, 0, 0], dtype=np.int16),
+    ]
+
+    infos, base_weights = group_shift_weights_optimized(raw_weights)
+
+    assert [info.offset for info in infos] == [2, 1]
+    assert [info.index for info in infos] == [0, 0]
+    assert len(base_weights) == 1
+    np.testing.assert_array_equal(
+        base_weights[0],
+        np.array([3, 0, 5, 0, 0, 0], dtype=np.int16),
+    )
+
+
+def test_choose_weight_strategy_sparse_keeps_original_row():
+    weight = np.zeros(192, dtype=np.int16)
+    weight[[17, 18, 31]] = [3, 4, 5]
+
+    selected, compress = choose_weight_strategy(
+        weight,
+        DataWidth.WIDTH_8BIT,
+        DataWidth.WIDTH_8BIT,
+        AddPotentialMode.NORMAL,
+    )
+
+    assert selected.compress
+    np.testing.assert_array_equal(selected.raw_weights, weight.tolist())
+    assert compress == WeightCompressType.SPARSE
+
+
+@pytest.mark.parametrize(
+    ("input_width", "last_dense_candidate_index", "expected_compress"),
+    [
+        (DataWidth.WIDTH_1BIT, 127, WeightCompressType.SPARSE),
+        (DataWidth.WIDTH_2BIT, 63, WeightCompressType.SPARSE),
+        (DataWidth.WIDTH_4BIT, 31, WeightCompressType.SPARSE),
+        (DataWidth.WIDTH_8BIT, 15, WeightCompressType.DENSE),
+    ],
+    ids=["input-1bit", "input-2bit", "input-4bit", "input-8bit"],
+)
+def test_choose_weight_strategy_dense_candidate_depends_on_sram_savings(
+    input_width,
+    last_dense_candidate_index,
+    expected_compress,
+):
+    weight = np.zeros(last_dense_candidate_index + 1, dtype=np.int16)
+    weight[[0, last_dense_candidate_index]] = [1, 2]
+
+    selected, compress = choose_weight_strategy(
+        weight,
+        DataWidth.WIDTH_8BIT,
+        input_width,
+        AddPotentialMode.NORMAL,
+    )
+
+    assert compress == expected_compress
+    assert selected.compress is (expected_compress == WeightCompressType.SPARSE)
+
+
+def test_choose_weight_strategy_dense_tie_remains_dense():
+    weight = np.array([1, 2, 3, 4, 5], dtype=np.int16)
+
+    selected, compress = choose_weight_strategy(
+        weight,
+        DataWidth.WIDTH_8BIT,
+        DataWidth.WIDTH_8BIT,
+        AddPotentialMode.NORMAL,
+    )
+
+    assert not selected.compress
+    assert selected.raw_weights == [1, 2, 3, 4, 5]
+    assert compress == WeightCompressType.DENSE
+
+
+def test_choose_weight_strategy_single_tap_uses_sparse_when_sram_smaller():
+    weight = np.zeros(129, dtype=np.int16)
+    weight[128] = 1
+
+    selected, compress = choose_weight_strategy(
+        weight,
+        DataWidth.WIDTH_1BIT,
+        DataWidth.WIDTH_8BIT,
+        AddPotentialMode.NORMAL,
+    )
+
+    assert selected.compress
+    assert selected.raw_weights == weight.tolist()
+    assert compress == WeightCompressType.SPARSE
+    assert selected.to_package().size == 2
+
+
+def test_choose_weight_strategy_uint8_high_index_uses_sparse_csc_original_row():
+    weight = np.zeros(192, dtype=np.int16)
+    weight[[144, 146]] = [1, 2]
+
+    selected, compress = choose_weight_strategy(
+        weight,
+        DataWidth.WIDTH_8BIT,
+        DataWidth.WIDTH_8BIT,
+        AddPotentialMode.NORMAL,
+    )
+
+    assert selected.compress
+    assert selected.raw_weights == weight.tolist()
+    assert compress == WeightCompressType.SPARSE
+
+
+def test_choose_weight_strategy_uint8_long_span_row_still_uses_sparse_if_smaller():
+    weight = np.zeros(192, dtype=np.int16)
+    weight[[7, 136]] = [1, 2]
+
+    selected, compress = choose_weight_strategy(
+        weight,
+        DataWidth.WIDTH_8BIT,
+        DataWidth.WIDTH_8BIT,
+        AddPotentialMode.NORMAL,
+    )
+
+    assert selected.compress
+    assert selected.raw_weights == weight.tolist()
+    assert compress == WeightCompressType.SPARSE

--- a/tests/backendv2/test_mapper.py
+++ b/tests/backendv2/test_mapper.py
@@ -311,6 +311,7 @@ def _shared_sparse_linear_neuron_placements(mapper: Mapper):
         for neu_placement in core_placement.neus
     ]
 
+
 def test_mapper_default_auto_strategy_mixes_sparse_and_dense_csc(tmp_path):
     graph = compile_to_paiir(
         DefaultMixedSparseDenseLinear().eval(),
@@ -467,6 +468,7 @@ def test_mapper_default_uint8_long_span_weight_stays_sparse_when_smaller(tmp_pat
     assert placements[0].neu_attrs_part2.vjt_initial == (
         placements[0].neu_attrs_part1.weight_address_start
     )
+
 
 def test_mapper_sparse_csc_uses_full_neurons_for_different_weight_addresses(tmp_path):
     graph = compile_to_paiir(

--- a/tests/backendv2/test_mapper.py
+++ b/tests/backendv2/test_mapper.py
@@ -8,12 +8,17 @@ import pytest
 import torch
 from paicorelib import (
     LCN_EX,
+    CSCAccelerateMode,
     DataSign,
     DataWidth,
+    NeuronType,
+    WeightCompressType,
     find_coordxy_shortest_path,
 )
 from torch import nn
 
+from paibox.backendv2 import routing as routing_mod
+from paibox.backendv2.coreplacement import OfflineCorePlacementV2
 from paibox.backendv2.export.utils import export_framearray_to_int32
 from paibox.backendv2.mapper import Mapper
 from paibox.backendv2.op_node import SourceElem
@@ -90,6 +95,93 @@ class ConvPotential(nn.Module):
 
     def forward(self, x):
         return self.conv(x)
+
+
+class DefaultMixedSparseDenseLinear(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(160, 3, bias=False)
+        with torch.no_grad():
+            self.linear.weight.zero_()
+            self.linear.weight[0, [16, 40, 80]] = torch.tensor(
+                [1, 2, 3], dtype=torch.float32
+            )
+            self.linear.weight[1, [0, 128]] = torch.tensor([1, 2], dtype=torch.float32)
+            self.linear.weight[2, [1, 3, 5, 7, 9]] = 1
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class DefaultSparseHalfReuseLinear(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(160, 2, bias=False)
+        with torch.no_grad():
+            self.linear.weight.zero_()
+            self.linear.weight[0, [16, 40, 80]] = torch.tensor(
+                [1, 2, 3], dtype=torch.float32
+            )
+            self.linear.weight[1, [17, 41, 81]] = torch.tensor(
+                [1, 2, 3], dtype=torch.float32
+            )
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class Uint8HighIndexDenseCandidateLinear(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(192, 2, bias=False)
+        with torch.no_grad():
+            self.linear.weight.zero_()
+            self.linear.weight[0, [144, 146]] = torch.tensor(
+                [1, 1], dtype=torch.float32
+            )
+            self.linear.weight[1, [160, 162]] = torch.tensor(
+                [1, 1], dtype=torch.float32
+            )
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class Uint8LongSpanSparseLinear(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(192, 1, bias=False)
+        with torch.no_grad():
+            self.linear.weight.zero_()
+            self.linear.weight[0, [7, 136]] = torch.tensor([1, 1], dtype=torch.float32)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class Uint8DifferentSparseBasesLinear(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(192, 2, bias=False)
+        with torch.no_grad():
+            self.linear.weight.zero_()
+            self.linear.weight[0, [0, 191]] = torch.tensor([1, 1], dtype=torch.float32)
+            self.linear.weight[1, [1, 190]] = torch.tensor([1, 1], dtype=torch.float32)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class Uint1HighIndexSparseCscLinear(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(192, 1, bias=False)
+        with torch.no_grad():
+            self.linear.weight.zero_()
+            self.linear.weight[0, [64, 191]] = torch.tensor([7, 5], dtype=torch.float32)
+
+    def forward(self, x):
+        return self.linear(x)
 
 
 class _FakeOutputElem:
@@ -210,6 +302,277 @@ def _assert_output_group_allocator_matches_inputs(out_grp: OutputGroup) -> None:
         out_grp.input_list
     )
     assert out_grp.input_mapping == out_grp.axon_bit_allocator.axon_by_elem
+
+
+def _shared_sparse_linear_neuron_placements(mapper: Mapper):
+    return [
+        neu_placement
+        for core_placement in mapper.coreplacements
+        for neu_placement in core_placement.neus
+    ]
+
+def test_mapper_default_auto_strategy_mixes_sparse_and_dense_csc(tmp_path):
+    graph = compile_to_paiir(
+        DefaultMixedSparseDenseLinear().eval(),
+        torch.zeros(1, 160),
+        input_formats={"InputNode_0": (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT)},
+        timesteps=1,
+        auto_reset=True,
+        strict=True,
+    )
+    mapper = Mapper()
+    mapper.compile(graph, tmp_path, target_platform="x86", debug=False)
+
+    core = mapper.coreplacements[0]
+    placements = _shared_sparse_linear_neuron_placements(mapper)
+
+    assert {c.frontend_core_config.input_width for c in mapper.coreplacements} == {
+        DataWidth.WIDTH_1BIT
+    }
+    assert {c.default_core_config.csc_accelerate for c in mapper.coreplacements} == {
+        CSCAccelerateMode.ENABLE
+    }
+    assert [weight.compress for weight in core.weights] == [True, True, False]
+    assert np.flatnonzero(core.weights[0].raw_weights).tolist() == [0, 24, 64]
+    assert np.flatnonzero(core.weights[1].raw_weights).tolist() == [0, 128]
+    assert core.weights[2].processed_weights == [1, 0, 1, 0, 1, 0, 1, 0, 1]
+    assert [placement.neu_attrs_part1.weight_skew for placement in placements] == [
+        16,
+        0,
+        1,
+    ]
+    assert [placement.neu_attrs_part2 is None for placement in placements] == [
+        False,
+        False,
+        False,
+    ]
+    assert [placement.neu_attrs_part2.weight_compress for placement in placements] == [
+        WeightCompressType.SPARSE,
+        WeightCompressType.SPARSE,
+        WeightCompressType.DENSE,
+    ]
+    assert placements[2].neu_attrs_part1.weight_address_start == (
+        core.weights[0].n_sram_required
+        + core.weights[1].n_sram_required
+        + sum(neu.n_sram_required for neu in core.neus)
+    )
+    assert placements[0].neu_attrs_part2.vjt_initial == (
+        placements[0].neu_attrs_part1.weight_address_start
+    )
+    assert placements[1].neu_attrs_part2.vjt_initial == (
+        placements[1].neu_attrs_part1.weight_address_start
+    )
+    assert placements[2].neu_attrs_part2.vjt_initial == 0
+
+
+def test_mapper_default_sparse_csc_half_reuse_is_true_sparse_csc(tmp_path):
+    graph = compile_to_paiir(
+        DefaultSparseHalfReuseLinear().eval(),
+        torch.zeros(1, 160),
+        input_formats={"InputNode_0": (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT)},
+        timesteps=1,
+        auto_reset=True,
+        strict=True,
+    )
+    mapper = Mapper()
+    mapper.compile(graph, tmp_path, target_platform="x86", debug=False)
+
+    core = mapper.coreplacements[0]
+    placements = _shared_sparse_linear_neuron_placements(mapper)
+
+    assert {c.frontend_core_config.input_width for c in mapper.coreplacements} == {
+        DataWidth.WIDTH_1BIT
+    }
+    assert {c.default_core_config.csc_accelerate for c in mapper.coreplacements} == {
+        CSCAccelerateMode.ENABLE
+    }
+    assert len(core.weights) == 1
+    assert core.weights[0].compress
+    assert np.flatnonzero(core.weights[0].raw_weights).tolist() == [0, 24, 64]
+    assert [placement.neuron_type for placement in placements] == [
+        NeuronType.FULL,
+        NeuronType.HALF,
+    ]
+    assert [placement.neu_attrs_part1.weight_skew for placement in placements] == [
+        16,
+        17,
+    ]
+    assert [placement.neu_attrs_part2 is None for placement in placements] == [
+        False,
+        True,
+    ]
+    assert placements[0].neu_attrs_part2.weight_compress == WeightCompressType.SPARSE
+    assert placements[0].neu_attrs_part2.vjt_initial == (
+        placements[0].neu_attrs_part1.weight_address_start
+    )
+    assert placements[1].neu_attrs_part1.weight_address_start == (
+        placements[0].neu_attrs_part1.weight_address_start
+    )
+    assert placements[1].neu_attrs_part1.weight_address_end == (
+        placements[0].neu_attrs_part1.weight_address_end
+    )
+
+
+def test_mapper_default_uint8_high_index_shifted_base_tie_uses_dense(tmp_path):
+    graph = compile_to_paiir(
+        Uint8HighIndexDenseCandidateLinear().eval(),
+        torch.zeros(1, 192),
+        input_formats={"InputNode_0": (DataSign.UNSIGNED, DataWidth.WIDTH_8BIT)},
+        timesteps=1,
+        auto_reset=True,
+        strict=True,
+    )
+    mapper = Mapper()
+    mapper.compile(graph, tmp_path, target_platform="x86", debug=False)
+
+    core = mapper.coreplacements[0]
+    placements = _shared_sparse_linear_neuron_placements(mapper)
+
+    assert core.frontend_core_config.input_width == DataWidth.WIDTH_8BIT
+    assert core.default_core_config.csc_accelerate == CSCAccelerateMode.ENABLE
+    assert len(core.weights) == 1
+    assert not core.weights[0].compress
+    assert core.weights[0].processed_weights == [1, 0, 1]
+    assert [placement.neuron_type for placement in placements] == [
+        NeuronType.FULL,
+        NeuronType.HALF,
+    ]
+    assert [placement.neu_attrs_part1.weight_skew for placement in placements] == [
+        144 * 8,
+        160 * 8,
+    ]
+    assert placements[0].neu_attrs_part2.weight_compress == WeightCompressType.DENSE
+    assert placements[0].neu_attrs_part2.vjt_initial == 0
+    assert placements[1].neu_attrs_part2 is None
+
+
+def test_mapper_default_uint8_long_span_weight_stays_sparse_when_smaller(tmp_path):
+    graph = compile_to_paiir(
+        Uint8LongSpanSparseLinear().eval(),
+        torch.zeros(1, 192),
+        input_formats={"InputNode_0": (DataSign.UNSIGNED, DataWidth.WIDTH_8BIT)},
+        timesteps=1,
+        auto_reset=True,
+        strict=True,
+    )
+    mapper = Mapper()
+    mapper.compile(graph, tmp_path, target_platform="x86", debug=False)
+
+    core = mapper.coreplacements[0]
+    placements = _shared_sparse_linear_neuron_placements(mapper)
+
+    assert len(core.weights) == 1
+    assert core.weights[0].compress
+    assert placements[0].neu_attrs_part2.weight_compress == WeightCompressType.SPARSE
+    assert placements[0].neu_attrs_part2.vjt_initial == (
+        placements[0].neu_attrs_part1.weight_address_start
+    )
+
+def test_mapper_sparse_csc_uses_full_neurons_for_different_weight_addresses(tmp_path):
+    graph = compile_to_paiir(
+        Uint8DifferentSparseBasesLinear().eval(),
+        torch.zeros(1, 192),
+        input_formats={"InputNode_0": (DataSign.UNSIGNED, DataWidth.WIDTH_8BIT)},
+        timesteps=1,
+        auto_reset=True,
+        strict=True,
+    )
+    mapper = Mapper()
+    mapper.compile(graph, tmp_path, target_platform="x86", debug=False)
+
+    core = mapper.coreplacements[0]
+    placements = _shared_sparse_linear_neuron_placements(mapper)
+
+    assert len(core.weights) == 2
+    assert [weight.compress for weight in core.weights] == [True, True]
+    assert [placement.neuron_type for placement in placements] == [
+        NeuronType.FULL,
+        NeuronType.FULL,
+    ]
+    assert [placement.neu_attrs_part2.weight_compress for placement in placements] == [
+        WeightCompressType.SPARSE,
+        WeightCompressType.SPARSE,
+    ]
+    assert placements[0].neu_attrs_part1.weight_address_start != (
+        placements[1].neu_attrs_part1.weight_address_start
+    )
+    assert placements[0].neu_attrs_part2.vjt_initial == (
+        placements[0].neu_attrs_part1.weight_address_start
+    )
+    assert placements[1].neu_attrs_part2.vjt_initial == (
+        placements[1].neu_attrs_part1.weight_address_start
+    )
+
+
+def test_mapper_sparse_csc_allows_half_for_different_weight_addresses_without_accel(
+    tmp_path, monkeypatch
+):
+    class NoCscAccelOfflineCorePlacementV2(OfflineCorePlacementV2):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.default_core_config.csc_accelerate = CSCAccelerateMode.DISABLE
+
+    monkeypatch.setattr(
+        routing_mod, "OfflineCorePlacementV2", NoCscAccelOfflineCorePlacementV2
+    )
+    graph = compile_to_paiir(
+        Uint8DifferentSparseBasesLinear().eval(),
+        torch.zeros(1, 192),
+        input_formats={"InputNode_0": (DataSign.UNSIGNED, DataWidth.WIDTH_8BIT)},
+        timesteps=1,
+        auto_reset=True,
+        strict=True,
+    )
+    mapper = Mapper()
+    mapper.compile(graph, tmp_path, target_platform="x86", debug=False)
+
+    core = mapper.coreplacements[0]
+    placements = _shared_sparse_linear_neuron_placements(mapper)
+
+    assert core.default_core_config.csc_accelerate == CSCAccelerateMode.DISABLE
+    assert len(core.weights) == 2
+    assert [weight.compress for weight in core.weights] == [True, True]
+    assert [placement.neuron_type for placement in placements] == [
+        NeuronType.FULL,
+        NeuronType.HALF,
+    ]
+    assert placements[0].neu_attrs_part2.weight_compress == WeightCompressType.SPARSE
+    assert placements[0].neu_attrs_part2.vjt_initial == 0
+    assert placements[1].neu_attrs_part2 is None
+    assert placements[0].neu_attrs_part1.weight_address_start != (
+        placements[1].neu_attrs_part1.weight_address_start
+    )
+
+
+def test_mapper_uint1_high_index_sparse_csc_uses_shifted_base_row(tmp_path):
+    graph = compile_to_paiir(
+        Uint1HighIndexSparseCscLinear().eval(),
+        torch.zeros(1, 192),
+        input_formats={"InputNode_0": (DataSign.UNSIGNED, DataWidth.WIDTH_1BIT)},
+        timesteps=1,
+        auto_reset=True,
+        strict=True,
+    )
+    mapper = Mapper()
+    mapper.compile(graph, tmp_path, target_platform="x86", debug=False)
+
+    core = mapper.coreplacements[0]
+    placements = _shared_sparse_linear_neuron_placements(mapper)
+
+    assert core.frontend_core_config.input_width == DataWidth.WIDTH_1BIT
+    assert core.default_core_config.csc_accelerate == CSCAccelerateMode.ENABLE
+    assert len(core.weights) == 1
+    assert core.weights[0].compress
+    assert len(core.weights[0].processed_weights) == 128
+    assert core.weights[0].processed_weights[0] == 7
+    assert core.weights[0].processed_weights[127] == 5
+    assert len(placements) == 1
+    assert placements[0].neuron_type == NeuronType.FULL
+    assert placements[0].neu_attrs_part1.weight_skew == 64
+    assert placements[0].neu_attrs_part2.weight_compress == WeightCompressType.SPARSE
+    assert placements[0].neu_attrs_part2.vjt_initial == (
+        placements[0].neu_attrs_part1.weight_address_start
+    )
 
 
 CoreTickKey = tuple[int, int, int, tuple[str, ...], tuple[int, int, int]]


### PR DESCRIPTION
## Summary

- Backfill `vjt_initial` from `weight_address_start` for sparse CSC full neurons when CSC acceleration is enabled.
- Preserve nonzero `vjt_initial` semantics by disabling CSC acceleration for that core instead of overwriting init voltage.
- Prevent unsafe half-neuron reuse when sparse CSC accelerated neurons would need different shared part2 `vjt_initial` metadata.
- Add backendv2 unit/integration coverage for sparse CSC address metadata, half-neuron reuse, sparse/dense strategy boundaries, and shifted base rows.