### PR TITLE
Perf backendv2 weight

### DIFF
--- a/paibox/backendv2/coreplacement.py
+++ b/paibox/backendv2/coreplacement.py
@@ -54,7 +54,7 @@ class CorePlacement:
     def max_input_num(self) -> int:
         max_input_num = 0
         for weight in self.weights:
-            input_num = len(weight.processed_weights)
+            input_num = weight.processed_weights.size
             max_input_num = max(max_input_num, input_num)
         return max_input_num
 

--- a/paibox/backendv2/get_weight.py
+++ b/paibox/backendv2/get_weight.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections import defaultdict
 from dataclasses import dataclass
 
@@ -22,6 +20,9 @@ from ..paiir.ir import (
 from ..paiir.nn.pool import SumPool1d, SumPool2d
 from .op_node import CoreOpNode, Neuron, SourceElem, SourceNode
 from .weight import Weight
+
+FLOAT32_EXACT_INT_LIMIT = 1 << 24
+INT32_INDEX_LIMIT = np.iinfo(np.int32).max
 
 
 def feature_shape(shape: torch.Size | tuple[int, ...]) -> tuple[int, ...]:
@@ -121,6 +122,23 @@ def identity_weight_matrix(
     return matrix
 
 
+def _np_index_dtype(max_index: int) -> np.dtype[np.int32 | np.int64]:
+    return np.dtype(np.int32) if max_index <= INT32_INDEX_LIMIT else np.dtype(np.int64)
+
+
+def _torch_index_dtype(max_index: int) -> torch.dtype:
+    return torch.int32 if max_index <= INT32_INDEX_LIMIT else torch.int64
+
+
+def _index_dtype_for_elems(elems_by_target: dict) -> np.dtype[np.int32 | np.int64]:
+    max_index = 0
+    for elems in elems_by_target.values():
+        for first, second in elems:
+            max_index = max(max_index, first, second)
+
+    return _np_index_dtype(max_index)
+
+
 def unfold_input_indices_2d(
     channels: int,
     spatial_shape: tuple[int, int],
@@ -133,11 +151,12 @@ def unfold_input_indices_2d(
     # flattened input indices. Zero means "came from padding".
     height, width = spatial_shape
     n_input = channels * height * width
-    input_ids = torch.arange(1, n_input + 1, dtype=torch.float64).reshape(
+    index_dtype = torch.float32 if n_input <= FLOAT32_EXACT_INT_LIMIT else torch.float64
+    input_ids = torch.arange(1, n_input + 1, dtype=index_dtype).reshape(
         1, channels, height, width
     )
     patches = F.unfold(input_ids, kernel_size, dilation, padding, stride)
-    return patches.to(torch.int64).squeeze(0)
+    return patches.to(_torch_index_dtype(n_input)).squeeze(0)
 
 
 def conv2d_weight_matrix(
@@ -185,15 +204,15 @@ def conv2d_weight_matrix(
             f"Conv unfold mismatch: expected {out_size} output positions, got {patches.shape[1]}."
         )
 
+    kernel_elems = in_channels_per_group * kernel_height * kernel_width
     row_offsets = np.tile(
-        np.arange(out_size, dtype=np.int64),
-        in_channels_per_group * kernel_height * kernel_width,
+        np.arange(out_size, dtype=_np_index_dtype(out_size - 1)), kernel_elems
     )
 
     for out_channel in range(out_channels):
         group_idx = out_channel // out_channels_per_group
         patch_start = group_idx * in_channels_per_group * kernel_height * kernel_width
-        patch_end = patch_start + in_channels_per_group * kernel_height * kernel_width
+        patch_end = patch_start + kernel_elems
 
         # Scatter each kernel coefficient to the input positions that feed the
         # corresponding flattened output locations.
@@ -246,7 +265,9 @@ def pool2d_weight_matrix(
         )
 
     kernel_elems = int(np.prod(kernel_size))
-    row_offsets = np.tile(np.arange(out_size, dtype=np.int64), kernel_elems)
+    row_offsets = np.tile(
+        np.arange(out_size, dtype=_np_index_dtype(out_size - 1)), kernel_elems
+    )
 
     for channel in range(channels):
         patch_start = channel * kernel_elems
@@ -695,10 +716,11 @@ def build_weights(
         input_group[elem.target].append((j, elem.index.idx))
 
     input_map = {}
+    index_dtype = _index_dtype_for_elems(input_group)
 
     for tgt, elems in input_group.items():
-        js = np.fromiter((j for j, _ in elems), dtype=np.int64)
-        idxs = np.fromiter((idx for _, idx in elems), dtype=np.int64)
+        js = np.fromiter((j for j, _ in elems), dtype=index_dtype)
+        idxs = np.fromiter((idx for _, idx in elems), dtype=index_dtype)
         input_map[tgt] = (js, idxs)
 
     for i, neu in enumerate(raw_neus):
@@ -760,9 +782,10 @@ def build_weights_numba(
         input_group[elem.target].append((j, elem.index.idx))
 
     input_map = {}
+    input_index_dtype = _index_dtype_for_elems(input_group)
     for tgt, elems in input_group.items():
-        js = np.fromiter((j for j, _ in elems), dtype=np.int32)
-        idxs = np.fromiter((idx for _, idx in elems), dtype=np.int32)
+        js = np.fromiter((j for j, _ in elems), dtype=input_index_dtype)
+        idxs = np.fromiter((idx for _, idx in elems), dtype=input_index_dtype)
         input_map[tgt] = (js, idxs)
 
     # -------- 2. output grouping --------
@@ -771,9 +794,10 @@ def build_weights_numba(
         output_group[neu.target].append((i, neu.index.idx))
 
     output_map = {}
+    output_index_dtype = _index_dtype_for_elems(output_group)
     for tgt, elems in output_group.items():
-        is_ = np.fromiter((i for i, _ in elems), dtype=np.int32)
-        idxs = np.fromiter((idx for _, idx in elems), dtype=np.int32)
+        is_ = np.fromiter((i for i, _ in elems), dtype=output_index_dtype)
+        idxs = np.fromiter((idx for _, idx in elems), dtype=output_index_dtype)
         output_map[tgt] = (is_, idxs)
 
     # -------- 3. flatten cache + 构建任务 --------

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -440,12 +440,10 @@ class RoutingGroup(
         # Weight Strategy
         if weight_info.index not in stored_base_weight:
             # 这个 base weight 还没有存储过，需要存储
-            current_weight_width = frontend_core_conf.weight_width
             base_weight = base_weights[weight_info.index]
-            current_weight_width = frontend_core_conf.weight_width
             selected_weight, weight_compress = choose_weight_strategy(
                 base_weight,
-                current_weight_width,
+                frontend_core_conf.weight_width,
                 frontend_core_conf.input_width,
                 frontend_core_conf.add_potential,
             )
@@ -638,11 +636,10 @@ class RoutingGroup(
                     continue
 
                 if index not in weight_strategy_cache:
-                    current_weight_width = frontend_core_conf.weight_width
                     base_weight = base_weights[index]
                     selected_weight, weight_compress = choose_weight_strategy(
                         base_weight,
-                        current_weight_width,
+                        frontend_core_conf.weight_width,
                         frontend_core_conf.input_width,
                         frontend_core_conf.add_potential,
                     )

--- a/paibox/backendv2/weight.py
+++ b/paibox/backendv2/weight.py
@@ -1,6 +1,8 @@
 from collections.abc import Sequence
+from math import ceil
 
 import numpy as np
+from numpy.typing import ArrayLike
 from paicorelib import (
     AddPotentialMode,
     DataWidth,
@@ -20,60 +22,50 @@ N_WEIGHTS_PER_SRAM = {
 class Weight:
     def __init__(
         self,
-        data: np.ndarray | list[int],
+        data: ArrayLike,
         compress_type: WeightCompressType,
         weight_width: DataWidth,
         input_width: DataWidth,
         AddPotential: AddPotentialMode = AddPotentialMode.NORMAL,
-    ):
+    ) -> None:
+        raw_weights = np.asarray(data, dtype=np.int16).ravel()
+
         if AddPotential == AddPotentialMode.DIRECT_ADD:
             # in direct add mode, weight width should be at least 4 bit to avoid overflow
             weight_width = DataWidth.WIDTH_1BIT
             input_width = DataWidth.WIDTH_1BIT
-            if isinstance(data, list):
-                data = np.array(data, dtype=np.int16)
-            data = data.astype(np.int16)  # ensure weight is in int16 to avoid overflow
-            data = np.repeat(
-                data, 32
-            )  # each one in original weight repeat 32 times to form mask for direct add mode
+            # each one in original weight repeat 32 times to form mask for direct add mode
+            raw_weights = np.repeat(raw_weights, 32)
 
-        if isinstance(data, np.ndarray):
-            self.raw_weights: list[int] = data.tolist()
-        else:
-            self.raw_weights: list[int] = list(data)
-
+        self.raw_weights = raw_weights
         self.weight_width = weight_width
         self.input_width = input_width
 
-        self.compress: bool = (
-            compress_type == WeightCompressType.SPARSE
-        )  # whether the weight is compressed
+        # whether the weight is compressed
+        self.compress = compress_type == WeightCompressType.SPARSE
 
-        # processed weights remove zero at the end if not compressed
-        self.processed_weights: list[int] = self.raw_weights.copy()
-        # remove zero at the end of raw weights
-        while len(self.processed_weights) > 0 and self.processed_weights[-1] == 0:
-            self.processed_weights.pop()
+        nonzero_indices = np.flatnonzero(self.raw_weights)
+        n_nonzero = nonzero_indices.size
+        end = nonzero_indices[-1] + 1 if n_nonzero > 0 else 0
 
-        self.n_sram_required = self.n_sram_required_()
+        self.processed_weights = self.raw_weights[:end]
+        self.n_sram_required = self.get_n_sram_required(n_nonzero)
 
-    def n_sram_required_(self) -> int:
-        if not self.compress:
-            return (len(self.processed_weights) * (2**self.weight_width) + 127) // 128
-
-        else:
-            # non zero weight in raw weights
-            n_non_zero = sum(1 for w in self.raw_weights if w != 0)
+    def get_n_sram_required(self, n_nonzero: int) -> int:
+        if self.compress:
             n_weight_per_sram = N_WEIGHTS_PER_SRAM.get(self.weight_width, 0)
             if n_weight_per_sram == 0:
                 raise ValueError(
-                    f"Unsupported weight width for compression: {self.weight_width}"
+                    f"Unsupported weight width for compression: {self.weight_width.name}"
                 )
-            return (n_non_zero + n_weight_per_sram - 1) // n_weight_per_sram
+            return ceil(n_nonzero / n_weight_per_sram)
+        else:
+            n_weight_per_sram = 128 >> self.weight_width
+            return ceil(self.processed_weights.size / n_weight_per_sram)
 
     def to_package(self, weight_skews: Sequence[int] | None = None) -> FrameArrayType:
         return OfflineFrameGenV2.gen_config_frame3_weight_pkg(
-            np.array(self.processed_weights),
+            self.processed_weights,
             weight_width=self.weight_width,
             input_width=self.input_width,
             csc_compress=self.compress,

--- a/paibox/backendv2/weight.py
+++ b/paibox/backendv2/weight.py
@@ -74,8 +74,8 @@ class Weight:
     def to_package(self, weight_skews: Sequence[int] | None = None) -> FrameArrayType:
         return OfflineFrameGenV2.gen_config_frame3_weight_pkg(
             np.array(self.processed_weights),
-            self.input_width,
-            self.weight_width,
-            self.compress,
+            weight_width=self.weight_width,
+            input_width=self.input_width,
+            csc_compress=self.compress,
             weight_skews=weight_skews,
         )

--- a/tests/backendv2/test_get_weight.py
+++ b/tests/backendv2/test_get_weight.py
@@ -8,14 +8,20 @@ from torch import nn
 from torch.nn import functional as F
 
 from paibox.backendv2.get_weight import (
+    INT32_INDEX_LIMIT,
     _adaptive_pool_window_bounds,
+    _index_dtype_for_elems,
+    _np_index_dtype,
+    _torch_index_dtype,
     adaptive_avgpool1d_weight_matrix,
     adaptive_avgpool2d_weight_matrix,
     adaptive_maxpool1d_weight_matrix,
     adaptive_maxpool2d_weight_matrix,
     choose_weight_strategy,
+    conv2d_weight_matrix,
     expanded_path_weight_matrix,
     group_shift_weights_optimized,
+    unfold_input_indices_2d,
 )
 from paibox.backendv2.op_node import CoreOpNode, InNode
 from paibox.backendv2.weight import Weight
@@ -54,6 +60,25 @@ def _standalone_comp(comp: nn.Module) -> StandaloneCompOp:
     raw_node.core_params.tick_duration = 0
     raw_node.core_params.tick_initial = 1
     return raw_node
+
+
+def _conv2d_output_shape(
+    input_shape: tuple[int, int, int],
+    kernel_shape: tuple[int, int],
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+    out_channels: int,
+) -> tuple[int, int, int]:
+    _, height, width = input_shape
+    kernel_height, kernel_width = kernel_shape
+    out_height = (
+        height + 2 * padding[0] - dilation[0] * (kernel_height - 1) - 1
+    ) // stride[0] + 1
+    out_width = (
+        width + 2 * padding[1] - dilation[1] * (kernel_width - 1) - 1
+    ) // stride[1] + 1
+    return out_channels, out_height, out_width
 
 
 @dataclass(frozen=True)
@@ -115,6 +140,68 @@ def test_adaptive_pool_window_bounds_matches_pytorch_formula():
         (4, 6),
         (6, 8),
     ]
+
+
+def test_index_dtype_helpers_default_to_int32_and_fallback_to_int64():
+    assert _np_index_dtype(INT32_INDEX_LIMIT) == np.int32
+    assert _np_index_dtype(INT32_INDEX_LIMIT + 1) == np.int64
+    assert _torch_index_dtype(INT32_INDEX_LIMIT) is torch.int32
+    assert _torch_index_dtype(INT32_INDEX_LIMIT + 1) is torch.int64
+    assert _index_dtype_for_elems({"a": [(1, 2)], "b": [(3, 4)]}) == np.int32
+    assert _index_dtype_for_elems({"a": [(1, INT32_INDEX_LIMIT + 1)]}) == np.int64
+
+
+def test_unfold_input_indices_2d_uses_int32_for_normal_input_size():
+    patches = unfold_input_indices_2d(
+        1, (4, 4), kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), dilation=(1, 1)
+    )
+
+    assert patches.dtype is torch.int32
+    assert patches.shape == (9, 16)
+    assert int(patches.max().item()) == 16
+
+
+def test_conv2d_weight_matrix_matches_grouped_pytorch_conv2d():
+    input_shape = (4, 5, 6)
+    weight = torch.tensor(
+        [
+            [[[1, 0], [0, -2], [3, 0]], [[0, 1], [0, 0], [-1, 2]]],
+            [[[0, 0], [2, 0], [0, 0]], [[-2, 0], [0, 1], [0, 0]]],
+            [[[1, 1], [0, 0], [2, 0]], [[0, -1], [0, 0], [1, 0]]],
+            [[[0, 0], [0, 0], [0, 0]], [[1, 0], [0, -1], [0, 2]]],
+        ],
+        dtype=torch.float32,
+    )
+    stride = (2, 1)
+    padding = (1, 0)
+    dilation = (1, 1)
+    groups = 2
+    output_shape = _conv2d_output_shape(
+        input_shape, (3, 2), stride, padding, dilation, out_channels=4
+    )
+
+    matrix = conv2d_weight_matrix(
+        weight, input_shape, output_shape, stride, padding, dilation, groups, sign=-1
+    )
+    input_tensor = torch.arange(
+        1, 1 + int(np.prod(input_shape)), dtype=torch.float32
+    ).reshape(1, *input_shape)
+
+    actual = matrix @ input_tensor.numpy().reshape(-1)
+    expected = (
+        -F.conv2d(
+            input_tensor,
+            weight,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+        )
+        .numpy()
+        .reshape(-1)
+    )
+
+    np.testing.assert_array_equal(actual, expected)
 
 
 def test_adaptive_maxpool2d_weight_matrix_irregular_windows():
@@ -224,21 +311,76 @@ def test_expanded_path_weight_matrix_handles_adaptive_pool(case: ExpandedPathCas
     assert _active_cols(matrix[case.probe_row]) == case.expected_cols
 
 
-def test_group_shift_weights_default_still_reuses_shifted_base_rows():
-    raw_weights = [
-        np.array([0, 0, 3, 0, 5, 0], dtype=np.int16),
-        np.array([0, 3, 0, 5, 0, 0], dtype=np.int16),
-    ]
+def _expected_shifted_base(row: np.ndarray) -> tuple[int, np.ndarray]:
+    nonzero = np.flatnonzero(row)
+    offset = int(nonzero[0]) if nonzero.size else 0
+    base = np.zeros_like(row)
+    base[: row.size - offset] = row[offset:]
+    return offset, base
+
+
+@pytest.mark.parametrize(
+    "raw_weights, expected_base_count",
+    [
+        (
+            [
+                np.array([0, 0, 3, 0, 5, 0], dtype=np.int16),
+                np.array([0, 3, 0, 5, 0, 0], dtype=np.int16),
+            ],
+            1,
+        ),
+        (
+            [
+                np.zeros(6, dtype=np.int16),
+                np.zeros(6, dtype=np.int16),
+                np.array([0, 0, 1, 0, 0, 0], dtype=np.int16),
+            ],
+            2,
+        ),
+        (
+            [
+                np.array([0, 1, 2, 0], dtype=np.int8),
+                np.array([0, 0, 1, 2], dtype=np.int8),
+                np.array([1, 2, 0, 0], dtype=np.int8),
+            ],
+            1,
+        ),
+        (
+            [
+                np.array([0, -3, 0, 5, 0], dtype=np.int16),
+                np.array([0, 0, -3, 0, 5], dtype=np.int16),
+                np.array([0, 0, 7, 0, 5], dtype=np.int16),
+            ],
+            2,
+        ),
+    ],
+)
+def test_group_shift_weights_preserves_shifted_base_semantics(
+    raw_weights: list[np.ndarray], expected_base_count: int
+):
+    expected = [_expected_shifted_base(row) for row in raw_weights]
 
     infos, base_weights = group_shift_weights_optimized(raw_weights)
 
-    assert [info.offset for info in infos] == [2, 1]
-    assert [info.index for info in infos] == [0, 0]
-    assert len(base_weights) == 1
-    np.testing.assert_array_equal(
-        base_weights[0],
-        np.array([3, 0, 5, 0, 0, 0], dtype=np.int16),
-    )
+    assert [info.offset for info in infos] == [offset for offset, _ in expected]
+    assert len(base_weights) == expected_base_count
+    for info, (_offset, expected_base) in zip(infos, expected):
+        np.testing.assert_array_equal(base_weights[info.index], expected_base)
+
+
+def test_group_shift_weights_random_int8_matches_reference():
+    rng = np.random.default_rng(12345)
+    raw_weights = [rng.integers(-4, 5, size=32, dtype=np.int8) for _ in range(16)]
+    raw_weights[3] = np.roll(raw_weights[0], 2)
+    raw_weights[3][:2] = 0
+
+    infos, base_weights = group_shift_weights_optimized(raw_weights)
+
+    assert all(base.dtype == np.int8 for base in base_weights)
+    for row, info in zip(raw_weights, infos):
+        expected_offset, expected_base = _expected_shifted_base(row)
+        assert info.offset == expected_offset
+        np.testing.assert_array_equal(base_weights[info.index], expected_base)
 
 
 def test_choose_weight_strategy_sparse_keeps_original_row():
@@ -246,14 +388,11 @@ def test_choose_weight_strategy_sparse_keeps_original_row():
     weight[[17, 18, 31]] = [3, 4, 5]
 
     selected, compress = choose_weight_strategy(
-        weight,
-        DataWidth.WIDTH_8BIT,
-        DataWidth.WIDTH_8BIT,
-        AddPotentialMode.NORMAL,
+        weight, DataWidth.WIDTH_8BIT, DataWidth.WIDTH_8BIT, AddPotentialMode.NORMAL
     )
 
     assert selected.compress
-    np.testing.assert_array_equal(selected.raw_weights, weight.tolist())
+    np.testing.assert_array_equal(selected.raw_weights, weight)
     assert compress == WeightCompressType.SPARSE
 
 
@@ -276,10 +415,7 @@ def test_choose_weight_strategy_dense_candidate_depends_on_sram_savings(
     weight[[0, last_dense_candidate_index]] = [1, 2]
 
     selected, compress = choose_weight_strategy(
-        weight,
-        DataWidth.WIDTH_8BIT,
-        input_width,
-        AddPotentialMode.NORMAL,
+        weight, DataWidth.WIDTH_8BIT, input_width, AddPotentialMode.NORMAL
     )
 
     assert compress == expected_compress
@@ -290,14 +426,11 @@ def test_choose_weight_strategy_dense_tie_remains_dense():
     weight = np.array([1, 2, 3, 4, 5], dtype=np.int16)
 
     selected, compress = choose_weight_strategy(
-        weight,
-        DataWidth.WIDTH_8BIT,
-        DataWidth.WIDTH_8BIT,
-        AddPotentialMode.NORMAL,
+        weight, DataWidth.WIDTH_8BIT, DataWidth.WIDTH_8BIT, AddPotentialMode.NORMAL
     )
 
     assert not selected.compress
-    assert selected.raw_weights == [1, 2, 3, 4, 5]
+    np.testing.assert_array_equal(selected.raw_weights, [1, 2, 3, 4, 5])
     assert compress == WeightCompressType.DENSE
 
 
@@ -306,14 +439,11 @@ def test_choose_weight_strategy_single_tap_uses_sparse_when_sram_smaller():
     weight[128] = 1
 
     selected, compress = choose_weight_strategy(
-        weight,
-        DataWidth.WIDTH_1BIT,
-        DataWidth.WIDTH_8BIT,
-        AddPotentialMode.NORMAL,
+        weight, DataWidth.WIDTH_1BIT, DataWidth.WIDTH_8BIT, AddPotentialMode.NORMAL
     )
 
     assert selected.compress
-    assert selected.raw_weights == weight.tolist()
+    np.testing.assert_array_equal(selected.raw_weights, weight)
     assert compress == WeightCompressType.SPARSE
     assert selected.to_package(weight_skews=(0,)).size == 2
 
@@ -348,14 +478,11 @@ def test_choose_weight_strategy_uint8_high_index_uses_sparse_csc_original_row():
     weight[[144, 146]] = [1, 2]
 
     selected, compress = choose_weight_strategy(
-        weight,
-        DataWidth.WIDTH_8BIT,
-        DataWidth.WIDTH_8BIT,
-        AddPotentialMode.NORMAL,
+        weight, DataWidth.WIDTH_8BIT, DataWidth.WIDTH_8BIT, AddPotentialMode.NORMAL
     )
 
     assert selected.compress
-    assert selected.raw_weights == weight.tolist()
+    np.testing.assert_array_equal(selected.raw_weights, weight)
     assert compress == WeightCompressType.SPARSE
 
 
@@ -364,12 +491,9 @@ def test_choose_weight_strategy_uint8_long_span_row_still_uses_sparse_if_smaller
     weight[[7, 136]] = [1, 2]
 
     selected, compress = choose_weight_strategy(
-        weight,
-        DataWidth.WIDTH_8BIT,
-        DataWidth.WIDTH_8BIT,
-        AddPotentialMode.NORMAL,
+        weight, DataWidth.WIDTH_8BIT, DataWidth.WIDTH_8BIT, AddPotentialMode.NORMAL
     )
 
     assert selected.compress
-    assert selected.raw_weights == weight.tolist()
+    np.testing.assert_array_equal(selected.raw_weights, weight)
     assert compress == WeightCompressType.SPARSE

--- a/tests/backendv2/test_mapper.py
+++ b/tests/backendv2/test_mapper.py
@@ -561,7 +561,9 @@ def test_mapper_default_auto_strategy_mixes_sparse_and_dense_csc(tmp_path):
     assert [weight.compress for weight in core.weights] == [True, True, False]
     assert np.flatnonzero(core.weights[0].raw_weights).tolist() == [0, 24, 64]
     assert np.flatnonzero(core.weights[1].raw_weights).tolist() == [0, 128]
-    assert core.weights[2].processed_weights == [1, 0, 1, 0, 1, 0, 1, 0, 1]
+    assert np.array_equal(
+        core.weights[2].processed_weights, [1, 0, 1, 0, 1, 0, 1, 0, 1]
+    )
     assert [placement.neu_attrs_part1.weight_skew for placement in placements] == [
         16,
         0,
@@ -723,7 +725,7 @@ def test_mapper_default_uint8_high_index_shifted_base_tie_uses_dense(tmp_path):
     assert core.default_core_config.csc_accelerate == CSCAccelerateMode.ENABLE
     assert len(core.weights) == 1
     assert not core.weights[0].compress
-    assert core.weights[0].processed_weights == [1, 0, 1]
+    np.testing.assert_array_equal(core.weights[0].processed_weights, [1, 0, 1])
     assert [placement.neuron_type for placement in placements] == [
         NeuronType.FULL,
         NeuronType.HALF,


### PR DESCRIPTION
## Summary

- Use NumPy arrays for backendv2 `Weight` storage and vectorize trailing-zero trim / nonzero counting.
- Narrow backendv2 index buffers to `int32` when safe, with automatic `int64` fallback for large indices.
- Update affected tests for ndarray-backed weight data and add coverage for shifted base-weight reuse semantics.