### PR TITLE
bugfix(backendv2): plan output completion path

### DIFF
--- a/paibox/backendv2/core_config.py
+++ b/paibox/backendv2/core_config.py
@@ -21,9 +21,12 @@ TEST_DEST_CORE = CoordXY(0, 0)
 # default core configs that not used temporarily, all cores share the same default configs
 @dataclass
 class Default_Core_Config:
-    busy_cycle: int = 2
-    delay_cycle: int = 2
-    width_cycle: int = 2
+    # Hardware timing margin for complete-frame emission after busy is low.
+    # Route selection should still align DATA and control-frame CPU ingress sides;
+    # do not rely on this margin as the primary ordering fix.
+    busy_cycle: int = 20
+    delay_cycle: int = 20
+    width_cycle: int = 10
     thread_number: int = 0
     csc_accelerate: CSCAccelerateMode = CSCAccelerateMode.ENABLE
 

--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import abstractmethod
 
 import numpy as np
@@ -16,7 +14,6 @@ from paicorelib import (
 )
 
 from .core_config import (
-    TEST_DEST_CORE,
     Auto_Core_Config,
     Backend_Core_Config,
     Default_Core_Config,
@@ -73,7 +70,7 @@ class CorePlacement:
         pass
 
     @abstractmethod
-    def set_auto_core_config(self) -> None:
+    def set_auto_core_config(self, test_dest_core: CoordXY) -> None:
         pass
 
     @property
@@ -179,12 +176,10 @@ class OfflineCorePlacementV2(CorePlacement):
                     neu.neu_attrs_part1.weight_address_start
                 )
 
-    def set_auto_core_config(self) -> None:
-        neuron_number = 0
-        for neu in self.neus:
-            neuron_number += neu.n_sram_required
+    def set_auto_core_config(self, test_dest_core: CoordXY) -> None:
+        neuron_number = sum(neu.n_sram_required for neu in self.neus)
+        pkt_offset, _ = find_coordxy_shortest_path(test_dest_core, self.coord)
         self.auto_core_config.neuron_number = neuron_number
-        pkt_offset, _ = find_coordxy_shortest_path(TEST_DEST_CORE, self.coord)
         self.auto_core_config.test_core_xy = pkt_offset.z
         self.auto_core_config.test_core_x = pkt_offset.x
         self.auto_core_config.test_core_y = pkt_offset.y

--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -3,17 +3,29 @@ from abc import abstractmethod
 import numpy as np
 from paicorelib import (
     FRAME_DTYPE,
+    LCN_EX,
+    AddPotentialMode,
     CoordXY,
+    CoordZXYOffset,
     CSCAccelerateMode,
     DataWidth,
     FrameArrayType,
     OfflineCoreRegV2,
     OfflineFrameGenV2,
+    OnlineCoreRegV2,
+    OnlineCoreType,
+    OnlineCoreWorkMode,
+    OnlineDataWidth,
+    OnlineFrameGenV2,
+    OnlineSNNMode,
+    PoolingMode,
     WeightCompressType,
+    ZeroOutputMode,
     find_coordxy_shortest_path,
 )
 
 from .core_config import (
+    TEST_DEST_CORE,
     Auto_Core_Config,
     Backend_Core_Config,
     Default_Core_Config,
@@ -45,8 +57,7 @@ class CorePlacement:
 
     @property
     @abstractmethod
-    def core_config(self) -> OfflineCoreRegV2:
-        pass
+    def core_config(self) -> OfflineCoreRegV2 | OnlineCoreRegV2: ...
 
     @property
     @abstractmethod
@@ -70,7 +81,7 @@ class CorePlacement:
         pass
 
     @abstractmethod
-    def set_auto_core_config(self, test_dest_core: CoordXY) -> None:
+    def set_auto_core_config(self, test_offset: CoordZXYOffset | None = None) -> None:
         pass
 
     @property
@@ -176,13 +187,16 @@ class OfflineCorePlacementV2(CorePlacement):
                     neu.neu_attrs_part1.weight_address_start
                 )
 
