### PR TITLE
bugfix(backendv2): fix fold skew validation & completion root scoring

### DIFF
--- a/paibox/backendv2/fold_neu.py
+++ b/paibox/backendv2/fold_neu.py
@@ -3,7 +3,7 @@ import math
 import numpy as np
 
 
-def get_skew_info(offsets: list[int]):
+def get_skew_info(offsets: list[int]) -> tuple[list[int], list[int]] | None:
     offset_diff = np.diff(offsets)
     diff_num = len(np.unique(offset_diff))
     if diff_num > 3:
@@ -15,9 +15,9 @@ def get_skew_info(offsets: list[int]):
         ranges = [len(offsets)]
         return skews, ranges
 
-    skews = []
-    ranges = []
-    distances = []
+    skews: list[int] = []
+    ranges: list[int] = []
+    distances: list[int] = []
     for i, diff in enumerate(offset_diff):
         if len(skews) == 0:
             skews.append(diff.item())
@@ -40,38 +40,31 @@ def get_skew_info(offsets: list[int]):
                 else:
                     continue
 
-    skews = skews
-
     last_distance = len(offsets)
     for i in reversed(range(len(distances))):
         if last_distance % distances[i] != 0:
             return None
         ranges.insert(0, last_distance // distances[i])
         last_distance = distances[i]
-    ranges = ranges
     return skews, ranges
 
 
-def closest_factor(n, partition_num) -> int:
+def closest_factor(n: int, partition_num: int) -> int:
     if partition_num == 1:
         return n
     if n <= 0:
         raise ValueError("n must be a positive integer.")
 
-    # 1. 计算立方根并取整作为起点
     start = int(math.pow(n, 1 / partition_num))
-
-    # 2. 从起点向 1 递减搜索
-    for i in range(start, 0, -1):
-        if n % i == 0:
-            return i
-    return 1  # 如果没有找到任何因数，返回 1
+    return next((i for i in range(start, 0, -1) if n % i == 0), 1)
 
 
-def process_exceed(ranges, weight_skews, axon_addr_skews):
-    processed_ranges = []
-    processed_weight_skews = []
-    processed_axon_addr_skews = []
+def process_exceed(
+    ranges: list[int], weight_skews: list[int], axon_addr_skews: list[int]
+) -> tuple[list[int], list[int], list[int]] | None:
+    processed_ranges: list[int] = []
+    processed_weight_skews: list[int] = []
+    processed_axon_addr_skews: list[int] = []
     remain_space = 3 - len(ranges)
     for i, range_ in enumerate(ranges):
         if range_ < 2048:
@@ -84,8 +77,8 @@ def process_exceed(ranges, weight_skews, axon_addr_skews):
                 return None
             remain_num = range_
             for j in range(num_partition):
-                patial_num = num_partition - j
-                factor = closest_factor(remain_num, patial_num)
+                partial_num = num_partition - j
+                factor = closest_factor(remain_num, partial_num)
                 if factor < 2048:
                     processed_ranges.append(factor)
                     processed_weight_skews.append(weight_skews[i])
@@ -105,7 +98,9 @@ def process_exceed(ranges, weight_skews, axon_addr_skews):
     return processed_ranges, processed_weight_skews, processed_axon_addr_skews
 
 
-def get_fold_info(weight_offsets: list[int], axon_addr_offsets: list[int]):
+def get_fold_info(
+    weight_offsets: list[int], axon_addr_offsets: list[int]
+) -> tuple[list[int], list[int], list[int]] | None:
     """Return fold ranges with weight-skew and axon-skew sequences.
 
     The public contract is `(ranges, weight_skews, axon_addr_skews)`. Keep every

--- a/paibox/backendv2/output_completion.py
+++ b/paibox/backendv2/output_completion.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Literal
 
-from paicorelib import CoordXY, CoordZXYOffset
+from paicorelib import CoordXY, CoordZXYOffset, find_coordxy_shortest_path
 
 from .core_config import TEST_DEST_CORE
 from .global_signal import (
@@ -43,6 +43,16 @@ class EmptyRelayCore:
 
 
 @dataclass(frozen=True)
+class OutputCompletionScore:
+    data_penalty: int
+    control_loop_cost: int
+    cpu_to_root_path_len: int
+    complete_path_len: int
+    global_signal_tree_max_depth: int
+    global_signal_tree_total_edges: int
+
+
+@dataclass(frozen=True)
 class OutputCompletionPlan:
     output_routes: tuple[OutputRouteDecision, ...]
     control_offset: CoordZXYOffset
@@ -50,10 +60,7 @@ class OutputCompletionPlan:
     global_signal_root: CoordXY
     root_kind: RootKind
     relay_cores: tuple[EmptyRelayCore, ...]
-    data_penalty: int
-    global_signal_tree_max_depth: int
-    global_signal_tree_total_edges: int
-    complete_path_len: int
+    score: OutputCompletionScore
     diagnostics: tuple[str, ...]
 
     @property
@@ -102,9 +109,7 @@ class _RootSuffixCandidate:
     control_offset: CoordZXYOffset
     root_kind: RootKind
     relay_cores: tuple[EmptyRelayCore, ...]
-    data_penalty: int
-    global_signal_tree_max_depth: int
-    global_signal_tree_total_edges: int
+    score: OutputCompletionScore
 
 
 def _is_in_global_route_grid(coord: CoordXY) -> bool:
@@ -254,6 +259,16 @@ def select_output_completion_plan(
             default=TEST_DEST_CORE,
         )
         control_offset = candidate_offsets(root, TEST_DEST_CORE)[0]
+        cpu_to_root_path_len = find_coordxy_shortest_path(root)[1]
+        complete_path_len = route_len(control_offset)
+        score = OutputCompletionScore(
+            data_penalty=0,
+            control_loop_cost=cpu_to_root_path_len + complete_path_len,
+            cpu_to_root_path_len=cpu_to_root_path_len,
+            complete_path_len=complete_path_len,
+            global_signal_tree_max_depth=0,
+            global_signal_tree_total_edges=0,
+        )
         return OutputCompletionPlan(
             output_routes=(),
             control_offset=control_offset,
@@ -261,10 +276,7 @@ def select_output_completion_plan(
             global_signal_root=root,
             root_kind="used" if root in used_core_coords else "empty_offline",
             relay_cores=(),
-            data_penalty=0,
-            global_signal_tree_max_depth=0,
-            global_signal_tree_total_edges=0,
-            complete_path_len=route_len(control_offset),
+            score=score,
             diagnostics=tuple(diagnostics),
         )
 
@@ -312,6 +324,19 @@ def select_output_completion_plan(
             producer.weight * choice.penalty
             for producer, choice in zip(producers_tuple, choices, strict=True)
         )
+        cpu_to_root_path_len = find_coordxy_shortest_path(root)[1]
+        complete_path_len = len(suffix) - 1
+        control_loop_cost = (
+            cpu_to_root_path_len + 2 * global_signal_tree.max_depth + complete_path_len
+        )
+        score = OutputCompletionScore(
+            data_penalty=data_penalty,
+            control_loop_cost=control_loop_cost,
+            cpu_to_root_path_len=cpu_to_root_path_len,
+            complete_path_len=complete_path_len,
+            global_signal_tree_max_depth=global_signal_tree.max_depth,
+            global_signal_tree_total_edges=global_signal_tree.total_edges,
+        )
         candidates.append(
             _RootSuffixCandidate(
                 root=root,
@@ -320,9 +345,7 @@ def select_output_completion_plan(
                 control_offset=control_offset,
                 root_kind=root_kind,
                 relay_cores=relay_cores,
-                data_penalty=data_penalty,
-                global_signal_tree_max_depth=global_signal_tree.max_depth,
-                global_signal_tree_total_edges=global_signal_tree.total_edges,
+                score=score,
             )
         )
 
@@ -339,21 +362,21 @@ def select_output_completion_plan(
     selected = min(
         candidates,
         key=lambda candidate: (
-            candidate.data_penalty,
+            candidate.score.data_penalty,
             1 if candidate.root_kind != "used" else 0,
             1 if candidate.root_kind == "empty_online" else 0,
-            candidate.global_signal_tree_max_depth,
-            candidate.global_signal_tree_total_edges,
-            len(candidate.suffix) - 1,
+            candidate.score.control_loop_cost,
+            candidate.score.global_signal_tree_total_edges,
             candidate.root.x,
             candidate.root.y,
         ),
     )
 
-    if selected.data_penalty > 0:
+    if selected.score.data_penalty > 0:
         diagnostics.append(
             "selected minimum-penalty fallback because no zero-penalty common "
-            f"DATA suffix root was feasible; data_penalty={selected.data_penalty}."
+            "DATA suffix root was feasible; data_penalty="
+            f"{selected.score.data_penalty}."
         )
 
     output_routes = tuple(
@@ -367,9 +390,6 @@ def select_output_completion_plan(
         global_signal_root=selected.root,
         root_kind=selected.root_kind,
         relay_cores=selected.relay_cores,
-        data_penalty=selected.data_penalty,
-        global_signal_tree_max_depth=selected.global_signal_tree_max_depth,
-        global_signal_tree_total_edges=selected.global_signal_tree_total_edges,
-        complete_path_len=len(selected.suffix) - 1,
+        score=selected.score,
         diagnostics=tuple(diagnostics),
     )

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -18,6 +18,7 @@ from paicorelib import (
     OfflineNeuFoldedAttrsV2Part2,
     OfflineNeuFullAttrsV2Part1,
     OfflineNeuFullAttrsV2Part2,
+    OfflineNeuRegLimV2,
     WeightCompressType,
     find_coordxy_shortest_path,
 )
@@ -51,6 +52,24 @@ from .op_node import (
 from .weight import Weight
 
 FANIN_BASE = 512
+FOLD_WEIGHT_SKEW_MAX = OfflineNeuRegLimV2.FOLD_SKEW_MAX
+FOLD_AXON_MAX = OfflineNeuRegLimV2.FOLD_AXON_MAX
+
+
+def _first_invalid_fold_field(
+    skews: list[int], bit_num: int, field_max: int
+) -> tuple[int, int] | None:
+    field_values = [skew * bit_num for skew in skews]
+    if any(not 0 <= field_value <= field_max for field_value in field_values):
+        return next(
+            (
+                (skew, field_value)
+                for skew, field_value in zip(skews, field_values)
+                if not 0 <= field_value <= field_max
+            ),
+            None,
+        )
+    return None
 
 
 class Group:
@@ -583,22 +602,26 @@ class RoutingGroup(
                 print(f"{prefix}    fold_range: {ranges}")
                 print(f"{prefix}    fold_weight_skews: {fold_weight_skews}")
                 print(f"{prefix}    fold_axon_skews: {fold_axon_skews}")
-                skip_fold = False
-                for skew in fold_weight_skews:
-                    if skew * self.input_bit_num > 2047:
-                        print(
-                            f"{prefix}Fold weight skew {skew} is too large for input bit num {self.input_bit_num}, skipping fold."
-                        )
-                        skip_fold = True
-                        break
-                for skew in fold_axon_skews:
-                    if skew * dest_group.input_bit_num > 2047:
-                        print(
-                            f"{prefix}Fold axon skew {skew} is too large for input bit num {self.input_bit_num}, skipping fold."
-                        )
-                        skip_fold = True
-                        break
-                if skip_fold:
+                invalid_weight = _first_invalid_fold_field(
+                    fold_weight_skews, self.input_bit_num, FOLD_WEIGHT_SKEW_MAX
+                )
+                if invalid_weight is not None:
+                    skew, field_value = invalid_weight
+                    print(
+                        f"{prefix}Fold weight skew {skew} maps to {field_value}, "
+                        f"outside [0, {FOLD_WEIGHT_SKEW_MAX}], skipping fold."
+                    )
+                    continue
+
+                invalid_axon = _first_invalid_fold_field(
+                    fold_axon_skews, dest_group.input_bit_num, FOLD_AXON_MAX
+                )
+                if invalid_axon is not None:
+                    skew, field_value = invalid_axon
+                    print(
+                        f"{prefix}Fold axon skew {skew} maps to {field_value}, "
+                        f"outside [0, {FOLD_AXON_MAX}], skipping fold."
+                    )
                     continue
 
                 attrs_part2s = [neu.attrs_part2() for neu in sub_neurons]

--- a/tests/backendv2/test_mapper.py
+++ b/tests/backendv2/test_mapper.py
@@ -14,9 +14,11 @@ from paicorelib import (
     DataSign,
     DataWidth,
     NeuronType,
+    OfflineNeuRegLimV2,
     WeightCompressType,
     find_coordxy_shortest_path,
 )
+from spikingjelly.activation_based import neuron
 from torch import nn
 
 from paibox.backendv2 import routing as routing_mod
@@ -183,6 +185,24 @@ class DefaultSparseHalfReuseLinear(nn.Module):
 
     def forward(self, x):
         return self.linear(x)
+
+
+class ConvIfAvgPoolWithNegativeFoldAxonCandidate(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(6, 32, 3, padding=1, bias=True)
+        self.ifn = neuron.IFNode(v_threshold=127.0)
+        self.avg = nn.AvgPool2d(2)
+        with torch.no_grad():
+            self.conv.weight.zero_()
+            self.conv.bias.zero_()
+            for oc in range(32):
+                channels = [(oc + i) % 6 for i in range(2 + oc % 5)]
+                for idx, ic in enumerate(channels):
+                    self.conv.weight[oc, ic, 1, 1] = 1 if idx % 2 == 0 else -1
+
+    def forward(self, x):
+        return self.avg(self.ifn(self.conv(x)))
 
 
 class Uint8HighIndexDenseCandidateLinear(nn.Module):
@@ -515,6 +535,36 @@ def test_mapper_default_sparse_csc_half_reuse_is_true_sparse_csc(tmp_path):
     assert placements[1].neu_attrs_part1.weight_address_end == (
         placements[0].neu_attrs_part1.weight_address_end
     )
+
+
+def test_mapper_skips_negative_fold_axon_skew_candidate(tmp_path):
+    graph = compile_to_paiir(
+        ConvIfAvgPoolWithNegativeFoldAxonCandidate().eval(),
+        torch.zeros(1, 6, 16, 16),
+        input_formats={"InputNode_0": (DataSign.UNSIGNED, DataWidth.WIDTH_8BIT)},
+        timesteps=1,
+        auto_reset=True,
+        output_approx="sum_approx_if_avgpool",
+        strict=True,
+    )
+    mapper = Mapper()
+    mapper.compile(graph, tmp_path, target_platform="x86", debug=False)
+
+    assert mapper.coreplacements
+    placements = _shared_sparse_linear_neuron_placements(mapper)
+    folded_attrs = [
+        placement.folded_neu_attrs_part1
+        for placement in placements
+        if placement.folded_neu_attrs_part1 is not None
+    ]
+    assert folded_attrs
+    for attrs in folded_attrs:
+        assert 0 <= attrs.fold_axon_y <= OfflineNeuRegLimV2.FOLD_AXON_MAX
+        assert 0 <= attrs.fold_axon_x <= OfflineNeuRegLimV2.FOLD_AXON_MAX
+        assert 0 <= attrs.fold_axon_xy <= OfflineNeuRegLimV2.FOLD_AXON_MAX
+        assert 0 <= attrs.fold_skew_y <= OfflineNeuRegLimV2.FOLD_SKEW_MAX
+        assert 0 <= attrs.fold_skew_x <= OfflineNeuRegLimV2.FOLD_SKEW_MAX
+        assert 0 <= attrs.fold_skew_xy <= OfflineNeuRegLimV2.FOLD_SKEW_MAX
 
 
 def test_mapper_does_not_fold_neurons_with_different_part2_attrs(tmp_path):

--- a/tests/backendv2/test_mapper.py
+++ b/tests/backendv2/test_mapper.py
@@ -406,7 +406,7 @@ def test_mapper_builds_output_completion_plan_without_full_compile(monkeypatch):
 
     assert plan.global_signal_root == CoordXY(0, 2)
     assert plan.root_kind == "empty_offline"
-    assert plan.data_penalty == 2
+    assert plan.score.data_penalty == 2
     assert {route.target_coord for route in plan.output_routes} == {CoordXY(0, 0)}
 
 

--- a/tests/backendv2/test_output_completion.py
+++ b/tests/backendv2/test_output_completion.py
@@ -21,9 +21,10 @@ def _all_empty_offline_except(*used: CoordXY) -> set[CoordXY]:
 
 
 def _assert_control_loop_cost_fields(plan) -> None:
-    assert plan.score.cpu_to_root_path_len == find_coordxy_shortest_path(
-        plan.global_signal_root
-    )[1]
+    assert (
+        plan.score.cpu_to_root_path_len
+        == find_coordxy_shortest_path(plan.global_signal_root)[1]
+    )
     assert plan.score.complete_path_len == route_len(plan.control_offset)
     assert (
         plan.score.control_loop_cost

--- a/tests/backendv2/test_output_completion.py
+++ b/tests/backendv2/test_output_completion.py
@@ -1,6 +1,7 @@
 import pytest
-from paicorelib import CoordXY
+from paicorelib import CoordXY, find_coordxy_shortest_path
 
+from paibox.backendv2.global_signal import GlobalSignalTree
 from paibox.backendv2.output_completion import (
     OutputCompletionNoFeasiblePlanError,
     OutputProducer,
@@ -19,6 +20,19 @@ def _all_empty_offline_except(*used: CoordXY) -> set[CoordXY]:
     }
 
 
+def _assert_control_loop_cost_fields(plan) -> None:
+    assert plan.score.cpu_to_root_path_len == find_coordxy_shortest_path(
+        plan.global_signal_root
+    )[1]
+    assert plan.score.complete_path_len == route_len(plan.control_offset)
+    assert (
+        plan.score.control_loop_cost
+        == plan.score.cpu_to_root_path_len
+        + 2 * plan.score.global_signal_tree_max_depth
+        + plan.score.complete_path_len
+    )
+
+
 def test_single_output_root_is_on_data_path_and_complete_path_is_suffix():
     producer = CoordXY(3, 4)
     cpu = CoordXY(0, 0)
@@ -35,12 +49,12 @@ def test_single_output_root_is_on_data_path_and_complete_path_is_suffix():
 
     assert plan.global_signal_root == producer
     assert plan.root_kind == "used"
-    assert plan.data_penalty == 0
+    assert plan.score.data_penalty == 0
     assert (
         route_coord_path(plan.global_signal_root, plan.control_offset)
         == data_path[root_index:]
     )
-    assert plan.complete_path_len == route_len(plan.control_offset)
+    _assert_control_loop_cost_fields(plan)
 
 
 def test_multi_output_selects_common_suffix_root():
@@ -56,13 +70,57 @@ def test_multi_output_selects_common_suffix_root():
     complete_path = route_coord_path(plan.global_signal_root, plan.control_offset)
     assert plan.global_signal_root == CoordXY(0, 1)
     assert plan.root_kind == "empty_offline"
-    assert plan.data_penalty == 1
+    assert plan.score.data_penalty == 1
     assert "minimum-penalty fallback" in plan.diagnostics[0]
+    _assert_control_loop_cost_fields(plan)
 
     for route in plan.output_routes:
         data_path = route_coord_path(route.producer_coord, route.offset)
         root_index = data_path.index(plan.global_signal_root)
         assert data_path[root_index:] == complete_path
+
+
+def test_control_loop_cost_ranks_tree_and_complete_path_together(monkeypatch):
+    producer = CoordXY(1, 4)
+    far_shallow_root = CoordXY(0, 3)
+    near_deeper_root = CoordXY(0, 1)
+
+    def fake_global_signal_tree(raw_points, root=None, verbose=False):
+        del raw_points, verbose
+        assert root is not None
+        depth_by_root = {
+            producer: 5,
+            far_shallow_root: 1,
+            near_deeper_root: 2,
+        }
+        return GlobalSignalTree(
+            root=root,
+            order=[root],
+            added=[],
+            send_directions={},
+            max_depth=depth_by_root.get(root, 99),
+            total_edges=4,
+        )
+
+    monkeypatch.setattr(
+        "paibox.backendv2.output_completion.solve_global_signal_tree",
+        fake_global_signal_tree,
+    )
+
+    plan = select_output_completion_plan(
+        [OutputProducer(producer, CoordXY(0, 0), 1)],
+        {producer, far_shallow_root, near_deeper_root},
+        _all_empty_offline_except(producer, far_shallow_root, near_deeper_root),
+    )
+
+    assert plan.global_signal_root == near_deeper_root
+    assert plan.root_kind == "used"
+    assert plan.score.data_penalty == 0
+    assert plan.score.global_signal_tree_max_depth == 2
+    assert plan.score.global_signal_tree_total_edges == 4
+    assert plan.score.cpu_to_root_path_len == 1
+    assert plan.score.complete_path_len == 1
+    assert plan.score.control_loop_cost == 6
 
 
 @pytest.mark.parametrize(
@@ -98,7 +156,7 @@ def test_used_root_priority_for_equal_data_penalty(
 
     assert plan.global_signal_root == producer
     assert plan.root_kind == "used"
-    assert plan.data_penalty == 0
+    assert plan.score.data_penalty == 0
     assert not plan.root_is_online_empty
 
 


### PR DESCRIPTION
## Summary

- Skip folded-neuron candidates whose weight or axon skew fields fall outside paicorelib register limits.
- Rank output-completion roots by combined control-loop cost after DATA path and root-kind priority.
- Group output-completion scoring diagnostics under `OutputCompletionScore`.
- Add regression coverage for invalid fold skew fallback and completion control-loop scoring.