-    def set_auto_core_config(self, test_dest_core: CoordXY) -> None:
-        neuron_number = sum(neu.n_sram_required for neu in self.neus)
-        pkt_offset, _ = find_coordxy_shortest_path(test_dest_core, self.coord)
-        self.auto_core_config.neuron_number = neuron_number
-        self.auto_core_config.test_core_xy = pkt_offset.z
-        self.auto_core_config.test_core_x = pkt_offset.x
-        self.auto_core_config.test_core_y = pkt_offset.y
+    def set_auto_core_config(self, test_offset: CoordZXYOffset | None = None) -> None:
+        if test_offset is None:
+            test_offset, _ = find_coordxy_shortest_path(TEST_DEST_CORE, self.coord)
+
+        self.auto_core_config.neuron_number = sum(
+            neu.n_sram_required for neu in self.neus
+        )
+        self.auto_core_config.test_core_xy = test_offset.z
+        self.auto_core_config.test_core_x = test_offset.x
+        self.auto_core_config.test_core_y = test_offset.y
 
     def to_frame(
         self,
@@ -233,4 +247,102 @@ class EmptyOfflineCorePlacementV2(OfflineCorePlacementV2):
 
         # frame_type_1: core config
         frame_type1 = OfflineFrameGenV2.gen_config_frame1(pkt_offset, self.core_config)
+        return frame_type1, None, None
+
+
+class EmptyOnlineCorePlacementV2(CorePlacement):
+    """Minimal empty online core used only as a global signal relay.
+
+    backendv2 does not yet carry a complete online-core configuration policy.
+    The class exposes coord and auto core config state so the planner can reason
+    about this fallback, and exports only the online core config frame1 needed
+    for global signal send/receive and control routing.
+    """
+
+    def _unsupported_empty_online_property(self, name: str) -> NotImplementedError:
+        return NotImplementedError(
+            f"EmptyOnlineCorePlacementV2.{name} is not implemented. "
+            "This placement is only a global signal relay with online frame1 export."
+        )
+
+    @property
+    def n_sram_required(self) -> int:
+        raise self._unsupported_empty_online_property("n_sram_required")
+
+    @property
+    def weight_sram_required(self) -> int:
+        raise self._unsupported_empty_online_property("weight_sram_required")
+
+    @property
+    def neuron_sram_required(self) -> int:
+        raise self._unsupported_empty_online_property("neuron_sram_required")
+
+    @property
+    def core_config(self) -> OnlineCoreRegV2:
+        return OnlineCoreRegV2(
+            name=f"empty_online_core_reg_at_({self.coord.x},{self.coord.y})",
+            snn_ann=OnlineSNNMode.SNN_LIF,
+            max_pooling=PoolingMode.AVERAGE,
+            add_potential=AddPotentialMode.NORMAL,
+            zero_output=ZeroOutputMode.DISABLE,
+            work_mode=OnlineCoreWorkMode.FORWARD_INFERENCE,
+            input_core=OnlineCoreType.ONLINE,
+            input_width=OnlineDataWidth.TYPE_1BIT,
+            output_core=OnlineCoreType.ONLINE,
+            output_width=OnlineDataWidth.TYPE_1BIT,
+            lcn_at=LCN_EX.LCN_1X,
+            lcn_mp=LCN_EX.LCN_1X,
+            lcn_lg=LCN_EX.LCN_1X,
+            target_lcn_at=LCN_EX.LCN_1X,
+            target_lcn_mp=LCN_EX.LCN_1X,
+            target_lcn_lg=LCN_EX.LCN_1X,
+            axon_skew=0,
+            neuron_number=0,
+            update_number=0,
+            csc_accelerate=CSCAccelerateMode.DISABLE,
+            scale_in=1.0,
+            bias_in=0.0,
+            scale_out=1.0,
+            bias_out=0.0,
+            learning_rate=0.0,
+            update_core_xy=0,
+            update_core_x=0,
+            update_core_y=0,
+            test_core_xy=self.auto_core_config.test_core_xy,
+            test_core_x=self.auto_core_config.test_core_x,
+            test_core_y=self.auto_core_config.test_core_y,
+            global_send=self.auto_core_config.global_send,
+            global_receive=self.auto_core_config.global_receive,
+            thread_number=0,
+            busy_cycle=20,
+            delay_cycle=20,
+            width_cycle=10,
+            tick_start=0,
+            tick_duration=0,
+            tick_initial=0,
+        )
+
+    @property
+    def output_width(self) -> DataWidth:
+        raise self._unsupported_empty_online_property("output_width")
+
+    def set_weight_address(self) -> None:
+        return None
+
+    def set_auto_core_config(self, test_offset: CoordZXYOffset | None = None) -> None:
+        if test_offset is None:
+            test_offset, _ = find_coordxy_shortest_path(TEST_DEST_CORE, self.coord)
+
+        self.auto_core_config.neuron_number = 0
+        self.auto_core_config.test_core_xy = test_offset.z
+        self.auto_core_config.test_core_x = test_offset.x
+        self.auto_core_config.test_core_y = test_offset.y
+
+    def to_frame(
+        self,
+    ) -> tuple[FrameArrayType, FrameArrayType | None, FrameArrayType | None]:
+        pkt_offset, _ = find_coordxy_shortest_path(self.coord)
+
+        # frame_type_1: minimal online core config for global signal relay.
+        frame_type1 = OnlineFrameGenV2.gen_config_frame1(pkt_offset, self.core_config)
         return frame_type1, None, None

--- a/paibox/backendv2/fold_neu.py
+++ b/paibox/backendv2/fold_neu.py
@@ -106,6 +106,12 @@ def process_exceed(ranges, weight_skews, axon_addr_skews):
 
 
 def get_fold_info(weight_offsets: list[int], axon_addr_offsets: list[int]):
+    """Return fold ranges with weight-skew and axon-skew sequences.
+
+    The public contract is `(ranges, weight_skews, axon_addr_skews)`. Keep every
+    branch in this order because routing writes the two skew families into
+    different folded-neuron config fields.
+    """
     # weight_offsets_diff = np.diff(weight_offsets)
     # axon_addr_offsets_diff = np.diff(axon_addr_offsets)
     weight_info = get_skew_info(weight_offsets)
@@ -119,8 +125,7 @@ def get_fold_info(weight_offsets: list[int], axon_addr_offsets: list[int]):
     if len(weight_ranges) == len(axon_addr_ranges):
         if weight_ranges == axon_addr_ranges:
             ranges = weight_ranges
-            process_result = process_exceed(ranges, weight_skews, axon_addr_skews)
-            return process_result
+            return process_exceed(ranges, weight_skews, axon_addr_skews)
         else:
             return None
     elif len(weight_ranges) == 1 or len(axon_addr_ranges) == 1:
@@ -135,22 +140,22 @@ def get_fold_info(weight_offsets: list[int], axon_addr_offsets: list[int]):
         if weight_ranges[0] == axon_addr_ranges[0]:
             ranges = weight_ranges
             axon_addr_skews = axon_addr_skews + [axon_addr_skews[-1]]
-            return ranges, axon_addr_skews, weight_skews
+            return ranges, weight_skews, axon_addr_skews
         elif weight_ranges[-1] == axon_addr_ranges[-1]:
             ranges = weight_ranges
             axon_addr_skews = [axon_addr_skews[0]] + axon_addr_skews
-            return ranges, axon_addr_skews, weight_skews
+            return ranges, weight_skews, axon_addr_skews
         else:
             return None
     elif len(weight_ranges) == 2 and len(axon_addr_ranges) == 3:
         if weight_ranges[0] == axon_addr_ranges[0]:
             ranges = axon_addr_ranges
             weight_skews = weight_skews + [weight_skews[-1]]
-            return ranges, axon_addr_skews, weight_skews
+            return ranges, weight_skews, axon_addr_skews
         elif weight_ranges[-1] == axon_addr_ranges[-1]:
             ranges = axon_addr_ranges
             weight_skews = [weight_skews[0]] + weight_skews
-            return ranges, axon_addr_skews, weight_skews
+            return ranges, weight_skews, axon_addr_skews
         else:
             return None
     else:

--- a/paibox/backendv2/global_signal.py
+++ b/paibox/backendv2/global_signal.py
@@ -1,97 +1,130 @@
 from collections import defaultdict, deque
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Generic, Literal, TypeVar
 
-from paicorelib import CoordXY, CoordZXYOffset, find_coordxy_shortest_path
+from paicorelib import (
+    CoordXY,
+    CoordXYUnitVec,
+    CoordZXYOffset,
+    find_coordxy_shortest_path,
+)
 
-from .coreplacement import CorePlacement, EmptyOfflineCorePlacementV2
+from .coreplacement import (
+    CorePlacement,
+    EmptyOfflineCorePlacementV2,
+    EmptyOnlineCorePlacementV2,
+)
 
-DIRS = [(1, 1), (-1, -1), (1, 0), (-1, 0), (0, 1), (0, -1)]
-RESERVE_DIRS = {
-    (1, 1): (-1, -1),
-    (-1, -1): (1, 1),
-    (1, 0): (-1, 0),
-    (-1, 0): (1, 0),
-    (0, 1): (0, -1),
-    (0, -1): (0, 1),
+T = TypeVar("T", int, CoordXY)
+EmptyRelayCoreKind = Literal["offline", "online"]
+
+GlobalSignalEdge = tuple[CoordXY, CoordXYUnitVec]
+GlobalSignalAdjacency = dict[CoordXY, list[GlobalSignalEdge]]
+GlobalSignalUnitVecMap = dict[CoordXY, list[CoordXYUnitVec]]
+
+GLOBAL_SIGNAL_DIRECTIONS: list[CoordXYUnitVec] = [
+    CoordXYUnitVec.Z_POS,
+    CoordXYUnitVec.Z_NEG,
+    CoordXYUnitVec.X_POS,
+    CoordXYUnitVec.X_NEG,
+    CoordXYUnitVec.Y_POS,
+    CoordXYUnitVec.Y_NEG,
+]
+OPPOSITE_GLOBAL_SIGNAL_DIRECTION: dict[CoordXYUnitVec, CoordXYUnitVec] = {
+    CoordXYUnitVec.Z_POS: CoordXYUnitVec.Z_NEG,
+    CoordXYUnitVec.Z_NEG: CoordXYUnitVec.Z_POS,
+    CoordXYUnitVec.X_POS: CoordXYUnitVec.X_NEG,
+    CoordXYUnitVec.X_NEG: CoordXYUnitVec.X_POS,
+    CoordXYUnitVec.Y_POS: CoordXYUnitVec.Y_NEG,
+    CoordXYUnitVec.Y_NEG: CoordXYUnitVec.Y_POS,
 }
-DIRS_OFFSET = {
-    (1, 1): 5,  # +xy
-    (-1, -1): 4,  # -xy
-    (1, 0): 3,  # +x
-    (-1, 0): 2,  # -x
-    (0, 1): 1,  # +y
-    (0, -1): 0,  # -y
+GLOBAL_SIGNAL_DIRECTION_BIT: dict[CoordXYUnitVec, int] = {
+    CoordXYUnitVec.Z_POS: 5,  # +xy
+    CoordXYUnitVec.Z_NEG: 4,  # -xy
+    CoordXYUnitVec.X_POS: 3,  # +x
+    CoordXYUnitVec.X_NEG: 2,  # -x
+    CoordXYUnitVec.Y_POS: 1,  # +y
+    CoordXYUnitVec.Y_NEG: 0,  # -y
 }
-DIRS_NAME = {
-    (1, 1): "+xy",
-    (-1, -1): "-xy",
-    (1, 0): "+x",
-    (-1, 0): "-x",
-    (0, 1): "+y",
-    (0, -1): "-y",
+GLOBAL_SIGNAL_DIRECTION_NAME: dict[CoordXYUnitVec, str] = {
+    CoordXYUnitVec.Z_POS: "+xy",
+    CoordXYUnitVec.Z_NEG: "-xy",
+    CoordXYUnitVec.X_POS: "+x",
+    CoordXYUnitVec.X_NEG: "-x",
+    CoordXYUnitVec.Y_POS: "+y",
+    CoordXYUnitVec.Y_NEG: "-y",
 }
 
 
-# ---------- 并查集 ----------
-class DSU:
-    def __init__(self, items):
-        self.p = {x: x for x in items}
+@dataclass(frozen=True)
+class GlobalSignalTree:
+    root: CoordXY
+    order: list[CoordXY]
+    added: list[CoordXY]
+    send_directions: GlobalSignalUnitVecMap
+    max_depth: int
+    total_edges: int
 
-    def find(self, x):
-        while self.p[x] != x:
-            self.p[x] = self.p[self.p[x]]
-            x = self.p[x]
+
+class DSU(Generic[T]):
+    def __init__(self, items: Iterable[T]) -> None:
+        self.parent: dict[T, T] = {item: item for item in items}
+
+    def find(self, x: T) -> T:
+        while self.parent[x] != x:
+            self.parent[x] = self.parent[self.parent[x]]
+            x = self.parent[x]
         return x
 
-    def union(self, a, b):
+    def union(self, a: T, b: T) -> bool:
         ra, rb = self.find(a), self.find(b)
         if ra == rb:
             return False
-        self.p[ra] = rb
+        self.parent[ra] = rb
         return True
 
 
-# ---------- 正确的最少步数:方向集 {(1,1),(1,0),(0,1)} 及其反向 ----------
-def hex_steps(a: tuple[int, int], b: tuple[int, int]):
-    dx, dy = b[0] - a[0], b[1] - a[1]
-    # 同号时 (1,1)/(-1,-1) 可同时消耗,取 max;异号时只能分别消耗,取和
-    # 统一写法: max(|dx|, |dy|, |dx - dy|)
-    return max(abs(dx), abs(dy), abs(dx - dy))
+def hex_steps(a: CoordXY, b: CoordXY) -> int:
+    diff = b - a
+    # Direction set is (+xy, +x, +y) and its reverse directions.
+    return max(abs(diff.x), abs(diff.y), abs(diff.x - diff.y))
 
 
-# ---------- 生成 A->B 的最短路径上的整数点(含端点) ----------
-def path_points(a: tuple[int, int], b: tuple[int, int]):
+def neighbor_coord(coord: CoordXY, direction: CoordXYUnitVec) -> CoordXY:
+    return coord + direction.value
+
+
+def path_coords(a: CoordXY, b: CoordXY) -> list[CoordXY]:
     steps = hex_steps(a, b)
     if steps == 0:
         return [a]
     pts = [a]
-    cx, cy = a
-    bx, by = b
+    current = a
     for _ in range(steps):
-        remaining_steps = hex_steps((cx, cy), (bx, by))
+        remaining_steps = hex_steps(current, b)
         chosen = None
-        for ddx, ddy in DIRS:
-            nx, ny = cx + ddx, cy + ddy
-            if hex_steps((nx, ny), (bx, by)) == remaining_steps - 1:
-                chosen = (ddx, ddy)
+        for direction in GLOBAL_SIGNAL_DIRECTIONS:
+            neighbor = neighbor_coord(current, direction)
+            if hex_steps(neighbor, b) == remaining_steps - 1:
+                chosen = direction
                 break
         if chosen is None:
-            raise RuntimeError(f"No progress from {(cx, cy)} towards {b}")
-        cx, cy = cx + chosen[0], cy + chosen[1]
-        pts.append((cx, cy))
+            raise RuntimeError(f"No progress from {current} towards {b}")
+        current = neighbor_coord(current, chosen)
+        pts.append(current)
     return pts
 
 
-# ---------- 在邻接图上做 BFS,返回 (各点距离, 离心率) ----------
 def bfs_distances(
-    start: tuple[int, int],
-    adj: dict[tuple[int, int], list[tuple[tuple[int, int], tuple[int, int]]]],
-) -> tuple[dict[tuple[int, int], int], int]:
-    dist: dict[tuple[int, int], int] = {start: 0}
-    queue: deque[tuple[int, int]] = deque([start])
+    start: CoordXY, adj: GlobalSignalAdjacency
+) -> tuple[dict[CoordXY, int], int]:
+    dist: dict[CoordXY, int] = {start: 0}
+    queue = deque([start])
     ecc = 0
     while queue:
         u = queue.popleft()
-        for v, _ in adj[u]:
+        for v, _ in adj.get(u, []):
             if v not in dist:
                 dist[v] = dist[u] + 1
                 if dist[v] > ecc:
@@ -100,32 +133,31 @@ def bfs_distances(
     return dist, ecc
 
 
-# ---------- 主流程 ----------
-def solve(
-    raw_points: list[tuple[int, int]],
-) -> tuple[
-    list[tuple[int, int]],
-    list[tuple[int, int]],
-    dict[tuple[int, int], list[tuple[int, int]]],
-]:
-    # 1) 连通分量
+def solve_global_signal_tree(
+    raw_points: list[CoordXY], root: CoordXY | None = None, verbose: bool = False
+) -> GlobalSignalTree:
+    # 1) connected components
     points = set(raw_points)
+    if root is not None:
+        points.add(root)
+
     dsu = DSU(points)
     for p in points:
-        for dx, dy in DIRS:
-            q = (p[0] + dx, p[1] + dy)
+        for direction in GLOBAL_SIGNAL_DIRECTIONS:
+            q = neighbor_coord(p, direction)
             if q in points:
                 dsu.union(p, q)
-    comps = defaultdict(list[tuple[int, int]])
+    comps = defaultdict(list[CoordXY])
     for p in points:
         comps[dsu.find(p)].append(p)
-    comp_list: list[list[tuple[int, int]]] = list(comps.values())
-    print(f"components({len(comp_list)}):")
-    for comp in comp_list:
-        print(f"  {comp}")
+    comp_list: list[list[CoordXY]] = list(comps.values())
+    if verbose:
+        print(f"components({len(comp_list)}):")
+        for comp in comp_list:
+            print(f"  {comp}")
 
-    # 2) MST 连接各分量,补最少点
-    added = []
+    # 2) connect components with a minimum spanning tree over shortest bridges
+    added: list[CoordXY] = []
     if len(comp_list) > 1:
         edges = []
         for i in range(len(comp_list)):
@@ -142,38 +174,44 @@ def solve(
         edges.sort(key=lambda e: e[0])
 
         comp_dsu = DSU(range(len(comp_list)))
-        for cost, i, j, pa, pb in edges:
+        for _, i, j, pa, pb in edges:
             if comp_dsu.union(i, j):
-                mids = path_points(pa, pb)[1:-1]
+                mids = path_coords(pa, pb)[1:-1]
                 for m in mids:
                     if m not in points:
                         points.add(m)
                         added.append(m)
 
-    # 3) 邻接表
-    adj = defaultdict(list)
+    # 3) adjacency table. Keep empty entries for isolated single-core trees.
+    adj: defaultdict[CoordXY, list[GlobalSignalEdge]] = defaultdict(list)
     for p in points:
-        for dx, dy in DIRS:
-            q = (p[0] + dx, p[1] + dy)
+        adj[p]
+        for direction in GLOBAL_SIGNAL_DIRECTIONS:
+            q = neighbor_coord(p, direction)
             if q in points:
-                adj[p].append((q, (dx, dy)))
+                adj[p].append((q, direction))
 
-    # 4) 选离心率最小的点作起点,最小化广播深度
-    #    对每个点跑一次 BFS,取离心率最小者;并列时取 (x+y, x, y) 最小者保证确定性
-    best_ecc = None
-    start = None
-    for p in points:
-        _, ecc = bfs_distances(p, adj)
-        key = (ecc, p[0] + p[1], p[0], p[1])
-        if best_ecc is None or key < best_ecc:
-            best_ecc = key
-            start = p
-    assert start is not None and best_ecc is not None, "no points to broadcast"
-    print(f"BFS start: {start}, eccentricity (tree depth): {best_ecc[0]}")
+    # 4) choose root. If planner supplied one, honor it.
+    if root is None:
+        best_ecc = None
+        start = None
+        for p in points:
+            _, ecc = bfs_distances(p, adj)
+            key = (ecc, p.x + p.y, p.x, p.y)
+            if best_ecc is None or key < best_ecc:
+                best_ecc = key
+                start = p
+        assert start is not None and best_ecc is not None, "no points to broadcast"
+        max_depth = best_ecc[0]
+    else:
+        start = root
+        _, max_depth = bfs_distances(start, adj)
+    if verbose:
+        print(f"BFS start: {start}, eccentricity (tree depth): {max_depth}")
 
-    # 5) 从中心点出发 BFS,按层扩展生成广播树
+    # 5) BFS broadcast tree from the selected root
     visited = {start}
-    move_dirs = defaultdict(list)
+    send_directions: defaultdict[CoordXY, list[CoordXYUnitVec]] = defaultdict(list)
     order = [start]
 
     queue = deque([start])
@@ -183,75 +221,108 @@ def solve(
             if v not in visited:
                 visited.add(v)
                 order.append(v)
-                move_dirs[u].append(d)
+                send_directions[u].append(d)
                 queue.append(v)
 
-    return order, added, dict(move_dirs)
+    return GlobalSignalTree(
+        start, order, added, dict(send_directions), max_depth, max(len(order) - 1, 0)
+    )
 
 
-def print_solution(order, added, moves):
+def print_solution(
+    order: list[CoordXY], added: list[CoordXY], moves: GlobalSignalUnitVecMap
+) -> None:
     print("visiting order:", order)
     print("added empty cores:", added)
-    print("send dirctions:")
+    print("send directions:")
     for p, ds in moves.items():
-        print(f"  {p} -> {[DIRS_NAME[d] + f':{d}' for d in ds]}")
+        print(f"  {p} -> " f"{[GLOBAL_SIGNAL_DIRECTION_NAME[d] + f':{d}' for d in ds]}")
 
 
 def set_global_signal(
     coreplacements: list[CorePlacement],
+    global_signal_root: CoordXY | None = None,
+    relay_core_kinds: Mapping[CoordXY, EmptyRelayCoreKind] | None = None,
+    verbose: bool = False,
 ) -> tuple[list[CorePlacement], dict[int, CoordZXYOffset]]:
-    # global signal 目前只包含 weight 地址范围,且所有 coreplacement 共用
-    # only one thread now, add support for multiple threads later if needed
+    # Global signal currently covers one thread and one shared weight range.
 
-    points: list[tuple[int, int]] = []
-    cp_dict: dict[tuple[int, int], CorePlacement] = {}
+    points: list[CoordXY] = []
+    cp_dict: dict[CoordXY, CorePlacement] = {}
     for cp in coreplacements:
-        point = (cp.coord.x, cp.coord.y)
-        points.append(point)
-        cp_dict[point] = cp
-    order, added, send_info = solve(points)
-    # print_solution(order, added, send_info)
-    for p in added:
-        empty_cp = EmptyOfflineCorePlacementV2()
-        empty_cp._coord = CoordXY(*p)
+        points.append(cp.coord)
+        cp_dict[cp.coord] = cp
+
+    root = global_signal_root
+    global_signal_tree = solve_global_signal_tree(points, root, verbose)
+    order = global_signal_tree.order
+    added = global_signal_tree.added
+    send_info = global_signal_tree.send_directions
+    relay_core_kinds = relay_core_kinds or {}
+
+    missing_points = list(added)
+    if root is not None and root not in cp_dict:
+        missing_points.insert(0, root)
+
+    for p in missing_points:
+        if p in cp_dict:
+            continue
+        relay_kind = relay_core_kinds.get(p, "offline")
+        if relay_kind == "online":
+            empty_cp = EmptyOnlineCorePlacementV2()
+        else:
+            empty_cp = EmptyOfflineCorePlacementV2()
+        empty_cp._coord = p
         cp_dict[p] = empty_cp
         coreplacements.append(empty_cp)
-        print(f"Added global signal core at {p}")
+        if verbose:
+            print(f"Added {relay_kind} global signal core at {p}")
 
-    receive_info = defaultdict(list)
-
+    receive_info: defaultdict[CoordXY, list[CoordXYUnitVec]] = defaultdict(list)
     for p, send_directions in send_info.items():
         for d in send_directions:
-            dest = (p[0] + d[0], p[1] + d[1])
-            receive_info[dest].append(RESERVE_DIRS[d])
+            dest = neighbor_coord(p, d)
+            receive_info[dest].append(OPPOSITE_GLOBAL_SIGNAL_DIRECTION[d])
 
-    print("\nSend Direction:")
-    for p, send_dirs in send_info.items():
-        print(f"    {p}: {[DIRS_NAME[d] + f':{d}' for d in send_dirs]}")
+    if verbose:
+        print("\nSend Direction:")
+        for p, send_dirs in send_info.items():
+            print(
+                f"    {p}: "
+                f"{[GLOBAL_SIGNAL_DIRECTION_NAME[d] + f':{d}' for d in send_dirs]}"
+            )
 
-    print("\nReceive Direction:")
-    for p, recv_dirs in receive_info.items():
-        print(f"    {p}: {[DIRS_NAME[d] + f':{d}' for d in recv_dirs]}")
+        print("\nReceive Direction:")
+        for p, recv_dirs in receive_info.items():
+            print(
+                f"    {p}: "
+                f"{[GLOBAL_SIGNAL_DIRECTION_NAME[d] + f':{d}' for d in recv_dirs]}"
+            )
 
+    added_points = set(added)
     for p, cp in cp_dict.items():
         send_directions = send_info.get(p, [])
         recv_directions = receive_info.get(p, [])
-        if p in added:
+        if p in added_points:
             global_send = 0
         else:
             global_send = 1 << 6  # send to local core
         global_receive = 0
         for d in send_directions:
-            global_send |= 1 << DIRS_OFFSET[d]
+            global_send |= 1 << GLOBAL_SIGNAL_DIRECTION_BIT[d]
         for d in recv_directions:
-            global_receive |= 1 << DIRS_OFFSET[d]
-        cp_dict[p].auto_core_config.global_send = global_send
-        cp_dict[p].auto_core_config.global_receive = global_receive
-        print(
-            f"Core at {p} global_send: {global_send:07b}, global_receive: {global_receive:07b}"
-        )
-    start_coord = CoordXY(*order[0])
-    print(f"Global signal start from {start_coord}")
+            global_receive |= 1 << GLOBAL_SIGNAL_DIRECTION_BIT[d]
+        cp.auto_core_config.global_send = global_send
+        cp.auto_core_config.global_receive = global_receive
+        if verbose:
+            print(
+                f"Core at {p} global_send: {global_send:07b}, "
+                f"global_receive: {global_receive:07b}"
+            )
+
+    start_coord = order[0]
     start_coord_offset, _ = find_coordxy_shortest_path(start_coord)
-    print(f"Global signal relative offset: {start_coord_offset}")
+    if verbose:
+        print(f"Global signal start from {start_coord}")
+        print(f"Global signal relative offset: {start_coord_offset}")
     return coreplacements, {0: start_coord_offset}

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -6,7 +6,6 @@ from paicorelib import CoordXY, CoordZXYOffset
 from paibox.paiir import PAIIRGraph
 from paibox.paiir.ir import OfflineCoreOp
 
-from .core_config import TEST_DEST_CORE
 from .coreplacement import CorePlacement
 from .export.cheader import export_cheader_files, export_cheader_merged
 from .export.npy import export_frame_npy
@@ -22,13 +21,14 @@ from .export.utils import (
 from .global_signal import set_global_signal
 from .group_tile import tile_groups
 from .op_node import AllNode, InputElem, Neuron, RemapElem, SourceElem, build_nodes
-from .output_cpu_ingress import (
-    OutputCpuIngressPlan,
-    OutputRouteEndpoint,
-    select_output_cpu_ingress_plan,
+from .output_completion import (
+    OutputCompletionPlan,
+    OutputProducer,
+    select_output_completion_plan,
 )
+from .output_routes import OutputCpuIngressPlan
 from .rg_build import build_groups
-from .route_solver import route_solve
+from .route_solver import HIVE, route_solve
 from .routing import InputGroup, OutputGroup, RemapGroup, RoutingGroup, toposort_for_rg
 
 
@@ -41,8 +41,8 @@ class Mapper:
         self.input_groups: list[InputGroup] = []
         self.coreplacements: list[CorePlacement] = []
         self.global_starts: dict[int, CoordZXYOffset] = {}
+        self.output_completion_plan: OutputCompletionPlan | None = None
         self.timesteps: int = 1
-        self.output_cpu_ingress_plan: OutputCpuIngressPlan | None = None
 
     def _resolve_timesteps(self, pai_graph: PAIIRGraph, timesteps: int | None) -> int:
         """Resolve the application runtime length used by output metadata.
@@ -151,29 +151,10 @@ class Mapper:
                         break
                 if not dest_found:
                     useless_elems.append(elem)
-            dest_strs: list[str] = []
-            if len(useless_elems) > 6:
-                print_elems = useless_elems[:3] + useless_elems[-3:]
-            else:
-                print_elems = useless_elems
-            for elem in print_elems:
-                dest_strs.append(str(elem))
-            if len(useless_elems) > 6:
-                dest_strs = dest_strs[:3] + ["..."] + dest_strs[-3:]
-            if len(useless_elems) > 0:
-                print(
-                    f"\nfound {len(useless_elems)} elements not used in group {src_grp.name}:"
-                )
-                print("    " + "\n    ".join(dest_strs))
-
             src_grp.update_raw_elems()
 
     def routing(self) -> None:
         self.routing_groups, next_rg_group = toposort_for_rg(self.groups)
-        print("\nTrying to solve routing")
-        for rg in self.routing_groups:
-            print(f"\tRouting Group {rg.name} requires {rg.n_core_required} cores.")
-
         areas = [rg.n_core_required for rg in self.routing_groups]
         print(f"\ttotal cores needed: {sum(areas)}")
         if sum(areas) > 63:
@@ -188,74 +169,74 @@ class Mapper:
             output_area_ids=[],
         )
 
-        print("\nRouting result:")
-        for rg, copy_config, rg_coords in zip(
-            self.routing_groups, copy_configs, coords
-        ):
-            print(f"\t{rg.name}({rg.n_core_required} cores):")
-            print(f"\t\tcopy: {copy_config}")
-            print(f"\t\tcoord: {rg_coords}")
-
         for rg, copy_config, rg_coords in zip(
             self.routing_groups, copy_configs, coords
         ):
             rg.assign_coord(rg_coords, copy_config)
 
-    def set_detail_dest(self) -> None:
+    def set_detail_dest(self, output_route_plan: OutputCpuIngressPlan) -> None:
+        # Output collection still targets the CPU. The plan only overrides the
+        # Z/X/Y decomposition so DATA and completion use the same CPU port.
+        output_route_offsets = output_route_plan.output_route_offsets()
         for rg in self.routing_groups:
-            rg.set_detail_dest()
+            rg.set_detail_dest(output_route_offsets)
         for in_grp in self.input_groups:
             in_grp.set_detail_dest()
 
-    def set_auto_core_config(self, test_dest_core: CoordXY) -> None:
-        for rg in self.routing_groups:
-            rg.set_auto_core_config(test_dest_core)
-
-        # Empty global-signal relay cores are appended to self.coreplacements
-        # after routing-group allocation, so set their auto config separately.
-        owned_cp_ids = {
-            id(cp) for rg in self.routing_groups for cp in rg.core_placements
-        }
+    def set_auto_core_config(
+        self, control_root_coord: CoordXY, control_offset: CoordZXYOffset
+    ) -> None:
+        seen_cp_ids: set[int] = set()
         for cp in self.coreplacements:
-            if id(cp) not in owned_cp_ids:
-                cp.set_auto_core_config(test_dest_core)
+            if id(cp) in seen_cp_ids:
+                continue
+            seen_cp_ids.add(id(cp))
 
-    def _collect_output_route_endpoints(self) -> list[OutputRouteEndpoint]:
-        endpoints: list[OutputRouteEndpoint] = []
-        seen: set[tuple[int, int, int, int]] = set()
+            if cp.coord == control_root_coord:
+                cp.set_auto_core_config(control_offset)
+            else:
+                cp.set_auto_core_config()
+
+    def _collect_output_producers(self) -> list[OutputProducer]:
+        producer_weights: dict[tuple[CoordXY, CoordXY], int] = {}
         for rg in self.routing_groups:
             for cp in rg.core_placements:
                 for neu_placement in cp.neus:
                     dest_group = rg.get_dest(neu_placement.raw_neus[0])
                     if not isinstance(dest_group, OutputGroup):
                         continue
-                    key = (id(cp), id(dest_group), cp.coord.x, cp.coord.y)
-                    if key in seen:
-                        continue
-                    seen.add(key)
-                    endpoints.append(
-                        OutputRouteEndpoint(cp.coord, dest_group.base_coord)
+                    key = (cp.coord, dest_group.base_coord)
+                    producer_weights[key] = producer_weights.get(key, 0) + len(
+                        neu_placement.raw_neus
                     )
-        return endpoints
 
-    def _global_root_coord(self) -> CoordXY:
-        if not self.global_starts:
-            return TEST_DEST_CORE
-        root_offset = self.global_starts.get(0, next(iter(self.global_starts.values())))
-        return CoordXY(0, 0) + root_offset.to_xy()
+        return [
+            OutputProducer(coord, target_coord, weight)
+            for (coord, target_coord), weight in sorted(
+                producer_weights.items(),
+                key=lambda item: (
+                    item[0][0].x,
+                    item[0][0].y,
+                    item[0][1].x,
+                    item[0][1].y,
+                ),
+            )
+        ]
 
-    def _apply_output_target(self, plan: OutputCpuIngressPlan) -> None:
-        if plan.output_target is not None:
-            for output_group in self.output_groups:
-                output_group.base_coord = plan.output_target
-
-    def finalize_output_cpu_ingress_plan(self) -> OutputCpuIngressPlan:
-        """Select final output/control targets before neuron dests are encoded."""
-        endpoints = self._collect_output_route_endpoints()
-        plan = select_output_cpu_ingress_plan(self._global_root_coord(), endpoints)
-        self.output_cpu_ingress_plan = plan
-        self._apply_output_target(plan)
-        return plan
+    def build_output_completion_plan(self) -> OutputCompletionPlan:
+        """Select DATA routes and a global signal root before dest encoding."""
+        used_core_coords = {cp.coord for cp in self.coreplacements}
+        empty_offline_coords = {
+            CoordXY(x, y) for x, y in HIVE if CoordXY(x, y) not in used_core_coords
+        }
+        return select_output_completion_plan(
+            self._collect_output_producers(),
+            used_core_coords,
+            empty_offline_coords,
+            set(),
+            allow_empty_online=False,
+            empty_online_frame_supported=False,
+        )
 
     def export_artifacts(
         self,
@@ -358,17 +339,11 @@ class Mapper:
         all_groups.extend(self.input_groups)
         all_groups.extend(self.groups)
         all_groups.extend(self.output_groups)
-        for grp in all_groups:
-            print(grp)
 
         # determine which rg each neuron sends to
         # dests and input_list set
         # other properties remain unset
         all_groups = tile_groups(all_groups)
-
-        print("\nAll groups after tiling:")
-        for grp in all_groups:
-            print(grp.info("   "))
 
         self.input_groups = []
         self.groups = []
@@ -387,9 +362,6 @@ class Mapper:
 
         self.set_rough_dest()
 
-        for grp in all_groups:
-            print(grp.info())
-
         for out_grp in self.output_groups:
             out_grp.set_lcn(self.timesteps)
 
@@ -400,33 +372,29 @@ class Mapper:
         for rg in self.routing_groups:
             rg.allocate_neurons()
 
-        print("\nAll groups after neuron allocation:")
-        for rg in all_groups:
-            print(rg.routing_summary())
-
         # set core placements' coord, and generate detailed dest info for each neuron
         self.routing()
-
-        print("\nAfter routing:")
-        # for grp in all_groups:
-        #     print(grp.info())
-
-        for rg in all_groups:
-            print(rg.routing_summary(prefix="    "))
 
         for rg in self.routing_groups:
             self.coreplacements.extend(rg.core_placements)
 
-        self.coreplacements, self.global_starts = set_global_signal(self.coreplacements)
-        print("Global signal relative offset:")
-        for thread_id, offset in self.global_starts.items():
-            print(f"    Thread {thread_id}: {offset}")
+        self.output_completion_plan = self.build_output_completion_plan()
 
-        output_route_plan = self.finalize_output_cpu_ingress_plan()
+        self.coreplacements, self.global_starts = set_global_signal(
+            self.coreplacements,
+            self.output_completion_plan.global_signal_root,
+            self.output_completion_plan.relay_core_kinds(),
+        )
 
-        # Detail destinations must observe any OutputGroup retarget selected above.
-        self.set_detail_dest()
-        self.set_auto_core_config(output_route_plan.control_target)
+        output_route_plan = self.output_completion_plan.to_cpu_ingress_plan()
+
+        # The global-signal root uses the selected control offset. Other cores
+        # keep their own local route to the same fixed CPU destination.
+        self.set_detail_dest(output_route_plan)
+        self.set_auto_core_config(
+            self.output_completion_plan.global_signal_root,
+            output_route_plan.control_offset,
+        )
 
         # export to hardware executable format
         if output_path is None:

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -1,11 +1,12 @@
 import os
 from pathlib import Path
 
-from paicorelib import CoordZXYOffset
+from paicorelib import CoordXY, CoordZXYOffset
 
 from paibox.paiir import PAIIRGraph
 from paibox.paiir.ir import OfflineCoreOp
 
+from .core_config import TEST_DEST_CORE
 from .coreplacement import CorePlacement
 from .export.cheader import export_cheader_files, export_cheader_merged
 from .export.npy import export_frame_npy
@@ -21,6 +22,11 @@ from .export.utils import (
 from .global_signal import set_global_signal
 from .group_tile import tile_groups
 from .op_node import AllNode, InputElem, Neuron, RemapElem, SourceElem, build_nodes
+from .output_cpu_ingress import (
+    OutputCpuIngressPlan,
+    OutputRouteEndpoint,
+    select_output_cpu_ingress_plan,
+)
 from .rg_build import build_groups
 from .route_solver import route_solve
 from .routing import InputGroup, OutputGroup, RemapGroup, RoutingGroup, toposort_for_rg
@@ -36,6 +42,7 @@ class Mapper:
         self.coreplacements: list[CorePlacement] = []
         self.global_starts: dict[int, CoordZXYOffset] = {}
         self.timesteps: int = 1
+        self.output_cpu_ingress_plan: OutputCpuIngressPlan | None = None
 
     def _resolve_timesteps(self, pai_graph: PAIIRGraph, timesteps: int | None) -> int:
         """Resolve the application runtime length used by output metadata.
@@ -200,9 +207,55 @@ class Mapper:
         for in_grp in self.input_groups:
             in_grp.set_detail_dest()
 
-    def set_auto_core_config(self) -> None:
+    def set_auto_core_config(self, test_dest_core: CoordXY) -> None:
         for rg in self.routing_groups:
-            rg.set_auto_core_config()
+            rg.set_auto_core_config(test_dest_core)
+
+        # Empty global-signal relay cores are appended to self.coreplacements
+        # after routing-group allocation, so set their auto config separately.
+        owned_cp_ids = {
+            id(cp) for rg in self.routing_groups for cp in rg.core_placements
+        }
+        for cp in self.coreplacements:
+            if id(cp) not in owned_cp_ids:
+                cp.set_auto_core_config(test_dest_core)
+
+    def _collect_output_route_endpoints(self) -> list[OutputRouteEndpoint]:
+        endpoints: list[OutputRouteEndpoint] = []
+        seen: set[tuple[int, int, int, int]] = set()
+        for rg in self.routing_groups:
+            for cp in rg.core_placements:
+                for neu_placement in cp.neus:
+                    dest_group = rg.get_dest(neu_placement.raw_neus[0])
+                    if not isinstance(dest_group, OutputGroup):
+                        continue
+                    key = (id(cp), id(dest_group), cp.coord.x, cp.coord.y)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    endpoints.append(
+                        OutputRouteEndpoint(cp.coord, dest_group.base_coord)
+                    )
+        return endpoints
+
+    def _global_root_coord(self) -> CoordXY:
+        if not self.global_starts:
+            return TEST_DEST_CORE
+        root_offset = self.global_starts.get(0, next(iter(self.global_starts.values())))
+        return CoordXY(0, 0) + root_offset.to_xy()
+
+    def _apply_output_target(self, plan: OutputCpuIngressPlan) -> None:
+        if plan.output_target is not None:
+            for output_group in self.output_groups:
+                output_group.base_coord = plan.output_target
+
+    def finalize_output_cpu_ingress_plan(self) -> OutputCpuIngressPlan:
+        """Select final output/control targets before neuron dests are encoded."""
+        endpoints = self._collect_output_route_endpoints()
+        plan = select_output_cpu_ingress_plan(self._global_root_coord(), endpoints)
+        self.output_cpu_ingress_plan = plan
+        self._apply_output_target(plan)
+        return plan
 
     def export_artifacts(
         self,
@@ -361,17 +414,19 @@ class Mapper:
         for rg in all_groups:
             print(rg.routing_summary(prefix="    "))
 
-        self.set_detail_dest()
-
         for rg in self.routing_groups:
             self.coreplacements.extend(rg.core_placements)
-
-        self.set_auto_core_config()
 
         self.coreplacements, self.global_starts = set_global_signal(self.coreplacements)
         print("Global signal relative offset:")
         for thread_id, offset in self.global_starts.items():
             print(f"    Thread {thread_id}: {offset}")
+
+        output_route_plan = self.finalize_output_cpu_ingress_plan()
+
+        # Detail destinations must observe any OutputGroup retarget selected above.
+        self.set_detail_dest()
+        self.set_auto_core_config(output_route_plan.control_target)
 
         # export to hardware executable format
         if output_path is None:

--- a/paibox/backendv2/output_completion.py
+++ b/paibox/backendv2/output_completion.py
@@ -1,0 +1,375 @@
+from dataclasses import dataclass
+from typing import Literal
+
+from paicorelib import CoordXY, CoordZXYOffset
+
+from .core_config import TEST_DEST_CORE
+from .global_signal import (
+    EmptyRelayCoreKind,
+    solve_global_signal_tree,
+)
+from .output_route_offsets import (
+    RouteSide,
+    candidate_offsets,
+    route_coord_path,
+    route_len,
+    terminal_route_side,
+)
+from .output_routes import OutputCpuIngressPlan, OutputRouteDecision
+from .route_solver import G_X_MAX, G_X_MIN, G_Y_MAX, G_Y_MIN
+
+RootKind = Literal["used", "empty_offline", "empty_online"]
+
+
+class OutputCompletionError(RuntimeError):
+    """Base error for output DATA / complete-frame planning failures."""
+
+
+class OutputCompletionNoFeasiblePlanError(OutputCompletionError):
+    """Raised when DATA paths cannot share a valid complete-frame suffix."""
+
+
+@dataclass(frozen=True)
+class OutputProducer:
+    coord: CoordXY
+    target_coord: CoordXY = TEST_DEST_CORE
+    weight: int = 1
+
+
+@dataclass(frozen=True)
+class EmptyRelayCore:
+    coord: CoordXY
+    kind: EmptyRelayCoreKind
+
+
+@dataclass(frozen=True)
+class OutputCompletionPlan:
+    output_routes: tuple[OutputRouteDecision, ...]
+    control_offset: CoordZXYOffset
+    ingress_side: RouteSide
+    global_signal_root: CoordXY
+    root_kind: RootKind
+    relay_cores: tuple[EmptyRelayCore, ...]
+    data_penalty: int
+    global_signal_tree_max_depth: int
+    global_signal_tree_total_edges: int
+    complete_path_len: int
+    diagnostics: tuple[str, ...]
+
+    @property
+    def root_is_unused(self) -> bool:
+        return self.root_kind != "used"
+
+    @property
+    def root_is_online_empty(self) -> bool:
+        return self.root_kind == "empty_online"
+
+    def output_route_offsets(self) -> dict[tuple[CoordXY, CoordXY], CoordZXYOffset]:
+        return {
+            (route.producer_coord, route.target_coord): route.offset
+            for route in self.output_routes
+        }
+
+    def relay_core_kinds(self) -> dict[CoordXY, EmptyRelayCoreKind]:
+        relay_core_kinds: dict[CoordXY, EmptyRelayCoreKind] = {
+            relay.coord: relay.kind for relay in self.relay_cores
+        }
+        if self.root_kind in {"empty_offline", "empty_online"}:
+            relay_core_kinds[self.global_signal_root] = (
+                "online" if self.root_kind == "empty_online" else "offline"
+            )
+        return relay_core_kinds
+
+    def to_cpu_ingress_plan(self) -> OutputCpuIngressPlan:
+        return OutputCpuIngressPlan(
+            self.output_routes, self.control_offset, self.ingress_side
+        )
+
+
+@dataclass(frozen=True)
+class _ProducerPathChoice:
+    offset: CoordZXYOffset
+    path: tuple[CoordXY, ...]
+    path_len: int
+    penalty: int
+
+
+@dataclass(frozen=True)
+class _RootSuffixCandidate:
+    root: CoordXY
+    suffix: tuple[CoordXY, ...]
+    choices: tuple[_ProducerPathChoice, ...]
+    control_offset: CoordZXYOffset
+    root_kind: RootKind
+    relay_cores: tuple[EmptyRelayCore, ...]
+    data_penalty: int
+    global_signal_tree_max_depth: int
+    global_signal_tree_total_edges: int
+
+
+def _is_in_global_route_grid(coord: CoordXY) -> bool:
+    return G_X_MIN <= coord.x <= G_X_MAX and G_Y_MIN <= coord.y <= G_Y_MAX
+
+
+def _control_offset_for_suffix(
+    root: CoordXY, target_coord: CoordXY, suffix: tuple[CoordXY, ...]
+) -> CoordZXYOffset | None:
+    for offset in candidate_offsets(root, target_coord):
+        if route_coord_path(root, offset) == suffix:
+            return offset
+    return None
+
+
+def _root_kind(
+    root: CoordXY,
+    used_core_coords: set[CoordXY],
+    available_empty_offline_coords: set[CoordXY],
+    available_empty_online_coords: set[CoordXY],
+    allow_empty_online: bool,
+    empty_online_frame_supported: bool,
+) -> RootKind | None:
+    if root in used_core_coords:
+        return "used"
+    if root in available_empty_offline_coords:
+        return "empty_offline"
+    if (
+        allow_empty_online
+        and empty_online_frame_supported
+        and root in available_empty_online_coords
+    ):
+        return "empty_online"
+    return None
+
+
+def _classify_relay_cores(
+    added_points: list[CoordXY],
+    used_core_coords: set[CoordXY],
+    available_empty_offline_coords: set[CoordXY],
+    available_empty_online_coords: set[CoordXY],
+    allow_empty_online: bool,
+    empty_online_frame_supported: bool,
+) -> tuple[EmptyRelayCore, ...] | None:
+    relay_cores: list[EmptyRelayCore] = []
+    for coord in added_points:
+        if coord in used_core_coords:
+            continue
+        if coord in available_empty_offline_coords:
+            relay_cores.append(EmptyRelayCore(coord, "offline"))
+            continue
+        if (
+            allow_empty_online
+            and empty_online_frame_supported
+            and coord in available_empty_online_coords
+        ):
+            relay_cores.append(EmptyRelayCore(coord, "online"))
+            continue
+        return None
+    return tuple(relay_cores)
+
+
+def _producer_choices_by_root_suffix(
+    producer: OutputProducer,
+) -> dict[tuple[CoordXY, tuple[CoordXY, ...]], _ProducerPathChoice]:
+    offsets = candidate_offsets(producer.coord, producer.target_coord)
+    if not offsets:
+        raise OutputCompletionNoFeasiblePlanError(
+            "No legal output DATA route offset from "
+            f"({producer.coord.x},{producer.coord.y}) to "
+            f"({producer.target_coord.x},{producer.target_coord.y})."
+        )
+
+    shortest_len = route_len(offsets[0])
+    choices: dict[tuple[CoordXY, tuple[CoordXY, ...]], _ProducerPathChoice] = {}
+    for offset in offsets:
+        path = route_coord_path(producer.coord, offset)
+        for index, point in enumerate(path[:-1]):
+            if not _is_in_global_route_grid(point):
+                continue
+            suffix = path[index:]
+            key = (point, suffix)
+            path_len = route_len(offset)
+            choice = _ProducerPathChoice(
+                offset, path, path_len, path_len - shortest_len
+            )
+            current = choices.get(key)
+            if current is None or (choice.path_len, choice.offset.to_tuple()) < (
+                current.path_len,
+                current.offset.to_tuple(),
+            ):
+                choices[key] = choice
+
+    return choices
+
+
+def _candidate_root_suffixes(
+    producers: tuple[OutputProducer, ...],
+) -> dict[tuple[CoordXY, tuple[CoordXY, ...]], tuple[_ProducerPathChoice, ...]]:
+    producer_choices = [
+        _producer_choices_by_root_suffix(producer) for producer in producers
+    ]
+    common_keys = set(producer_choices[0])
+    for choices in producer_choices[1:]:
+        common_keys &= set(choices)
+
+    def sort_key(
+        root_suffix: tuple[CoordXY, tuple[CoordXY, ...]],
+    ) -> tuple[tuple[int, int], tuple[tuple[int, int], ...]]:
+        root, suffix = root_suffix
+        return (root.x, root.y), tuple((coord.x, coord.y) for coord in suffix)
+
+    return {
+        key: tuple(choices[key] for choices in producer_choices)
+        for key in sorted(common_keys, key=sort_key)
+    }
+
+
+def select_output_completion_plan(
+    producers: list[OutputProducer],
+    used_core_coords: set[CoordXY],
+    available_empty_offline_coords: set[CoordXY],
+    available_empty_online_coords: set[CoordXY] | None = None,
+    *,
+    allow_empty_online: bool = False,
+    empty_online_frame_supported: bool = False,
+) -> OutputCompletionPlan:
+    """Choose output DATA routes and a completion root with a shared suffix.
+
+    The selected global signal root lies on every output DATA route. The
+    complete/control route from that root to CPU is exactly the common suffix of
+    those DATA routes, so a complete frame cannot overtake already-issued DATA
+    frames after the convergence point.
+    """
+    available_empty_online_coords = available_empty_online_coords or set()
+    diagnostics: list[str] = []
+    if allow_empty_online and not empty_online_frame_supported:
+        diagnostics.append(
+            "empty online relay candidates disabled: backendv2 online frame1 "
+            "export is not wired."
+        )
+
+    if not producers:
+        root = min(
+            used_core_coords,
+            key=lambda coord: (coord.x, coord.y),
+            default=TEST_DEST_CORE,
+        )
+        control_offset = candidate_offsets(root, TEST_DEST_CORE)[0]
+        return OutputCompletionPlan(
+            output_routes=(),
+            control_offset=control_offset,
+            ingress_side=terminal_route_side(control_offset),
+            global_signal_root=root,
+            root_kind="used" if root in used_core_coords else "empty_offline",
+            relay_cores=(),
+            data_penalty=0,
+            global_signal_tree_max_depth=0,
+            global_signal_tree_total_edges=0,
+            complete_path_len=route_len(control_offset),
+            diagnostics=tuple(diagnostics),
+        )
+
+    producers_tuple = tuple(
+        OutputProducer(
+            producer.coord, producer.target_coord, max(int(producer.weight), 1)
+        )
+        for producer in producers
+    )
+    candidates: list[_RootSuffixCandidate] = []
+    for (root, suffix), choices in _candidate_root_suffixes(producers_tuple).items():
+        if root == TEST_DEST_CORE:
+            continue
+        control_offset = _control_offset_for_suffix(
+            root, producers_tuple[0].target_coord, suffix
+        )
+        if control_offset is None:
+            continue
+        root_kind = _root_kind(
+            root,
+            used_core_coords,
+            available_empty_offline_coords,
+            available_empty_online_coords,
+            allow_empty_online,
+            empty_online_frame_supported,
+        )
+        if root_kind is None:
+            continue
+
+        global_signal_tree = solve_global_signal_tree(
+            list(used_core_coords), root=root, verbose=False
+        )
+        relay_cores = _classify_relay_cores(
+            global_signal_tree.added,
+            used_core_coords,
+            available_empty_offline_coords,
+            available_empty_online_coords,
+            allow_empty_online,
+            empty_online_frame_supported,
+        )
+        if relay_cores is None:
+            continue
+
+        data_penalty = sum(
+            producer.weight * choice.penalty
+            for producer, choice in zip(producers_tuple, choices, strict=True)
+        )
+        candidates.append(
+            _RootSuffixCandidate(
+                root=root,
+                suffix=suffix,
+                choices=choices,
+                control_offset=control_offset,
+                root_kind=root_kind,
+                relay_cores=relay_cores,
+                data_penalty=data_penalty,
+                global_signal_tree_max_depth=global_signal_tree.max_depth,
+                global_signal_tree_total_edges=global_signal_tree.total_edges,
+            )
+        )
+
+    if not candidates:
+        raise OutputCompletionNoFeasiblePlanError(
+            "Cannot find a global signal root on a common output DATA suffix. "
+            "producers="
+            f"{[(p.coord.x, p.coord.y, p.weight) for p in producers_tuple]}, "
+            f"used={sorted((c.x, c.y) for c in used_core_coords)}, "
+            "empty_online_enabled="
+            f"{allow_empty_online and empty_online_frame_supported}"
+        )
+
+    selected = min(
+        candidates,
+        key=lambda candidate: (
+            candidate.data_penalty,
+            1 if candidate.root_kind != "used" else 0,
+            1 if candidate.root_kind == "empty_online" else 0,
+            candidate.global_signal_tree_max_depth,
+            candidate.global_signal_tree_total_edges,
+            len(candidate.suffix) - 1,
+            candidate.root.x,
+            candidate.root.y,
+        ),
+    )
+
+    if selected.data_penalty > 0:
+        diagnostics.append(
+            "selected minimum-penalty fallback because no zero-penalty common "
+            f"DATA suffix root was feasible; data_penalty={selected.data_penalty}."
+        )
+
+    output_routes = tuple(
+        OutputRouteDecision(producer.coord, producer.target_coord, choice.offset)
+        for producer, choice in zip(producers_tuple, selected.choices, strict=True)
+    )
+    return OutputCompletionPlan(
+        output_routes=output_routes,
+        control_offset=selected.control_offset,
+        ingress_side=terminal_route_side(selected.control_offset),
+        global_signal_root=selected.root,
+        root_kind=selected.root_kind,
+        relay_cores=selected.relay_cores,
+        data_penalty=selected.data_penalty,
+        global_signal_tree_max_depth=selected.global_signal_tree_max_depth,
+        global_signal_tree_total_edges=selected.global_signal_tree_total_edges,
+        complete_path_len=len(selected.suffix) - 1,
+        diagnostics=tuple(diagnostics),
+    )

--- a/paibox/backendv2/output_cpu_ingress.py
+++ b/paibox/backendv2/output_cpu_ingress.py
@@ -1,0 +1,144 @@
+from dataclasses import dataclass
+from typing import Literal
+
+from paicorelib import CoordXY, CoordZXYOffset, find_coordxy_shortest_path
+
+from .core_config import TEST_DEST_CORE
+from .route_solver import G_X_MAX, G_X_MIN
+
+CpuIngressSide = tuple[Literal["x", "y", "xy", "local"], int]
+
+
+class CpuIngressError(RuntimeError):
+    """Base error for output DATA and control-frame CPU-ingress alignment."""
+
+
+class CpuIngressNoFeasiblePlanError(CpuIngressError):
+    """Raised when no output/control targets can share one CPU ingress side."""
+
+
+@dataclass(frozen=True)
+class OutputRouteEndpoint:
+    producer_coord: CoordXY
+    target_coord: CoordXY
+
+
+@dataclass(frozen=True)
+class OutputCpuIngressPlan:
+    output_target: CoordXY | None
+    control_target: CoordXY
+    ingress_side: CpuIngressSide
+
+
+def terminal_cpu_ingress_side(offset: CoordZXYOffset) -> CpuIngressSide:
+    """Return the destination-side ingress used by a routed ZXY packet.
+
+    The v2.5 packet walker consumes route fields in Z, then X, then Y order.
+    The last non-zero leg is therefore the side from which the packet reaches
+    its destination port.
+    """
+    if offset.y != 0:
+        return ("y", 1 if offset.y > 0 else -1)
+    if offset.x != 0:
+        return ("x", 1 if offset.x > 0 else -1)
+    if offset.z != 0:
+        return ("xy", 1 if offset.z > 0 else -1)
+    return ("local", 0)
+
+
+def _cpu_io_target_candidates(preferred: list[CoordXY]) -> list[CoordXY]:
+    """Return deterministic candidate cores on the CPU-facing chip side."""
+    candidates: list[CoordXY] = []
+    seen: set[tuple[int, int]] = set()
+
+    def add(coord: CoordXY) -> None:
+        key = (coord.x, coord.y)
+        if key not in seen:
+            seen.add(key)
+            candidates.append(coord)
+
+    for coord in preferred:
+        add(coord)
+
+    # Offline compute cores are placed at y >= 2. The y=0/1 rows are the
+    # CPU-facing side available for DATA and control/test-frame collection.
+    for y in (0, 1):
+        for x in range(G_X_MIN, G_X_MAX + 1):
+            add(CoordXY(x, y))
+
+    return candidates
+
+
+def _route_ingress_sides(
+    endpoints: list[OutputRouteEndpoint], override_target: CoordXY | None = None
+) -> set[CpuIngressSide]:
+    ingress_sides: set[CpuIngressSide] = set()
+    for endpoint in endpoints:
+        target = (
+            override_target if override_target is not None else endpoint.target_coord
+        )
+        offset, _ = find_coordxy_shortest_path(target, endpoint.producer_coord)
+        ingress_sides.add(terminal_cpu_ingress_side(offset))
+    return ingress_sides
+
+
+def _choose_control_target_for_ingress_side(
+    root_coord: CoordXY, ingress_side: CpuIngressSide, preferred: list[CoordXY]
+) -> CoordXY | None:
+    for target in _cpu_io_target_candidates(preferred):
+        offset, _ = find_coordxy_shortest_path(target, root_coord)
+        if terminal_cpu_ingress_side(offset) == ingress_side:
+            return target
+    return None
+
+
+def select_output_cpu_ingress_plan(
+    root_coord: CoordXY, endpoints: list[OutputRouteEndpoint]
+) -> OutputCpuIngressPlan:
+    """Choose output DATA & completion targets with matching CPU ingress.
+
+    The CPU can observe a completion frame before all DATA frames if the two
+    streams enter the CPU-facing side from different ports. Prefer keeping the
+    existing output target and changing only the completion/test target. Retarget
+    output collection only when DATA producers do not already share one ingress.
+    """
+    if not endpoints:
+        return OutputCpuIngressPlan(None, TEST_DEST_CORE, ("local", 0))
+
+    current_targets = [endpoint.target_coord for endpoint in endpoints]
+    current_ingress_sides = _route_ingress_sides(endpoints)
+    if len(current_ingress_sides) == 1:
+        ingress_side = next(iter(current_ingress_sides))
+        control_target = _choose_control_target_for_ingress_side(
+            root_coord, ingress_side, current_targets
+        )
+        if control_target is not None:
+            return OutputCpuIngressPlan(None, control_target, ingress_side)
+
+    for output_target in _cpu_io_target_candidates(current_targets):
+        ingress_sides = _route_ingress_sides(endpoints, override_target=output_target)
+        if len(ingress_sides) != 1:
+            continue
+
+        ingress_side = next(iter(ingress_sides))
+        control_target = _choose_control_target_for_ingress_side(
+            root_coord, ingress_side, [output_target]
+        )
+        if control_target is not None:
+            return OutputCpuIngressPlan(output_target, control_target, ingress_side)
+
+    details = []
+    for endpoint in endpoints:
+        offset, _ = find_coordxy_shortest_path(
+            endpoint.target_coord, endpoint.producer_coord
+        )
+        details.append(
+            f"producer=({endpoint.producer_coord.x},{endpoint.producer_coord.y}) "
+            f"target=({endpoint.target_coord.x},{endpoint.target_coord.y}) "
+            f"offset=({offset.z},{offset.x},{offset.y}) "
+            f"ingress_side={terminal_cpu_ingress_side(offset)}"
+        )
+    raise CpuIngressNoFeasiblePlanError(
+        "Cannot find a CPU-side target that aligns output DATA and completion "
+        "control frames to the same ingress side:\n" + "\n".join(details)
+    )

--- a/paibox/backendv2/output_cpu_ingress.py
+++ b/paibox/backendv2/output_cpu_ingress.py
@@ -1,12 +1,17 @@
-from dataclasses import dataclass
-from typing import Literal
-
 from paicorelib import CoordXY, CoordZXYOffset, find_coordxy_shortest_path
 
 from .core_config import TEST_DEST_CORE
-from .route_solver import G_X_MAX, G_X_MIN
-
-CpuIngressSide = tuple[Literal["x", "y", "xy", "local"], int]
+from .output_route_offsets import (
+    RouteSide,
+    candidate_offsets,
+    route_len,
+    terminal_route_side,
+)
+from .output_routes import (
+    OutputCpuIngressPlan,
+    OutputRouteDecision,
+    OutputRouteEndpoint,
+)
 
 
 class CpuIngressError(RuntimeError):
@@ -14,131 +19,90 @@ class CpuIngressError(RuntimeError):
 
 
 class CpuIngressNoFeasiblePlanError(CpuIngressError):
-    """Raised when no output/control targets can share one CPU ingress side."""
+    """Raised when no output/control offsets can share one CPU ingress side."""
 
 
-@dataclass(frozen=True)
-class OutputRouteEndpoint:
-    producer_coord: CoordXY
-    target_coord: CoordXY
+def terminal_data_ingress_side(offset: CoordZXYOffset) -> RouteSide:
+    """Return the CPU ingress side used by output DATA packets."""
+    return terminal_route_side(offset)
 
 
-@dataclass(frozen=True)
-class OutputCpuIngressPlan:
-    output_target: CoordXY | None
-    control_target: CoordXY
-    ingress_side: CpuIngressSide
+def terminal_control_ingress_side(offset: CoordZXYOffset) -> RouteSide:
+    """Return the CPU ingress side used by completion/test packets."""
+    return terminal_route_side(offset)
 
 
-def terminal_cpu_ingress_side(offset: CoordZXYOffset) -> CpuIngressSide:
-    """Return the destination-side ingress used by a routed ZXY packet.
-
-    The v2.5 packet walker consumes route fields in Z, then X, then Y order.
-    The last non-zero leg is therefore the side from which the packet reaches
-    its destination port.
-    """
-    if offset.y != 0:
-        return ("y", 1 if offset.y > 0 else -1)
-    if offset.x != 0:
-        return ("x", 1 if offset.x > 0 else -1)
-    if offset.z != 0:
-        return ("xy", 1 if offset.z > 0 else -1)
-    return ("local", 0)
+def _offsets_by_ingress(
+    start_coord: CoordXY, target_coord: CoordXY
+) -> dict[RouteSide, CoordZXYOffset]:
+    by_side: dict[RouteSide, CoordZXYOffset] = {}
+    for offset in candidate_offsets(start_coord, target_coord):
+        by_side.setdefault(terminal_route_side(offset), offset)
+    return by_side
 
 
-def _cpu_io_target_candidates(preferred: list[CoordXY]) -> list[CoordXY]:
-    """Return deterministic candidate cores on the CPU-facing chip side."""
-    candidates: list[CoordXY] = []
-    seen: set[tuple[int, int]] = set()
-
-    def add(coord: CoordXY) -> None:
-        key = (coord.x, coord.y)
-        if key not in seen:
-            seen.add(key)
-            candidates.append(coord)
-
-    for coord in preferred:
-        add(coord)
-
-    # Offline compute cores are placed at y >= 2. The y=0/1 rows are the
-    # CPU-facing side available for DATA and control/test-frame collection.
-    for y in (0, 1):
-        for x in range(G_X_MIN, G_X_MAX + 1):
-            add(CoordXY(x, y))
-
-    return candidates
-
-
-def _route_ingress_sides(
-    endpoints: list[OutputRouteEndpoint], override_target: CoordXY | None = None
-) -> set[CpuIngressSide]:
-    ingress_sides: set[CpuIngressSide] = set()
-    for endpoint in endpoints:
-        target = (
-            override_target if override_target is not None else endpoint.target_coord
-        )
-        offset, _ = find_coordxy_shortest_path(target, endpoint.producer_coord)
-        ingress_sides.add(terminal_cpu_ingress_side(offset))
-    return ingress_sides
-
-
-def _choose_control_target_for_ingress_side(
-    root_coord: CoordXY, ingress_side: CpuIngressSide, preferred: list[CoordXY]
-) -> CoordXY | None:
-    for target in _cpu_io_target_candidates(preferred):
-        offset, _ = find_coordxy_shortest_path(target, root_coord)
-        if terminal_cpu_ingress_side(offset) == ingress_side:
-            return target
-    return None
+def _route_detail(
+    producer_coord: CoordXY, target_coord: CoordXY, offset: CoordZXYOffset
+) -> str:
+    return (
+        f"producer=({producer_coord.x},{producer_coord.y}) "
+        f"target=({target_coord.x},{target_coord.y}) "
+        f"offset=({offset.z},{offset.x},{offset.y}) "
+        f"ingress_side={terminal_route_side(offset)}"
+    )
 
 
 def select_output_cpu_ingress_plan(
     root_coord: CoordXY, endpoints: list[OutputRouteEndpoint]
 ) -> OutputCpuIngressPlan:
-    """Choose output DATA & completion targets with matching CPU ingress.
-
-    The CPU can observe a completion frame before all DATA frames if the two
-    streams enter the CPU-facing side from different ports. Prefer keeping the
-    existing output target and changing only the completion/test target. Retarget
-    output collection only when DATA producers do not already share one ingress.
-    """
+    """Choose route offsets that align DATA and completion at CPU ingress."""
     if not endpoints:
-        return OutputCpuIngressPlan(None, TEST_DEST_CORE, ("local", 0))
-
-    current_targets = [endpoint.target_coord for endpoint in endpoints]
-    current_ingress_sides = _route_ingress_sides(endpoints)
-    if len(current_ingress_sides) == 1:
-        ingress_side = next(iter(current_ingress_sides))
-        control_target = _choose_control_target_for_ingress_side(
-            root_coord, ingress_side, current_targets
+        control_offset = find_coordxy_shortest_path(TEST_DEST_CORE, root_coord)[0]
+        return OutputCpuIngressPlan(
+            (), control_offset, terminal_control_ingress_side(control_offset)
         )
-        if control_target is not None:
-            return OutputCpuIngressPlan(None, control_target, ingress_side)
 
-    for output_target in _cpu_io_target_candidates(current_targets):
-        ingress_sides = _route_ingress_sides(endpoints, override_target=output_target)
-        if len(ingress_sides) != 1:
-            continue
+    control_offsets = _offsets_by_ingress(root_coord, TEST_DEST_CORE)
+    output_offsets = [
+        _offsets_by_ingress(endpoint.producer_coord, endpoint.target_coord)
+        for endpoint in endpoints
+    ]
 
-        ingress_side = next(iter(ingress_sides))
-        control_target = _choose_control_target_for_ingress_side(
-            root_coord, ingress_side, [output_target]
-        )
-        if control_target is not None:
-            return OutputCpuIngressPlan(output_target, control_target, ingress_side)
+    common_sides = set(control_offsets)
+    for offsets in output_offsets:
+        common_sides &= set(offsets)
 
-    details = []
-    for endpoint in endpoints:
-        offset, _ = find_coordxy_shortest_path(
-            endpoint.target_coord, endpoint.producer_coord
+    if common_sides:
+        ingress_side = min(
+            common_sides,
+            key=lambda side: (
+                sum(route_len(offsets[side]) for offsets in output_offsets)
+                + route_len(control_offsets[side]),
+                str(side),
+            ),
         )
-        details.append(
-            f"producer=({endpoint.producer_coord.x},{endpoint.producer_coord.y}) "
-            f"target=({endpoint.target_coord.x},{endpoint.target_coord.y}) "
-            f"offset=({offset.z},{offset.x},{offset.y}) "
-            f"ingress_side={terminal_cpu_ingress_side(offset)}"
+        return OutputCpuIngressPlan(
+            tuple(
+                OutputRouteDecision(
+                    endpoint.producer_coord,
+                    endpoint.target_coord,
+                    offsets[ingress_side],
+                )
+                for endpoint, offsets in zip(endpoints, output_offsets, strict=True)
+            ),
+            control_offsets[ingress_side],
+            ingress_side,
         )
+
+    details: list[str] = []
+    for endpoint, offsets in zip(endpoints, output_offsets, strict=True):
+        for offset in offsets.values():
+            details.append(
+                _route_detail(endpoint.producer_coord, endpoint.target_coord, offset)
+            )
+    for offset in control_offsets.values():
+        details.append(_route_detail(root_coord, TEST_DEST_CORE, offset))
     raise CpuIngressNoFeasiblePlanError(
-        "Cannot find a CPU-side target that aligns output DATA and completion "
-        "control frames to the same ingress side:\n" + "\n".join(details)
+        "Cannot find fixed-CPU route offsets that align output DATA and "
+        "completion control frames to the same ingress side:\n" + "\n".join(details)
     )

--- a/paibox/backendv2/output_route_offsets.py
+++ b/paibox/backendv2/output_route_offsets.py
@@ -1,0 +1,76 @@
+from typing import Literal
+
+from paicorelib import CoordXY, CoordZXYOffset
+
+from .route_solver import G_X_MAX, G_X_MIN, G_Y_MAX, G_Y_MIN
+
+RouteSide = tuple[Literal["x", "y", "xy", "local"], int]
+
+
+def route_len(offset: CoordZXYOffset) -> int:
+    return abs(offset.z) + abs(offset.x) + abs(offset.y)
+
+
+def terminal_route_side(offset: CoordZXYOffset) -> RouteSide:
+    """Return the terminal route side after Z/XY, then X, then Y routing."""
+    if offset.y != 0:
+        return ("y", 1 if offset.y > 0 else -1)
+    if offset.x != 0:
+        return ("x", 1 if offset.x > 0 else -1)
+    if offset.z != 0:
+        return ("xy", 1 if offset.z > 0 else -1)
+    return ("local", 0)
+
+
+def route_coord_path(
+    start_coord: CoordXY, offset: CoordZXYOffset
+) -> tuple[CoordXY, ...]:
+    """Return the coordinate path produced by backendv2 Z, X, then Y routing."""
+    x, y = start_coord.x, start_coord.y
+    points = [start_coord]
+
+    def walk(step_count: int, dx: int, dy: int) -> None:
+        nonlocal x, y
+        for _ in range(step_count):
+            x += dx
+            y += dy
+            points.append(CoordXY(x, y))
+
+    if offset.z != 0:
+        walk(abs(offset.z), 1 if offset.z > 0 else -1, 1 if offset.z > 0 else -1)
+    if offset.x != 0:
+        walk(abs(offset.x), 1 if offset.x > 0 else -1, 0)
+    if offset.y != 0:
+        walk(abs(offset.y), 0, 1 if offset.y > 0 else -1)
+
+    return tuple(points)
+
+
+def route_stays_in_grid(
+    start_coord: CoordXY, offset: CoordZXYOffset, target_coord: CoordXY
+) -> bool:
+    path = route_coord_path(start_coord, offset)
+    return path[-1] == target_coord and all(
+        G_X_MIN <= coord.x <= G_X_MAX and G_Y_MIN <= coord.y <= G_Y_MAX
+        for coord in path
+    )
+
+
+def candidate_offsets(
+    start_coord: CoordXY, target_coord: CoordXY
+) -> tuple[CoordZXYOffset, ...]:
+    """Enumerate legal offsets to one fixed target without changing the target."""
+    dcoord = target_coord - start_coord
+    offsets: list[CoordZXYOffset] = []
+    for z in range(-31, 32):
+        x = dcoord.x - z
+        y = dcoord.y - z
+        if not (-31 <= x <= 31 and -31 <= y <= 31):
+            continue
+        offset = CoordZXYOffset(z, x, y)
+        if route_stays_in_grid(start_coord, offset, target_coord):
+            offsets.append(offset)
+
+    return tuple(
+        sorted(offsets, key=lambda offset: (route_len(offset), offset.to_tuple()))
+    )

--- a/paibox/backendv2/output_routes.py
+++ b/paibox/backendv2/output_routes.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+from paicorelib import CoordXY, CoordZXYOffset
+
+from .output_route_offsets import RouteSide
+
+
+@dataclass(frozen=True)
+class OutputRouteEndpoint:
+    producer_coord: CoordXY
+    target_coord: CoordXY
+
+
+@dataclass(frozen=True)
+class OutputRouteDecision:
+    producer_coord: CoordXY
+    target_coord: CoordXY
+    offset: CoordZXYOffset
+
+
+@dataclass(frozen=True)
+class OutputCpuIngressPlan:
+    output_routes: tuple[OutputRouteDecision, ...]
+    control_offset: CoordZXYOffset
+    ingress_side: RouteSide
+
+    def output_route_offsets(self) -> dict[tuple[CoordXY, CoordXY], CoordZXYOffset]:
+        return {
+            (route.producer_coord, route.target_coord): route.offset
+            for route in self.output_routes
+        }

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -9,6 +9,7 @@ from paicorelib import (
     LCN_EX,
     AERPacketZXYCopy,
     CoordXY,
+    CoordZXYOffset,
     CSCAccelerateMode,
     FoldType,
     NeuronType,
@@ -183,7 +184,12 @@ class SourceGroup(Generic[SOURCE_ELEM, SOURCE_NODE]):
         return f"{self.__class__.__name__}: \n" + self.info(prefix="  ") + "\n"
 
     def get_detail_dest(
-        self, elems: list[SOURCE_ELEM], self_coord: CoordXY = CoordXY(0, 0)
+        self,
+        elems: list[SOURCE_ELEM],
+        self_coord: CoordXY = CoordXY(0, 0),
+        output_route_offsets: (
+            dict[tuple[CoordXY, CoordXY], CoordZXYOffset] | None
+        ) = None,
     ) -> OfflineNeuDestInfoV2:
         dest_routing_group = self.get_dest(elems[0])
         axon_elem = self.get_axon(elems[0])
@@ -209,9 +215,15 @@ class SourceGroup(Generic[SOURCE_ELEM, SOURCE_NODE]):
 
         tick_relative, addr_axon = divmod(axon_bit_count, FANIN_BASE)
 
-        coord_offset, _ = find_coordxy_shortest_path(
-            target=dest_coord, start=self_coord
-        )
+        if output_route_offsets is not None and isinstance(
+            dest_routing_group, OutputGroup
+        ):
+            coord_offset = output_route_offsets.get((self_coord, dest_coord))
+        else:
+            coord_offset = None
+
+        if coord_offset is None:
+            coord_offset, _ = find_coordxy_shortest_path(dest_coord, start=self_coord)
 
         return OfflineNeuDestInfoV2(
             tick_relative=tick_relative,
@@ -856,7 +868,9 @@ class RoutingGroup(
         self._base_coord = coords[0]
         self._multicast_config = copy_config
 
-    def set_detail_dest(self):
+    def set_detail_dest(
+        self, output_route_offsets: dict[tuple[CoordXY, CoordXY], CoordZXYOffset]
+    ) -> None:
         for core_placement in track(
             self.core_placements,
             description=f"Setting Detail Destinations for {self.name}",
@@ -867,13 +881,14 @@ class RoutingGroup(
                 # for folded neuron placement, it may contain multiple raw_neus
                 # but we only need to set dest_info for the first raw_neu
                 dest_info = self.get_detail_dest(
-                    neu_placement.raw_neus, self_coord=core_placement.coord
+                    neu_placement.raw_neus, core_placement.coord, output_route_offsets
                 )
                 neu_placement.dest_info = dest_info
 
     def set_auto_core_config(self, test_dest_core: CoordXY) -> None:
         for cp in self.core_placements:
-            cp.set_auto_core_config(test_dest_core)
+            test_offset, _ = find_coordxy_shortest_path(test_dest_core, cp.coord)
+            cp.set_auto_core_config(test_offset)
 
     @property
     def multicast_config(self) -> AERPacketZXYCopy:
@@ -1169,11 +1184,6 @@ class OutputGroup(Group, DestGroup[SourceElem, SourceNode]):
     @property
     def base_coord(self) -> CoordXY:
         return self._base_coord
-
-    @base_coord.setter
-    def base_coord(self, coord: CoordXY) -> None:
-        """Retarget final DATA collection without changing compute placement."""
-        self._base_coord = coord
 
 
 def toposort_for_rg(

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -563,7 +563,7 @@ class RoutingGroup(
                 fold_info = get_fold_info(weight_offsets, axon_addr_offsets)
                 if fold_info is None:
                     continue
-                ranges, fold_axon_skews, fold_weight_skews = fold_info
+                ranges, fold_weight_skews, fold_axon_skews = fold_info
                 print(
                     f"{prefix}Find fold {len(sub_neurons)} neurons with base weight {index} "
                     f"to dest group {dest_group.name}:"
@@ -589,6 +589,16 @@ class RoutingGroup(
                 if skip_fold:
                     continue
 
+                attrs_part2s = [neu.attrs_part2() for neu in sub_neurons]
+                if any(
+                    attrs_part2 != attrs_part2s[0] for attrs_part2 in attrs_part2s[1:]
+                ):
+                    print(
+                        f"{prefix}Fold candidates with base weight {index} have "
+                        "different full-neuron Part2 attrs, skipping fold."
+                    )
+                    continue
+
                 if index not in weight_strategy_cache:
                     current_weight_width = frontend_core_conf.weight_width
                     base_weight = base_weights[index]
@@ -602,7 +612,7 @@ class RoutingGroup(
                 selected_weight, weight_compress = weight_strategy_cache[index]
                 weight_sram_req = selected_weight.n_sram_required
 
-                attrs_part2 = sub_neurons[0].attrs_part2()
+                attrs_part2 = attrs_part2s[0]
                 attrs_part2.weight_compress = weight_compress
                 neuron_type = NeuronType.FULL
                 output_type = sub_neurons[0].output_type()
@@ -861,9 +871,9 @@ class RoutingGroup(
                 )
                 neu_placement.dest_info = dest_info
 
-    def set_auto_core_config(self):
-        for core_placement in self.core_placements:
-            core_placement.set_auto_core_config()
+    def set_auto_core_config(self, test_dest_core: CoordXY) -> None:
+        for cp in self.core_placements:
+            cp.set_auto_core_config(test_dest_core)
 
     @property
     def multicast_config(self) -> AERPacketZXYCopy:
@@ -1159,6 +1169,11 @@ class OutputGroup(Group, DestGroup[SourceElem, SourceNode]):
     @property
     def base_coord(self) -> CoordXY:
         return self._base_coord
+
+    @base_coord.setter
+    def base_coord(self, coord: CoordXY) -> None:
+        """Retarget final DATA collection without changing compute placement."""
+        self._base_coord = coord
 
 
 def toposort_for_rg(

--- a/paibox/paiir/lowering/converter.py
+++ b/paibox/paiir/lowering/converter.py
@@ -84,6 +84,7 @@ from ..ir.op_node import (
     TransformOp,
 )
 from ..ir.reshape_semantics import RESHAPE_LEAF_MODULE_TYPES
+from ..nn import SumPool1d, SumPool2d
 from .conv_lowering import (
     build_conv_ir_node,
     extract_functional_conv_spec,
@@ -471,6 +472,8 @@ def _build_compute_module_map() -> ModuleMapper:
         nn.AvgPool2d,
         nn.AdaptiveAvgPool1d,
         nn.AdaptiveAvgPool2d,
+        SumPool1d,
+        SumPool2d,
     ]
     return dict.fromkeys(modules, _map_comp)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1696,19 +1696,22 @@ reference = "tsinghua"
 
 [[package]]
 name = "paicorelib"
-version = "2.0.0b3"
+version = "2.0.0b5"
 description = "Library of PAICORE"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 markers = "platform_machine != \"armv7l\""
 files = [
-    {file = "paicorelib-2.0.0b3-py3-none-any.whl", hash = "sha256:37e1ea893700970cc8b74a02a757f32f671cccf21da82b11724e784fa39e3e01"},
-    {file = "paicorelib-2.0.0b3.tar.gz", hash = "sha256:187c6dce6d62d38fbc6afc34d285915364c70a0056607eab31f0d529c0d72c55"},
+    {file = "paicorelib-2.0.0b5-py3-none-any.whl", hash = "sha256:fb9566b45779675cd679c1b5d47e83380ecc18e034d02c209e962137184bd2b3"},
+    {file = "paicorelib-2.0.0b5.tar.gz", hash = "sha256:4d5fc59654b9167c71a309a6f100f3c59b49bacf490498af930f180b03f3b15b"},
 ]
 
 [package.dependencies]
-numpy = {version = ">=2.1.0,<3.0.0", markers = "platform_machine != \"armv7l\""}
+numpy = [
+    {version = ">=2.1.0,<3.0.0", markers = "python_full_version < \"3.14.0\" and platform_machine != \"armv7l\""},
+    {version = ">=2.3.5,<3.0.0", markers = "python_full_version >= \"3.14.0\" and platform_machine != \"armv7l\""},
+]
 pydantic = ">=2.10.0,<3.0.0"
 
 [package.source]
@@ -3113,4 +3116,4 @@ reference = "tsinghua"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "ebf2a538cbab555dff179ee2a4f92d71cac9038727c365ba6a12c5da0cdd6e7e"
+content-hash = "08838854f51f1dccb5d7986df045ce6a2e227e743a662deeff228106a1c44bd9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,12 @@ packages = [{ include = "paibox" }]
 
 [dependency-groups]
 dev = [
-    "pytest>=8.0",
+    "pytest>=9.0",
     "pytest-cov>=7.0",
     "pytest-md>=0.2",
     "pytest-xdist>=3.7.0",
     "orjson>=3.11.6",
-    "paicorelib>=2.0.0b3 ; platform_machine != 'armv7l'",
+    "paicorelib>=2.0.0b5 ; platform_machine != 'armv7l'",
     "torch>=2.0.0,<2.2.0 ; python_full_version < '3.12'",
     "torch>=2.2.0 ; python_full_version >= '3.12'",
     "spikingjelly>=0.0.0.0.12",
@@ -69,7 +69,7 @@ torch = [
 ]
 
 [tool.pytest.ini_options]
-minversion = "8.0.0"
+minversion = "9.0"
 testpaths = ["tests"]
 addopts = ["--cov=paibox", "--cov-branch"] #, "--cov-report=term", "-nauto"]
 
@@ -95,6 +95,7 @@ default = true
 
 [tool.uv.sources]
 torch = { index = "pytorch-cpu" }
+torchvision = { index = "pytorch-cpu" }
 
 
 [build-system]

--- a/tests/backendv2/test_coreplacement.py
+++ b/tests/backendv2/test_coreplacement.py
@@ -1,4 +1,6 @@
 from paicorelib import (
+    CoordXY,
+    CoordZXYOffset,
     CSCAccelerateMode,
     DataWidth,
     FoldType,
@@ -17,7 +19,11 @@ from paicorelib import (
 )
 from paicorelib.neuron_defs import ResetMode
 
-from paibox.backendv2.coreplacement import OfflineCorePlacementV2
+from paibox.backendv2.coreplacement import (
+    EmptyOfflineCorePlacementV2,
+    EmptyOnlineCorePlacementV2,
+    OfflineCorePlacementV2,
+)
 from paibox.backendv2.neuron import OfflineNeuronPlacement
 from paibox.backendv2.weight import Weight
 
@@ -80,7 +86,7 @@ def _weight(compress_type: WeightCompressType) -> Weight:
 
 def _core_with_single_neuron(
     neuron: OfflineNeuronPlacement,
-    weight: Weight,
+    weight: Weight
 ) -> OfflineCorePlacementV2:
     core = OfflineCorePlacementV2()
     core.neus = [neuron]
@@ -136,3 +142,32 @@ def test_set_weight_address_does_not_touch_half_neuron_part2_semantics():
 
     assert core.default_core_config.csc_accelerate == CSCAccelerateMode.ENABLE
     assert neuron.neu_attrs_part2 is None
+
+
+def test_empty_offline_core_exports_only_frame1():
+    core = EmptyOfflineCorePlacementV2()
+    core._coord = CoordXY(1, 2)
+    core.set_auto_core_config(CoordZXYOffset(-1, 0, -1))
+
+    frame1, frame2, frame3 = core.to_frame()
+
+    assert frame1 is not None
+    assert frame2 is None
+    assert frame3 is None
+
+
+def test_empty_online_core_exports_minimal_online_frame1():
+    core = EmptyOnlineCorePlacementV2()
+    core._coord = CoordXY(1, 2)
+    core.set_auto_core_config(CoordZXYOffset(-1, 0, -1))
+
+    assert (
+        core.auto_core_config.test_core_xy,
+        core.auto_core_config.test_core_x,
+        core.auto_core_config.test_core_y,
+    ) == (-1, 0, -1)
+
+    frame1, frame2, frame3 = core.to_frame()
+    assert frame1 is not None
+    assert frame2 is None
+    assert frame3 is None

--- a/tests/backendv2/test_global_signal.py
+++ b/tests/backendv2/test_global_signal.py
@@ -1,0 +1,43 @@
+import pytest
+from paicorelib import CoordXY
+
+from paibox.backendv2.coreplacement import (
+    EmptyOfflineCorePlacementV2,
+    EmptyOnlineCorePlacementV2,
+    OfflineCorePlacementV2,
+)
+from paibox.backendv2.global_signal import set_global_signal
+
+
+def _offline_core(coord: CoordXY) -> OfflineCorePlacementV2:
+    core = OfflineCorePlacementV2()
+    core._coord = coord
+    return core
+
+
+@pytest.mark.parametrize(
+    ("relay_kind", "expected_type"),
+    [
+        ("offline", EmptyOfflineCorePlacementV2),
+        ("online", EmptyOnlineCorePlacementV2),
+    ],
+)
+def test_set_global_signal_uses_planner_selected_empty_root(relay_kind, expected_type):
+    root = CoordXY(1, 1)
+    cores = [_offline_core(CoordXY(3, 3))]
+
+    placements, global_starts = set_global_signal(cores, root, {root: relay_kind})
+
+    root_placements = [placement for placement in placements if placement.coord == root]
+    assert len(root_placements) == 1
+    assert isinstance(root_placements[0], expected_type)
+    assert CoordXY(0, 0) + global_starts[0].to_xy() == root
+
+
+def test_set_global_signal_is_quiet_by_default(capsys):
+    root = CoordXY(1, 1)
+    cores = [_offline_core(CoordXY(3, 3))]
+
+    set_global_signal(cores, root, {root: "offline"})
+
+    assert capsys.readouterr().out == ""

--- a/tests/backendv2/test_mapper.py
+++ b/tests/backendv2/test_mapper.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from paicorelib import (
     LCN_EX,
+    CoordXY,
     CSCAccelerateMode,
     DataSign,
     DataWidth,
@@ -22,6 +23,7 @@ from paibox.backendv2.coreplacement import OfflineCorePlacementV2
 from paibox.backendv2.export.utils import export_framearray_to_int32
 from paibox.backendv2.mapper import Mapper
 from paibox.backendv2.op_node import SourceElem
+from paibox.backendv2.output_cpu_ingress import OutputRouteEndpoint
 from paibox.backendv2.proto import get_schema_version
 from paibox.backendv2.proto.compile_artifacts_pb2 import (
     CompileArtifacts,
@@ -31,11 +33,63 @@ from paibox.backendv2.proto.compile_artifacts_pb2 import (
     RuntimeParams,
 )
 from paibox.backendv2.routing import FANIN_BASE, OutputGroup
-from paibox.paiir import compile_to_paiir
+from paibox.paiir import ANNNodeV25, LutCustom, compile_to_paiir, register_neuron
 from tests.paiir.conftest import ANNClassifier, SimpleCNN, SNNTwoLayer, make_img_3ch_8x8
 from tests.utils import is_ci_env
 
 DEBUG_EXPORT_ROOT = Path(__file__).with_name("debug") / "mapper_proto_export"
+
+
+class FloatOutputIdentityLutCustom(LutCustom):
+    def forward(self, x):
+        return super().forward(x).to(torch.float32)
+
+
+class RepeatedWeightDifferentBiasLinearLut(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        thresholds = torch.arange(256, dtype=torch.int32)
+        values = torch.arange(256, dtype=torch.uint8)
+        self.linear1 = nn.Linear(4, 4, bias=True)
+        self.lut1 = FloatOutputIdentityLutCustom(
+            thresholds, values, output_sign=0, is_float=False
+        )
+        self.linear2 = nn.Linear(4, 2, bias=True)
+        self.lut2 = FloatOutputIdentityLutCustom(
+            thresholds, values, output_sign=0, is_float=False
+        )
+        with torch.no_grad():
+            repeated_row = torch.tensor([1, -1, 1, -1], dtype=torch.float32)
+            self.linear1.weight.copy_(repeated_row.repeat(4, 1))
+            self.linear1.bias.copy_(
+                torch.tensor([120, 121, 122, 123], dtype=torch.float32)
+            )
+            self.linear2.weight.copy_(
+                torch.tensor([[1, 1, -1, -1], [-1, 1, -1, 1]], dtype=torch.float32)
+            )
+            self.linear2.bias.copy_(torch.tensor([128, 130], dtype=torch.float32))
+
+    def forward(self, x):
+        x = self.lut1(self.linear1(x))
+        return self.lut2(self.linear2(x))
+
+
+def _register_float_output_identity_lut_custom() -> None:
+    try:
+        register_neuron(
+            FloatOutputIdentityLutCustom,
+            converter=lambda lut: ANNNodeV25(
+                LutCustom(
+                    lut.thresholds.detach().clone(),
+                    lut.lut_values.detach().clone(),
+                    output_sign=lut.output_sign,
+                    is_float=lut.is_float,
+                )
+            ),
+        )
+    except ValueError as exc:
+        if "already registered" not in str(exc):
+            raise
 
 
 def _assert_debug_frame_text(path: Path) -> None:
@@ -312,6 +366,31 @@ def _shared_sparse_linear_neuron_placements(mapper: Mapper):
     ]
 
 
+def test_mapper_finalizes_output_cpu_ingress_plan_without_full_compile(monkeypatch):
+    mapper = Mapper()
+    endpoints = [
+        OutputRouteEndpoint(CoordXY(0, 2), CoordXY(0, 0)),
+        OutputRouteEndpoint(CoordXY(5, 2), CoordXY(0, 0)),
+    ]
+    applied_targets: list[CoordXY] = []
+
+    monkeypatch.setattr(mapper, "_collect_output_route_endpoints", lambda: endpoints)
+    monkeypatch.setattr(mapper, "_global_root_coord", lambda: CoordXY(2, 2))
+
+    def record_output_target(plan) -> None:
+        if plan.output_target is not None:
+            applied_targets.append(plan.output_target)
+
+    monkeypatch.setattr(mapper, "_apply_output_target", record_output_target)
+
+    plan = mapper.finalize_output_cpu_ingress_plan()
+
+    assert mapper.output_cpu_ingress_plan == plan
+    assert plan.output_target == CoordXY(4, 0)
+    assert plan.control_target == CoordXY(4, 0)
+    assert applied_targets == [CoordXY(4, 0)]
+
+
 def test_mapper_default_auto_strategy_mixes_sparse_and_dense_csc(tmp_path):
     graph = compile_to_paiir(
         DefaultMixedSparseDenseLinear().eval(),
@@ -412,6 +491,40 @@ def test_mapper_default_sparse_csc_half_reuse_is_true_sparse_csc(tmp_path):
     assert placements[1].neu_attrs_part1.weight_address_end == (
         placements[0].neu_attrs_part1.weight_address_end
     )
+
+
+def test_mapper_does_not_fold_neurons_with_different_part2_attrs(tmp_path):
+    _register_float_output_identity_lut_custom()
+    graph = compile_to_paiir(
+        RepeatedWeightDifferentBiasLinearLut().eval(),
+        torch.tensor([[3, 4, 5, 6]], dtype=torch.float32),
+        input_formats={"InputNode_0": (DataSign.UNSIGNED, DataWidth.WIDTH_8BIT)},
+        timesteps=1,
+        auto_reset=True,
+        strict=True,
+    )
+    mapper = Mapper()
+    mapper.compile(graph, tmp_path, target_platform="x86", debug=False)
+
+    placements = _shared_sparse_linear_neuron_placements(mapper)
+    first_layer = [
+        placement
+        for placement in placements
+        if len(placement.raw_neus) == 1
+        and placement.raw_neus[0].target.name == "SequentialOp_0"
+    ]
+    first_layer = sorted(
+        first_layer, key=lambda placement: placement.raw_neus[0].index.idx
+    )
+
+    assert len(first_layer) == 4
+    assert all(placement.folded_neu_attrs_part1 is None for placement in first_layer)
+    assert [placement.neu_attrs_part2.leak_v for placement in first_layer] == [
+        120,
+        121,
+        122,
+        123,
+    ]
 
 
 def test_mapper_default_uint8_high_index_shifted_base_tie_uses_dense(tmp_path):

--- a/tests/backendv2/test_mapper.py
+++ b/tests/backendv2/test_mapper.py
@@ -9,6 +9,7 @@ import torch
 from paicorelib import (
     LCN_EX,
     CoordXY,
+    CoordZXYOffset,
     CSCAccelerateMode,
     DataSign,
     DataWidth,
@@ -23,7 +24,7 @@ from paibox.backendv2.coreplacement import OfflineCorePlacementV2
 from paibox.backendv2.export.utils import export_framearray_to_int32
 from paibox.backendv2.mapper import Mapper
 from paibox.backendv2.op_node import SourceElem
-from paibox.backendv2.output_cpu_ingress import OutputRouteEndpoint
+from paibox.backendv2.output_completion import OutputProducer
 from paibox.backendv2.proto import get_schema_version
 from paibox.backendv2.proto.compile_artifacts_pb2 import (
     CompileArtifacts,
@@ -366,29 +367,52 @@ def _shared_sparse_linear_neuron_placements(mapper: Mapper):
     ]
 
 
-def test_mapper_finalizes_output_cpu_ingress_plan_without_full_compile(monkeypatch):
+def test_mapper_builds_output_completion_plan_without_full_compile(monkeypatch):
     mapper = Mapper()
-    endpoints = [
-        OutputRouteEndpoint(CoordXY(0, 2), CoordXY(0, 0)),
-        OutputRouteEndpoint(CoordXY(5, 2), CoordXY(0, 0)),
-    ]
-    applied_targets: list[CoordXY] = []
+    producer_coords = [CoordXY(4, 2), CoordXY(2, 4)]
+    mapper.coreplacements = []
+    for coord in producer_coords:
+        core = OfflineCorePlacementV2()
+        core._coord = coord
+        mapper.coreplacements.append(core)
 
-    monkeypatch.setattr(mapper, "_collect_output_route_endpoints", lambda: endpoints)
-    monkeypatch.setattr(mapper, "_global_root_coord", lambda: CoordXY(2, 2))
+    monkeypatch.setattr(
+        mapper,
+        "_collect_output_producers",
+        lambda: [OutputProducer(coord, CoordXY(0, 0), 1) for coord in producer_coords],
+    )
 
-    def record_output_target(plan) -> None:
-        if plan.output_target is not None:
-            applied_targets.append(plan.output_target)
+    plan = mapper.build_output_completion_plan()
 
-    monkeypatch.setattr(mapper, "_apply_output_target", record_output_target)
+    assert plan.global_signal_root == CoordXY(0, 2)
+    assert plan.root_kind == "empty_offline"
+    assert plan.data_penalty == 2
+    assert {route.target_coord for route in plan.output_routes} == {CoordXY(0, 0)}
 
-    plan = mapper.finalize_output_cpu_ingress_plan()
 
-    assert mapper.output_cpu_ingress_plan == plan
-    assert plan.output_target == CoordXY(4, 0)
-    assert plan.control_target == CoordXY(4, 0)
-    assert applied_targets == [CoordXY(4, 0)]
+def test_mapper_does_not_broadcast_root_control_offset_to_all_cores():
+    mapper = Mapper()
+    root_cp = OfflineCorePlacementV2()
+    other_cp = OfflineCorePlacementV2()
+    root_cp._coord = CoordXY(5, 5)
+    other_cp._coord = CoordXY(6, 5)
+    mapper.coreplacements = [root_cp, other_cp]
+
+    root_control_offset = CoordZXYOffset(-4, -1, -1)
+    mapper.set_auto_core_config(root_cp.coord, root_control_offset)
+
+    other_offset, _ = find_coordxy_shortest_path(CoordXY(0, 0), other_cp.coord)
+    assert (
+        root_cp.auto_core_config.test_core_xy,
+        root_cp.auto_core_config.test_core_x,
+        root_cp.auto_core_config.test_core_y,
+    ) == root_control_offset.to_tuple()
+    assert (
+        other_cp.auto_core_config.test_core_xy,
+        other_cp.auto_core_config.test_core_x,
+        other_cp.auto_core_config.test_core_y,
+    ) == other_offset.to_tuple()
+    assert other_offset != root_control_offset
 
 
 def test_mapper_default_auto_strategy_mixes_sparse_and_dense_csc(tmp_path):

--- a/tests/backendv2/test_output_completion.py
+++ b/tests/backendv2/test_output_completion.py
@@ -1,0 +1,133 @@
+import pytest
+from paicorelib import CoordXY
+
+from paibox.backendv2.output_completion import (
+    OutputCompletionNoFeasiblePlanError,
+    OutputProducer,
+    select_output_completion_plan,
+)
+from paibox.backendv2.output_route_offsets import route_coord_path, route_len
+
+
+def _all_empty_offline_except(*used: CoordXY) -> set[CoordXY]:
+    used_set = set(used)
+    return {
+        CoordXY(x, y)
+        for x in range(9)
+        for y in range(9)
+        if CoordXY(x, y) not in used_set
+    }
+
+
+def test_single_output_root_is_on_data_path_and_complete_path_is_suffix():
+    producer = CoordXY(3, 4)
+    cpu = CoordXY(0, 0)
+
+    plan = select_output_completion_plan(
+        [OutputProducer(producer, cpu, 7)],
+        {producer},
+        _all_empty_offline_except(producer),
+    )
+
+    route = plan.output_routes[0]
+    data_path = route_coord_path(route.producer_coord, route.offset)
+    root_index = data_path.index(plan.global_signal_root)
+
+    assert plan.global_signal_root == producer
+    assert plan.root_kind == "used"
+    assert plan.data_penalty == 0
+    assert (
+        route_coord_path(plan.global_signal_root, plan.control_offset)
+        == data_path[root_index:]
+    )
+    assert plan.complete_path_len == route_len(plan.control_offset)
+
+
+def test_multi_output_selects_common_suffix_root():
+    producers = [CoordXY(4, 2), CoordXY(2, 4)]
+    cpu = CoordXY(0, 0)
+
+    plan = select_output_completion_plan(
+        [OutputProducer(producer, cpu, 1) for producer in producers],
+        set(producers),
+        _all_empty_offline_except(*producers),
+    )
+
+    complete_path = route_coord_path(plan.global_signal_root, plan.control_offset)
+    assert plan.global_signal_root == CoordXY(0, 1)
+    assert plan.root_kind == "empty_offline"
+    assert plan.data_penalty == 1
+    assert "minimum-penalty fallback" in plan.diagnostics[0]
+
+    for route in plan.output_routes:
+        data_path = route_coord_path(route.producer_coord, route.offset)
+        root_index = data_path.index(plan.global_signal_root)
+        assert data_path[root_index:] == complete_path
+
+
+@pytest.mark.parametrize(
+    (
+        "available_empty_offline",
+        "available_empty_online",
+        "allow_empty_online",
+        "empty_online_frame_supported",
+    ),
+    [
+        ({CoordXY(2, 3)}, set(), False, False),
+        ({CoordXY(2, 3)}, {CoordXY(2, 3)}, True, True),
+    ],
+    ids=["used_beats_empty", "used_beats_online_empty"],
+)
+def test_used_root_priority_for_equal_data_penalty(
+    available_empty_offline,
+    available_empty_online,
+    allow_empty_online,
+    empty_online_frame_supported,
+):
+    producer = CoordXY(3, 4)
+    cpu = CoordXY(0, 0)
+
+    plan = select_output_completion_plan(
+        [OutputProducer(producer, cpu, 1)],
+        {producer},
+        available_empty_offline,
+        available_empty_online,
+        allow_empty_online=allow_empty_online,
+        empty_online_frame_supported=empty_online_frame_supported,
+    )
+
+    assert plan.global_signal_root == producer
+    assert plan.root_kind == "used"
+    assert plan.data_penalty == 0
+    assert not plan.root_is_online_empty
+
+
+def test_online_empty_is_not_selected_when_frame_export_is_unavailable():
+    producer = CoordXY(3, 4)
+    online_only_root = CoordXY(2, 3)
+    cpu = CoordXY(0, 0)
+
+    plan = select_output_completion_plan(
+        [OutputProducer(producer, cpu, 1)],
+        {producer},
+        set(),
+        {online_only_root},
+        allow_empty_online=True,
+        empty_online_frame_supported=False,
+    )
+
+    assert plan.global_signal_root != online_only_root
+    assert plan.root_kind == "used"
+    assert "online frame1" in plan.diagnostics[0]
+
+
+def test_no_feasible_root_raises_with_context():
+    producer = CoordXY(3, 4)
+
+    with pytest.raises(
+        OutputCompletionNoFeasiblePlanError,
+        match=r"Cannot find a global signal root.*producers=.*used=",
+    ):
+        select_output_completion_plan(
+            [OutputProducer(producer, CoordXY(0, 0), 1)], set(), set(), set()
+        )

--- a/tests/backendv2/test_output_cpu_ingress.py
+++ b/tests/backendv2/test_output_cpu_ingress.py
@@ -3,78 +3,90 @@ from paicorelib import CoordXY, CoordZXYOffset, find_coordxy_shortest_path
 
 from paibox.backendv2.output_cpu_ingress import (
     CpuIngressNoFeasiblePlanError,
-    OutputRouteEndpoint,
     select_output_cpu_ingress_plan,
-    terminal_cpu_ingress_side,
+    terminal_control_ingress_side,
+    terminal_data_ingress_side,
 )
+from paibox.backendv2.output_routes import OutputRouteEndpoint
 
 
-def test_terminal_cpu_ingress_side_uses_last_nonzero_zxy_leg():
-    assert terminal_cpu_ingress_side(CoordZXYOffset(2, 0, 0)) == ("xy", 1)
-    assert terminal_cpu_ingress_side(CoordZXYOffset(2, -1, 0)) == ("x", -1)
-    assert terminal_cpu_ingress_side(CoordZXYOffset(2, -1, 3)) == ("y", 1)
-    assert terminal_cpu_ingress_side(CoordZXYOffset(0, 0, 0)) == ("local", 0)
+@pytest.mark.parametrize(
+    "offset",
+    [
+        CoordZXYOffset(2, 0, 0),
+        CoordZXYOffset(2, -1, 0),
+        CoordZXYOffset(2, -1, 3),
+        CoordZXYOffset(0, 0, 0),
+    ],
+)
+def test_cpu_ingress_side_wrappers_share_the_same_physical_side(offset):
+    assert terminal_data_ingress_side(offset) == terminal_control_ingress_side(offset)
 
 
-def test_select_output_cpu_ingress_plan_keeps_output_target_when_side_is_shared():
-    root = CoordXY(5, 5)
-    producer = CoordXY(6, 5)
-    plan = select_output_cpu_ingress_plan(
-        root, [OutputRouteEndpoint(producer, CoordXY(0, 0))]
-    )
+@pytest.mark.parametrize(
+    ("root", "producer", "output_offset", "control_offset"),
+    [
+        (
+            CoordXY(5, 5),
+            CoordXY(6, 5),
+            CoordZXYOffset(-4, -2, -1),
+            CoordZXYOffset(-4, -1, -1),
+        ),
+        (
+            CoordXY(2, 2),
+            CoordXY(3, 4),
+            CoordZXYOffset(-3, 0, -1),
+            CoordZXYOffset(-1, -1, -1),
+        ),
+    ],
+    ids=["failing_65", "out_34"],
+)
+def test_single_output_plan_keeps_cpu_target(
+    root, producer, output_offset, control_offset
+):
+    cpu = CoordXY(0, 0)
+    plan = select_output_cpu_ingress_plan(root, [OutputRouteEndpoint(producer, cpu)])
 
-    assert plan.output_target is None
-    assert plan.control_target == CoordXY(0, 1)
-    assert plan.ingress_side == ("x", -1)
-
-    data_offset, _ = find_coordxy_shortest_path(CoordXY(0, 0), producer)
-    root_offset, _ = find_coordxy_shortest_path(plan.control_target, root)
-    assert terminal_cpu_ingress_side(data_offset) == terminal_cpu_ingress_side(
-        root_offset
-    )
-
-
-def test_select_output_cpu_ingress_plan_keeps_output_target_for_out_34_layout():
-    root = CoordXY(2, 2)
-    producer = CoordXY(3, 4)
-    plan = select_output_cpu_ingress_plan(
-        root, [OutputRouteEndpoint(producer, CoordXY(0, 0))]
-    )
-
-    assert plan.output_target is None
-    assert plan.control_target == CoordXY(1, 0)
     assert plan.ingress_side == ("y", -1)
+    assert plan.control_offset == control_offset
+    assert plan.output_route_offsets() == {(producer, cpu): output_offset}
+    assert terminal_data_ingress_side(output_offset) == terminal_control_ingress_side(
+        control_offset
+    )
 
 
-def test_select_output_cpu_ingress_plan_retargets_when_data_sides_differ():
+def test_multi_output_plan_aligns_sides_without_retargeting_cpu():
     root = CoordXY(2, 2)
     producers = [CoordXY(0, 2), CoordXY(5, 2)]
-    endpoints = [
-        OutputRouteEndpoint(producer, CoordXY(0, 0)) for producer in producers
-    ]
+    cpu = CoordXY(0, 0)
+    endpoints = [OutputRouteEndpoint(producer, cpu) for producer in producers]
 
     assert {
-        terminal_cpu_ingress_side(find_coordxy_shortest_path(CoordXY(0, 0), p)[0])
+        terminal_data_ingress_side(find_coordxy_shortest_path(cpu, p)[0])
         for p in producers
     } == {("y", -1), ("x", -1)}
 
     plan = select_output_cpu_ingress_plan(root, endpoints)
 
-    assert plan.output_target == CoordXY(4, 0)
-    assert plan.control_target == CoordXY(4, 0)
+    assert {route.target_coord for route in plan.output_routes} == {cpu}
     assert {
-        terminal_cpu_ingress_side(find_coordxy_shortest_path(plan.output_target, p)[0])
-        for p in producers
+        terminal_data_ingress_side(route.offset) for route in plan.output_routes
     } == {plan.ingress_side}
+    assert terminal_control_ingress_side(plan.control_offset) == plan.ingress_side
 
 
-def test_select_output_cpu_ingress_plan_error_includes_route_details(monkeypatch):
+def test_no_plan_error_includes_route_details(monkeypatch):
     root = CoordXY(2, 2)
     endpoint = OutputRouteEndpoint(CoordXY(6, 5), CoordXY(0, 0))
 
+    def fake_offsets_by_ingress(start_coord, target_coord):
+        if start_coord == root:
+            return {("x", -1): CoordZXYOffset(0, -1, 0)}
+        return {("y", -1): CoordZXYOffset(0, 0, -1)}
+
     monkeypatch.setattr(
-        "paibox.backendv2.output_cpu_ingress._cpu_io_target_candidates",
-        lambda preferred: [],
+        "paibox.backendv2.output_cpu_ingress._offsets_by_ingress",
+        fake_offsets_by_ingress,
     )
 
     with pytest.raises(

--- a/tests/backendv2/test_output_cpu_ingress.py
+++ b/tests/backendv2/test_output_cpu_ingress.py
@@ -1,0 +1,84 @@
+import pytest
+from paicorelib import CoordXY, CoordZXYOffset, find_coordxy_shortest_path
+
+from paibox.backendv2.output_cpu_ingress import (
+    CpuIngressNoFeasiblePlanError,
+    OutputRouteEndpoint,
+    select_output_cpu_ingress_plan,
+    terminal_cpu_ingress_side,
+)
+
+
+def test_terminal_cpu_ingress_side_uses_last_nonzero_zxy_leg():
+    assert terminal_cpu_ingress_side(CoordZXYOffset(2, 0, 0)) == ("xy", 1)
+    assert terminal_cpu_ingress_side(CoordZXYOffset(2, -1, 0)) == ("x", -1)
+    assert terminal_cpu_ingress_side(CoordZXYOffset(2, -1, 3)) == ("y", 1)
+    assert terminal_cpu_ingress_side(CoordZXYOffset(0, 0, 0)) == ("local", 0)
+
+
+def test_select_output_cpu_ingress_plan_keeps_output_target_when_side_is_shared():
+    root = CoordXY(5, 5)
+    producer = CoordXY(6, 5)
+    plan = select_output_cpu_ingress_plan(
+        root, [OutputRouteEndpoint(producer, CoordXY(0, 0))]
+    )
+
+    assert plan.output_target is None
+    assert plan.control_target == CoordXY(0, 1)
+    assert plan.ingress_side == ("x", -1)
+
+    data_offset, _ = find_coordxy_shortest_path(CoordXY(0, 0), producer)
+    root_offset, _ = find_coordxy_shortest_path(plan.control_target, root)
+    assert terminal_cpu_ingress_side(data_offset) == terminal_cpu_ingress_side(
+        root_offset
+    )
+
+
+def test_select_output_cpu_ingress_plan_keeps_output_target_for_out_34_layout():
+    root = CoordXY(2, 2)
+    producer = CoordXY(3, 4)
+    plan = select_output_cpu_ingress_plan(
+        root, [OutputRouteEndpoint(producer, CoordXY(0, 0))]
+    )
+
+    assert plan.output_target is None
+    assert plan.control_target == CoordXY(1, 0)
+    assert plan.ingress_side == ("y", -1)
+
+
+def test_select_output_cpu_ingress_plan_retargets_when_data_sides_differ():
+    root = CoordXY(2, 2)
+    producers = [CoordXY(0, 2), CoordXY(5, 2)]
+    endpoints = [
+        OutputRouteEndpoint(producer, CoordXY(0, 0)) for producer in producers
+    ]
+
+    assert {
+        terminal_cpu_ingress_side(find_coordxy_shortest_path(CoordXY(0, 0), p)[0])
+        for p in producers
+    } == {("y", -1), ("x", -1)}
+
+    plan = select_output_cpu_ingress_plan(root, endpoints)
+
+    assert plan.output_target == CoordXY(4, 0)
+    assert plan.control_target == CoordXY(4, 0)
+    assert {
+        terminal_cpu_ingress_side(find_coordxy_shortest_path(plan.output_target, p)[0])
+        for p in producers
+    } == {plan.ingress_side}
+
+
+def test_select_output_cpu_ingress_plan_error_includes_route_details(monkeypatch):
+    root = CoordXY(2, 2)
+    endpoint = OutputRouteEndpoint(CoordXY(6, 5), CoordXY(0, 0))
+
+    monkeypatch.setattr(
+        "paibox.backendv2.output_cpu_ingress._cpu_io_target_candidates",
+        lambda preferred: [],
+    )
+
+    with pytest.raises(
+        CpuIngressNoFeasiblePlanError,
+        match=r"producer=\(6,5\).*target=\(0,0\).*offset=.*ingress_side=",
+    ):
+        select_output_cpu_ingress_plan(root, [endpoint])

--- a/tests/backendv2/test_output_route_offsets.py
+++ b/tests/backendv2/test_output_route_offsets.py
@@ -1,0 +1,45 @@
+import pytest
+from paicorelib import CoordXY, CoordZXYOffset
+
+from paibox.backendv2.output_route_offsets import (
+    candidate_offsets,
+    route_coord_path,
+    route_len,
+    route_stays_in_grid,
+    terminal_route_side,
+)
+
+
+@pytest.mark.parametrize(
+    ("offset", "side"),
+    [
+        (CoordZXYOffset(2, 0, 0), ("xy", 1)),
+        (CoordZXYOffset(2, -1, 0), ("x", -1)),
+        (CoordZXYOffset(2, -1, 3), ("y", 1)),
+        (CoordZXYOffset(0, 0, 0), ("local", 0)),
+    ],
+)
+def test_terminal_route_side(offset, side):
+    assert terminal_route_side(offset) == side
+
+
+def test_route_coord_path_follows_z_x_y_order():
+    assert route_coord_path(CoordXY(3, 4), CoordZXYOffset(-2, 1, -1)) == (
+        CoordXY(3, 4),
+        CoordXY(2, 3),
+        CoordXY(1, 2),
+        CoordXY(2, 2),
+        CoordXY(2, 1),
+    )
+
+
+def test_candidate_offsets_are_sorted_by_length_then_offset_tuple():
+    offsets = candidate_offsets(CoordXY(3, 4), CoordXY(0, 0))
+
+    assert offsets[0] == CoordZXYOffset(-3, 0, -1)
+    assert [route_len(offset) for offset in offsets] == sorted(
+        route_len(offset) for offset in offsets
+    )
+    assert all(
+        route_stays_in_grid(CoordXY(3, 4), offset, CoordXY(0, 0)) for offset in offsets
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1343,8 +1343,8 @@ dev = [
     { name = "orjson", specifier = ">=3.11.6" },
     { name = "ortools", marker = "python_full_version < '3.14'", specifier = "==9.14.6206" },
     { name = "ortools", marker = "python_full_version >= '3.14'", specifier = "==9.15.6755" },
-    { name = "paicorelib", marker = "platform_machine != 'armv7l'", specifier = ">=2.0.0b3" },
-    { name = "pytest", specifier = ">=8.0" },
+    { name = "paicorelib", marker = "platform_machine != 'armv7l'", specifier = ">=2.0.0b5" },
+    { name = "pytest", specifier = ">=9.0" },
     { name = "pytest-cov", specifier = ">=7.0" },
     { name = "pytest-md", specifier = ">=0.2" },
     { name = "pytest-xdist", specifier = ">=3.7.0" },
@@ -1356,16 +1356,16 @@ dev = [
 
 [[package]]
 name = "paicorelib"
-version = "2.0.0b3"
+version = "2.0.0b5"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version < '3.11' and platform_machine != 'armv7l'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version >= '3.11' and platform_machine != 'armv7l'" },
     { name = "pydantic", marker = "platform_machine != 'armv7l'" },
 ]
-sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/64/ac/de4235be4b4e84b56abad4ff1d3150697f801e3ff980a47ad78f9a48250d/paicorelib-2.0.0b3.tar.gz", hash = "sha256:187c6dce6d62d38fbc6afc34d285915364c70a0056607eab31f0d529c0d72c55", size = 57979, upload-time = "2026-05-01T13:00:28.883Z" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/39/7b/ca3b4d68b88482bc425539db7502e014383a7113cc4a5dac2a4ba3292092/paicorelib-2.0.0b5.tar.gz", hash = "sha256:4d5fc59654b9167c71a309a6f100f3c59b49bacf490498af930f180b03f3b15b", size = 73560, upload-time = "2026-06-07T05:00:18.569Z" }
 wheels = [
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/44/5f/e88cb1add9e275cdec33f11e538bd3a10316909244edd07e33b79f56f83e/paicorelib-2.0.0b3-py3-none-any.whl", hash = "sha256:37e1ea893700970cc8b74a02a757f32f671cccf21da82b11724e784fa39e3e01", size = 66040, upload-time = "2026-05-01T13:00:27.639Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a4/17/f6befe24f9d512e804b6ed9daa23d50ce0115b132b74954e03342ebbb174/paicorelib-2.0.0b5-py3-none-any.whl", hash = "sha256:fb9566b45779675cd679c1b5d47e83380ecc18e034d02c209e962137184bd2b3", size = 81796, upload-time = "2026-06-07T05:00:19.74Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add an output completion planner that keeps DATA routes and completion frames on a shared CPU suffix
- allow the global signal root to be selected by the planner, including empty relay-core handling
- keep Mapper compile output quieter and route output/control offsets through the planner
- add focused route-offset, output-completion, global-signal, coreplacement, and mapper coverage
