### PR TITLE
feat(backendv2): support scoped route solving

### DIFF
--- a/paibox/backendv2/global_signal.py
+++ b/paibox/backendv2/global_signal.py
@@ -8,6 +8,10 @@ from paicorelib import (
     CoordXYUnitVec,
     CoordZXYOffset,
     find_coordxy_shortest_path,
+    global_signal_direction_mask,
+    global_signal_direction_name,
+    global_signal_directions,
+    global_signal_opposite_direction,
 )
 
 from .coreplacement import (
@@ -22,39 +26,6 @@ EmptyRelayCoreKind = Literal["offline", "online"]
 GlobalSignalEdge = tuple[CoordXY, CoordXYUnitVec]
 GlobalSignalAdjacency = dict[CoordXY, list[GlobalSignalEdge]]
 GlobalSignalUnitVecMap = dict[CoordXY, list[CoordXYUnitVec]]
-
-GLOBAL_SIGNAL_DIRECTIONS: list[CoordXYUnitVec] = [
-    CoordXYUnitVec.Z_POS,
-    CoordXYUnitVec.Z_NEG,
-    CoordXYUnitVec.X_POS,
-    CoordXYUnitVec.X_NEG,
-    CoordXYUnitVec.Y_POS,
-    CoordXYUnitVec.Y_NEG,
-]
-OPPOSITE_GLOBAL_SIGNAL_DIRECTION: dict[CoordXYUnitVec, CoordXYUnitVec] = {
-    CoordXYUnitVec.Z_POS: CoordXYUnitVec.Z_NEG,
-    CoordXYUnitVec.Z_NEG: CoordXYUnitVec.Z_POS,
-    CoordXYUnitVec.X_POS: CoordXYUnitVec.X_NEG,
-    CoordXYUnitVec.X_NEG: CoordXYUnitVec.X_POS,
-    CoordXYUnitVec.Y_POS: CoordXYUnitVec.Y_NEG,
-    CoordXYUnitVec.Y_NEG: CoordXYUnitVec.Y_POS,
-}
-GLOBAL_SIGNAL_DIRECTION_BIT: dict[CoordXYUnitVec, int] = {
-    CoordXYUnitVec.Z_POS: 5,  # +xy
-    CoordXYUnitVec.Z_NEG: 4,  # -xy
-    CoordXYUnitVec.X_POS: 3,  # +x
-    CoordXYUnitVec.X_NEG: 2,  # -x
-    CoordXYUnitVec.Y_POS: 1,  # +y
-    CoordXYUnitVec.Y_NEG: 0,  # -y
-}
-GLOBAL_SIGNAL_DIRECTION_NAME: dict[CoordXYUnitVec, str] = {
-    CoordXYUnitVec.Z_POS: "+xy",
-    CoordXYUnitVec.Z_NEG: "-xy",
-    CoordXYUnitVec.X_POS: "+x",
-    CoordXYUnitVec.X_NEG: "-x",
-    CoordXYUnitVec.Y_POS: "+y",
-    CoordXYUnitVec.Y_NEG: "-y",
-}
 
 
 @dataclass(frozen=True)
@@ -104,7 +75,7 @@ def path_coords(a: CoordXY, b: CoordXY) -> list[CoordXY]:
     for _ in range(steps):
         remaining_steps = hex_steps(current, b)
         chosen = None
-        for direction in GLOBAL_SIGNAL_DIRECTIONS:
+        for direction in global_signal_directions():
             neighbor = neighbor_coord(current, direction)
             if hex_steps(neighbor, b) == remaining_steps - 1:
                 chosen = direction
@@ -143,7 +114,7 @@ def solve_global_signal_tree(
 
     dsu = DSU(points)
     for p in points:
-        for direction in GLOBAL_SIGNAL_DIRECTIONS:
+        for direction in global_signal_directions():
             q = neighbor_coord(p, direction)
             if q in points:
                 dsu.union(p, q)
@@ -186,7 +157,7 @@ def solve_global_signal_tree(
     adj: defaultdict[CoordXY, list[GlobalSignalEdge]] = defaultdict(list)
     for p in points:
         adj[p]
-        for direction in GLOBAL_SIGNAL_DIRECTIONS:
+        for direction in global_signal_directions():
             q = neighbor_coord(p, direction)
             if q in points:
                 adj[p].append((q, direction))
@@ -236,17 +207,33 @@ def print_solution(
     print("added empty cores:", added)
     print("send directions:")
     for p, ds in moves.items():
-        print(f"  {p} -> {[GLOBAL_SIGNAL_DIRECTION_NAME[d] + f':{d}' for d in ds]}")
+        print(f"  {p} -> {[global_signal_direction_name(d) + f':{d}' for d in ds]}")
 
 
 def set_global_signal(
     coreplacements: list[CorePlacement],
     global_signal_root: CoordXY | None = None,
     relay_core_kinds: Mapping[CoordXY, EmptyRelayCoreKind] | None = None,
+    cpu_coord: CoordXY = CoordXY(0, 0),
     verbose: bool = False,
 ) -> tuple[list[CorePlacement], dict[int, CoordZXYOffset]]:
-    # Global signal currently covers one thread and one shared weight range.
+    """Configure global-signal routes for one backendv2 thread.
 
+    Args:
+        coreplacements: Existing configured cores that must receive the global
+            signal.
+        global_signal_root: Optional root coordinate for the global signal tree.
+            When omitted, the solver chooses a root from `coreplacements`.
+        relay_core_kinds: Empty relay-core kinds keyed by coordinate. Missing
+            relay coordinates default to offline empty cores.
+        cpu_coord: CPU endpoint coordinate used to encode the global-signal
+            start offset. Defaults to ``CoordXY(0, 0)``.
+        verbose: Whether to print the selected tree and start route.
+
+    Returns:
+        Updated core placements and per-placement global-signal start offsets.
+    """
+    # Global signal currently covers one thread and one shared weight range.
     points: list[CoordXY] = []
     cp_dict: dict[CoordXY, CorePlacement] = {}
     for cp in coreplacements:
@@ -282,36 +269,31 @@ def set_global_signal(
     for p, send_directions in send_info.items():
         for d in send_directions:
             dest = neighbor_coord(p, d)
-            receive_info[dest].append(OPPOSITE_GLOBAL_SIGNAL_DIRECTION[d])
+            receive_info[dest].append(global_signal_opposite_direction(d))
 
     if verbose:
         print("\nSend Direction:")
         for p, send_dirs in send_info.items():
             print(
                 f"    {p}: "
-                f"{[GLOBAL_SIGNAL_DIRECTION_NAME[d] + f':{d}' for d in send_dirs]}"
+                f"{[global_signal_direction_name(d) + f':{d}' for d in send_dirs]}"
             )
 
         print("\nReceive Direction:")
         for p, recv_dirs in receive_info.items():
             print(
                 f"    {p}: "
-                f"{[GLOBAL_SIGNAL_DIRECTION_NAME[d] + f':{d}' for d in recv_dirs]}"
+                f"{[global_signal_direction_name(d) + f':{d}' for d in recv_dirs]}"
             )
 
     added_points = set(added)
     for p, cp in cp_dict.items():
         send_directions = send_info.get(p, [])
         recv_directions = receive_info.get(p, [])
-        if p in added_points:
-            global_send = 0
-        else:
-            global_send = 1 << 6  # send to local core
-        global_receive = 0
-        for d in send_directions:
-            global_send |= 1 << GLOBAL_SIGNAL_DIRECTION_BIT[d]
-        for d in recv_directions:
-            global_receive |= 1 << GLOBAL_SIGNAL_DIRECTION_BIT[d]
+        global_send = global_signal_direction_mask(
+            send_directions, include_local=p not in added_points
+        )
+        global_receive = global_signal_direction_mask(recv_directions)
         cp.auto_core_config.global_send = global_send
         cp.auto_core_config.global_receive = global_receive
         if verbose:
@@ -321,7 +303,7 @@ def set_global_signal(
             )
 
     start_coord = order[0]
-    start_coord_offset, _ = find_coordxy_shortest_path(start_coord)
+    start_coord_offset, _ = find_coordxy_shortest_path(start_coord, start=cpu_coord)
     if verbose:
         print(f"Global signal start from {start_coord}")
         print(f"Global signal relative offset: {start_coord_offset}")

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from typing import Literal
 
-from paicorelib import CoordXY, CoordZXYOffset
+from paicorelib import CoordXY, CoordZXYOffset, find_coordxy_shortest_path
 
 from paibox.paiir import PAIIRGraph
 from paibox.paiir.ir import OfflineCoreOp
@@ -30,13 +30,13 @@ from .group_tile import tile_groups
 from .op_node import AllNode, InputElem, Neuron, RemapElem, SourceElem, build_nodes
 from .output_completion_planner import (
     OutputCompletionPlan,
-    OutputCpuIngressPlan,
     OutputProducer,
     select_output_completion_plan,
 )
 from .pressure_unroll import PressureUnrollConfig, PressureUnroller
 from .rg_build import build_groups
-from .route_solver import OFFLINE_CORE_COORDS, ONLINE_CORE_COORDS, route_solve
+from .route_scope import RouteScope, TargetBoard, get_route_scope
+from .route_solver import route_solve
 from .routing import InputGroup, OutputGroup, RemapGroup, RoutingGroup, toposort_for_rg
 
 
@@ -51,6 +51,7 @@ class Mapper:
         self.coreplacements: list[CorePlacement] = []
         self.global_starts: dict[int, CoordZXYOffset] = {}
         self.output_completion_plan: OutputCompletionPlan | None = None
+        self.route_scope: RouteScope = get_route_scope("single")
         self.timesteps: int = 1
 
     def _resolve_timesteps(self, pai_graph: PAIIRGraph, timesteps: int | None) -> int:
@@ -174,16 +175,11 @@ class Mapper:
 
         areas = [rg.n_core_required for rg in self.routing_groups]
         print(f"\ttotal cores needed: {sum(areas)}")
-        if sum(areas) > 63:
-            raise ValueError(
-                f"Total cores needed {sum(areas)} exceeds the limit of 63."
-            )
         copy_configs, coords = route_solve(
-            areas=areas,
-            next_area_id=self.next_rg_group,
-            io_target=(0, 0),
-            input_area_ids=[],
-            output_area_ids=[],
+            self.routing_groups,
+            self.next_rg_group,
+            self.input_groups,
+            self.route_scope,
             feasibility_only=feasibility_only,
             max_time_in_seconds=max_time_in_seconds,
         )
@@ -216,16 +212,17 @@ class Mapper:
             self.routing_groups,
             lambda: self.routing(feasibility_only=True, max_time_in_seconds=30),
             config,
+            self.route_scope,
         ).run()
 
-    def set_detail_dest(self, output_route_plan: OutputCpuIngressPlan) -> None:
+    def set_detail_dest(self, output_route_plan: OutputCompletionPlan) -> None:
         # Output collection still targets the CPU. The plan only overrides the
         # Z/X/Y decomposition so DATA and completion use the same CPU port.
         output_route_offsets = output_route_plan.output_route_offsets()
         for rg in self.routing_groups:
             rg.set_detail_dest(output_route_offsets)
         for in_grp in self.input_groups:
-            in_grp.set_detail_dest()
+            in_grp.set_detail_dest(self.route_scope.default_cpu.coord)
 
     def set_auto_core_config(
         self, control_root_coord: CoordXY, control_offset: CoordZXYOffset
@@ -239,7 +236,10 @@ class Mapper:
             if cp.coord == control_root_coord:
                 cp.set_auto_core_config(control_offset)
             else:
-                cp.set_auto_core_config()
+                test_offset, _ = find_coordxy_shortest_path(
+                    self.route_scope.default_cpu.coord, cp.coord
+                )
+                cp.set_auto_core_config(test_offset)
 
     def _collect_output_producers(self) -> list[OutputProducer]:
         producer_weights: dict[tuple[CoordXY, CoordXY], int] = {}
@@ -274,13 +274,13 @@ class Mapper:
         configured_thread_core_coords = {cp.coord for cp in self.coreplacements}
         empty_offline_coords = {
             coord
-            for coord in OFFLINE_CORE_COORDS
+            for coord in self.route_scope.offline_core_coords
             if coord not in configured_thread_core_coords
         }
         available_empty_online_coords = (
             {
                 coord
-                for coord in ONLINE_CORE_COORDS
+                for coord in self.route_scope.online_core_coords
                 if coord not in configured_thread_core_coords
             }
             if allow_empty_online_relay_core
@@ -292,6 +292,7 @@ class Mapper:
             empty_offline_coords,
             available_empty_online_coords,
             allow_empty_online_relay_core,
+            self.route_scope,
         )
 
     def add_output_completion_thread_cores(self, plan: OutputCompletionPlan) -> None:
@@ -359,6 +360,7 @@ class Mapper:
         literal_format: LiteralFormat = "bin",
         *,
         timesteps: int | None = None,
+        target_board: TargetBoard = "single",
         target_platform: TargetPlatform = "all",
         word_order: WordOrder = "high_first",
         export_merged_frames: bool = True,
@@ -391,6 +393,10 @@ class Mapper:
                 automatic-reset graphs is used first; otherwise a finite and
                 consistent output ``tick_duration`` is used. If neither is
                 available, it defaults to ``1``.
+            target_board: Fixed hardware board topology used by backendv2
+                routing and completion planning. ``"single"`` targets one
+                chip; ``"array_2x2"`` targets the fixed 2x2 chip array with
+                left-bottom CPU as the default endpoint.
             target_platform: Platform-specific artifact set to emit.
                 ``"x86"`` exports ``.npy`` frame arrays, ``"riscv"`` exports
                 C headers, and ``"all"`` exports both. When ``debug=True``,
@@ -433,6 +439,7 @@ class Mapper:
                 ``"fanin_margin"`` is a conservative fallback that reserves one
                 fanin slot during tiling and avoids generating the boundary case.
         """
+        self.route_scope = get_route_scope(target_board)
         self.timesteps = self._resolve_timesteps(pai_graph, timesteps)
 
         # determine raw_neus in routing groups, other properties remain unset
@@ -467,6 +474,7 @@ class Mapper:
 
         for out_grp in self.output_groups:
             out_grp.set_lcn(self.timesteps)
+            out_grp.set_base_coord(self.route_scope.default_cpu.coord)
 
         self.routing_groups = [
             grp for grp in self.groups if isinstance(grp, RoutingGroup)
@@ -505,19 +513,23 @@ class Mapper:
             self.coreplacements,
             self.output_completion_plan.global_signal_root,
             self.output_completion_plan.empty_thread_core_kinds(),
+            self.route_scope.default_cpu.coord,
         )
-
-        output_route_plan = self.output_completion_plan.to_cpu_ingress_plan()
 
         # The global-signal root uses the selected control offset. Other cores
         # keep their own local route to the same fixed CPU destination.
-        self.set_detail_dest(output_route_plan)
+        self.set_detail_dest(self.output_completion_plan)
         self.set_auto_core_config(
             self.output_completion_plan.global_signal_root,
-            output_route_plan.control_offset,
+            self.output_completion_plan.control_offset,
         )
 
-        # export to hardware executable format
+        # Export currently remains frame-coordinate driven. target_board is not
+        # written into proto/fbs metadata in this change to avoid widening the
+        # runtime schema contract before board-side consumers require it. Add a
+        # board field to the artifact schemas when runtime needs to reject
+        # mismatched artifacts, dispatch board-specific loaders, or distinguish
+        # multiple boards that can encode the same coordinate values differently.
         if output_path is None:
             env_output_path = os.environ.get("PAIBOX_OUTPUT_PATH")
             if env_output_path is not None:

--- a/paibox/backendv2/output_completion_planner.py
+++ b/paibox/backendv2/output_completion_planner.py
@@ -2,36 +2,24 @@
 
 from collections.abc import Iterable, Set
 from dataclasses import dataclass
+from functools import cache
 from itertools import chain
 from typing import Literal
 
-from paicorelib import CoordXY, CoordZXYOffset
+from paicorelib import CoordXY, CoordZXYOffset, route_coord_path, to_coordxys
 
-from .core_config import TEST_DEST_CORE
 from .global_signal import EmptyRelayCoreKind as EmptyThreadCoreKind
 from .global_signal import solve_global_signal_tree
-from .route_solver import (
-    CPU_COORD,
-    G_X_MAX,
-    G_X_MIN,
-    G_Y_MAX,
-    G_Y_MIN,
-    ONLINE_CORE_COORDS,
-    is_configurable_thread_core_coord,
-    is_global_route_coord,
-    is_online_core_coord,
-)
+from .route_scope import RouteScope, TargetBoard, get_route_scope
 
 __all__ = [
     "OutputCompletionPlan",
-    "OutputCpuIngressPlan",
     "OutputProducer",
     "select_output_completion_plan",
 ]
 
 RouteSide = tuple[Literal["x", "y", "xy", "local"], int]
 CompletionCoreTier = Literal["used", "empty_offline", "empty_online"]
-_JoinSelectionKey = tuple[int, int, int, int, int, tuple[tuple[int, int], ...]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,27 +31,8 @@ class OutputRouteDecision:
     offset: CoordZXYOffset
 
 
-@dataclass(frozen=True, slots=True)
-class OutputCpuIngressPlan:
-    """DATA and complete route offsets that share one CPU ingress side."""
-
-    output_routes: tuple[OutputRouteDecision, ...]
-    control_offset: CoordZXYOffset
-    ingress_side: RouteSide
-
-    def output_route_offsets(self) -> dict[tuple[CoordXY, CoordXY], CoordZXYOffset]:
-        return {
-            (route.producer_coord, route.target_coord): route.offset
-            for route in self.output_routes
-        }
-
-
-def route_len(offset: CoordZXYOffset) -> int:
-    return abs(offset.z) + abs(offset.x) + abs(offset.y)
-
-
 def terminal_route_side(offset: CoordZXYOffset) -> RouteSide:
-    """Returns the terminal route side after backendv2 Z, X, then Y routing."""
+    """Return the terminal route side after backendv2 Z, X, then Y routing."""
     if offset.y != 0:
         return ("y", 1 if offset.y > 0 else -1)
     if offset.x != 0:
@@ -73,57 +42,38 @@ def terminal_route_side(offset: CoordZXYOffset) -> RouteSide:
     return ("local", 0)
 
 
-def route_coord_path(
-    start_coord: CoordXY, offset: CoordZXYOffset
-) -> tuple[CoordXY, ...]:
-    """Returns the coordinate path produced by backendv2 Z, X, then Y routing."""
-    x, y = start_coord.x, start_coord.y
-    points = [start_coord]
-
-    def walk(step_count: int, dx: int, dy: int) -> None:
-        nonlocal x, y
-        for _ in range(step_count):
-            x += dx
-            y += dy
-            points.append(CoordXY(x, y))
-
-    if offset.z != 0:
-        walk(abs(offset.z), 1 if offset.z > 0 else -1, 1 if offset.z > 0 else -1)
-    if offset.x != 0:
-        walk(abs(offset.x), 1 if offset.x > 0 else -1, 0)
-    if offset.y != 0:
-        walk(abs(offset.y), 0, 1 if offset.y > 0 else -1)
-
-    return tuple(points)
-
-
-def route_stays_in_grid(
-    start_coord: CoordXY, offset: CoordZXYOffset, target_coord: CoordXY
-) -> bool:
-    path = route_coord_path(start_coord, offset)
-    return path[-1] == target_coord and all(
-        G_X_MIN <= coord.x <= G_X_MAX and G_Y_MIN <= coord.y <= G_Y_MAX
-        for coord in path
-    )
-
-
-def candidate_offsets(
-    start_coord: CoordXY, target_coord: CoordXY
-) -> tuple[CoordZXYOffset, ...]:
-    """Enumerates legal offsets to one fixed target without retargeting CPU."""
+@cache
+def _candidate_offset_paths(
+    start_coord: CoordXY, target_coord: CoordXY, scope_name: TargetBoard
+) -> tuple[tuple[CoordZXYOffset, tuple[CoordXY, ...]], ...]:
+    scope = get_route_scope(scope_name)
     dcoord = target_coord - start_coord
-    offsets: list[CoordZXYOffset] = []
+    routes: list[tuple[CoordZXYOffset, tuple[CoordXY, ...]]] = []
     for z in range(-31, 32):
         x = dcoord.x - z
         y = dcoord.y - z
         if not (-31 <= x <= 31 and -31 <= y <= 31):
             continue
         offset = CoordZXYOffset(z, x, y)
-        if route_stays_in_grid(start_coord, offset, target_coord):
-            offsets.append(offset)
+        path = route_coord_path(start_coord, offset)
+        if scope.route_path_valid(path, target_coord):
+            routes.append((offset, path))
 
     return tuple(
-        sorted(offsets, key=lambda offset: (route_len(offset), offset.to_tuple()))
+        sorted(routes, key=lambda item: (item[0].l1_norm(), item[0].to_tuple()))
+    )
+
+
+def candidate_offsets(
+    start_coord: CoordXY, target_coord: CoordXY, scope: RouteScope | None = None
+) -> tuple[CoordZXYOffset, ...]:
+    """Enumerate legal offsets to one fixed target without retargeting CPU."""
+    resolved_scope = scope or get_route_scope("single")
+    return tuple(
+        offset
+        for offset, _ in _candidate_offset_paths(
+            start_coord, target_coord, resolved_scope.name
+        )
     )
 
 
@@ -140,7 +90,7 @@ class OutputProducer:
     """Output-producing core endpoint and its static output-entry weight."""
 
     coord: CoordXY
-    target_coord: CoordXY = TEST_DEST_CORE
+    target_coord: CoordXY | None = None
     weight: int = 1
 
 
@@ -165,24 +115,18 @@ class OutputCompletionPlan:
     global_signal_relay_cores: tuple[EmptyThreadCore, ...]
 
     def output_route_offsets(self) -> dict[tuple[CoordXY, CoordXY], CoordZXYOffset]:
-        """Returns per-output-core DATA offsets keyed by producer and target."""
+        """Return per-output-core DATA offsets keyed by producer and target."""
         return {
             (route.producer_coord, route.target_coord): route.offset
             for route in self.output_routes
         }
 
     def empty_thread_core_kinds(self) -> dict[CoordXY, EmptyThreadCoreKind]:
-        """Returns all selected empty shell cores keyed by coordinate."""
+        """Return all selected empty shell cores keyed by coordinate."""
         empty_core_kinds: dict[CoordXY, EmptyThreadCoreKind] = {}
         for core in chain(self.completion_thread_cores, self.global_signal_relay_cores):
             empty_core_kinds[core.coord] = core.kind
         return empty_core_kinds
-
-    def to_cpu_ingress_plan(self) -> OutputCpuIngressPlan:
-        """Converts the completion decision to CPU ingress route metadata."""
-        return OutputCpuIngressPlan(
-            self.output_routes, self.control_offset, self.ingress_side
-        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -207,7 +151,7 @@ class _DataRouteOption:
     producer: OutputProducer
     offset: CoordZXYOffset
     path: tuple[CoordXY, ...]
-    path_len: int
+    l1_norm: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -224,50 +168,30 @@ class _JoinCandidate:
     data_routes: tuple[_DataRouteOption, ...]
     completion_thread_cores: tuple[EmptyThreadCore, ...]
     """Empty cores on producer-to-M DATA prefixes that must join this thread."""
-    completion_thread_core_coords: frozenset[CoordXY]
-    data_total_len: int
-    """Weighted total DATA route length across all output producers."""
+    data_total_l1_norm: int
+    """Weighted total DATA route L1 norm across all output producers."""
     join_tier: CompletionCoreTier
     """Join ownership tier: used core, available empty offline, or empty online."""
-    join_to_cpu_path_len: int
-    """Length of the shared completion_join_point-to-CPU suffix."""
 
 
 @dataclass(frozen=True, slots=True)
 class _CompletionCandidate:
-    """A complete candidate after selecting DATA routes, join, and source."""
+    """A complete candidate after selecting DATA routes and join point."""
 
     join_candidate: _JoinCandidate
-    source: CoordXY
-    source_tier: CompletionCoreTier
-    """Source ownership tier; source is the selected completion join point."""
     control_offset: CoordZXYOffset
-    control_path: tuple[CoordXY, ...]
     completion_thread_cores: tuple[EmptyThreadCore, ...]
-    """Completion-thread cores include join/source empty cores and DATA-prefix \
+    """Completion-thread cores include join empty cores and DATA-prefix \
         empty cores; global-signal relay cores are only tree-connectivity helpers."""
     global_signal_relay_cores: tuple[EmptyThreadCore, ...]
-    control_path_len: int
-    """Length of the source-to-CPU complete/control path."""
-    completion_thread_core_count: int
-
-
-def _coord_key(coord: CoordXY) -> tuple[int, int]:
-    return coord.x, coord.y
-
-
-def _coords_key(coords: tuple[CoordXY, ...]) -> tuple[tuple[int, int], ...]:
-    return tuple(_coord_key(coord) for coord in coords)
-
-
-def _empty_core_key(core: EmptyThreadCore) -> tuple[int, int, EmptyThreadCoreKind]:
-    return core.coord.x, core.coord.y, core.kind
 
 
 def _sorted_empty_cores(
     cores: Iterable[EmptyThreadCore],
 ) -> tuple[EmptyThreadCore, ...]:
-    return tuple(sorted(set(cores), key=_empty_core_key))
+    return tuple(
+        sorted(set(cores), key=lambda core: (*core.coord.to_tuple(), core.kind))
+    )
 
 
 def _path_suffix_from(
@@ -320,11 +244,14 @@ def _tier_rank(tier: CompletionCoreTier) -> int:
     return 2
 
 
-def _common_suffixes_for_path(path: tuple[CoordXY, ...]) -> tuple[_CommonSuffix, ...]:
+def _common_suffixes_for_path(
+    path: tuple[CoordXY, ...], scope: RouteScope
+) -> tuple[_CommonSuffix, ...]:
     suffixes: list[_CommonSuffix] = []
     seen: set[_CommonSuffix] = set()
+    configurable_coords = scope.configurable_coords
     for index, coord in enumerate(path[:-1]):
-        if not is_configurable_thread_core_coord(coord):
+        if coord not in configurable_coords:
             continue
         suffix = _CommonSuffix(coord, path[index:])
         if suffix in seen:
@@ -335,7 +262,10 @@ def _common_suffixes_for_path(path: tuple[CoordXY, ...]) -> tuple[_CommonSuffix,
 
 
 def _empty_data_prefix_thread_cores(
-    path: tuple[CoordXY, ...], join_point: CoordXY, pools: _ThreadCorePools
+    path: tuple[CoordXY, ...],
+    join_point: CoordXY,
+    pools: _ThreadCorePools,
+    scope: RouteScope,
 ) -> tuple[EmptyThreadCore, ...] | None:
     """Returns empty thread cores needed before DATA reaches the join point."""
     prefix = _path_prefix_to(path, join_point)
@@ -349,9 +279,9 @@ def _empty_data_prefix_thread_cores(
     # TODO: Model real DATA relay computation cores separately if such a
     # direction-changing relay is ever introduced.
     for coord in prefix:
-        if coord == CPU_COORD or coord in pools.configured:
+        if coord in scope.cpu_coords or coord in pools.configured:
             continue
-        if not is_configurable_thread_core_coord(coord):
+        if coord not in scope.configurable_coords:
             continue
         empty_core = _empty_completion_core(coord, pools)
         if empty_core is None:
@@ -402,6 +332,7 @@ class OutputCompletionPlanner:
         available_empty_offline_coords: Set[CoordXY],
         available_empty_online_coords: Set[CoordXY] | None = None,
         allow_empty_online: bool = True,
+        scope: RouteScope | None = None,
     ) -> None:
         """Initializes immutable planning inputs.
 
@@ -415,7 +346,10 @@ class OutputCompletionPlanner:
                 to this thread. If omitted and online relays are enabled, all
                 unused online-core coordinates are considered available.
             allow_empty_online: Whether empty online shell cores may be added.
+            scope: Selected board route scope for CPU target and grid checks.
         """
+        self._scope = scope or get_route_scope("single")
+        self._cpu_coord = self._scope.default_cpu.coord
         self._raw_producers = tuple(producers)
         self._configured_thread_core_coords = frozenset(configured_thread_core_coords)
         self._available_empty_offline_coords = frozenset(available_empty_offline_coords)
@@ -428,7 +362,17 @@ class OutputCompletionPlanner:
         self._request = self._normalize_request()
 
     def plan(self) -> OutputCompletionPlan:
-        """Builds and validates an output completion plan."""
+        """Build and validate an output completion plan.
+
+        Returns:
+            Selected DATA routes, completion route, and empty thread cores.
+
+        Raises:
+            OutputCompletionNoFeasiblePlanError: If DATA and completion routes
+                cannot share a valid thread-local suffix.
+            OutputCompletionError: If a selected candidate violates the planner
+                safety contract.
+        """
         if not self._request.producers:
             return self._plan_without_output_producers()
 
@@ -449,6 +393,7 @@ class OutputCompletionPlanner:
             self._request.producers,
             self._request.pools.configured,
             self._allow_empty_online,
+            self._scope,
         )
         return plan
 
@@ -457,13 +402,17 @@ class OutputCompletionPlanner:
         if not self._allow_empty_online:
             empty_online_coords: frozenset[CoordXY] = frozenset()
         elif self._available_empty_online_coords is None:
-            empty_online_coords = frozenset(ONLINE_CORE_COORDS - configured_coords)
+            empty_online_coords = frozenset(
+                self._scope.online_core_coords - configured_coords
+            )
         else:
             empty_online_coords = self._available_empty_online_coords
 
         producers = tuple(
             OutputProducer(
-                producer.coord, producer.target_coord, max(producer.weight, 1)
+                producer.coord,
+                producer.target_coord or self._cpu_coord,
+                max(producer.weight, 1),
             )
             for producer in self._raw_producers
         )
@@ -484,8 +433,10 @@ class OutputCompletionPlanner:
         )
 
     def _plan_without_output_producers(self) -> OutputCompletionPlan:
-        root = min(self._request.pools.configured, key=_coord_key)
-        control_offset = candidate_offsets(root, TEST_DEST_CORE)[0]
+        root = min(self._request.pools.configured, key=lambda coord: coord.to_tuple())
+        control_offset = _candidate_offset_paths(
+            root, self._cpu_coord, self._scope.name
+        )[0][0]
         return OutputCompletionPlan(
             (), control_offset, terminal_route_side(control_offset), root, root, (), ()
         )
@@ -512,24 +463,21 @@ class OutputCompletionPlanner:
     def _enumerate_data_route_options(
         self, producer: OutputProducer
     ) -> dict[_CommonSuffix, tuple[_DataRouteOption, ...]]:
-        offsets = candidate_offsets(producer.coord, producer.target_coord)
-        if not offsets:
+        target_coord = producer.target_coord or self._cpu_coord
+        offset_paths = _candidate_offset_paths(
+            producer.coord, target_coord, self._scope.name
+        )
+        if not offset_paths:
             raise OutputCompletionNoFeasiblePlanError(
                 "No legal output DATA route offset from "
                 f"({producer.coord.x},{producer.coord.y}) to "
-                f"({producer.target_coord.x},{producer.target_coord.y})."
+                f"({target_coord.x},{target_coord.y})."
             )
 
         option_groups: dict[_CommonSuffix, list[_DataRouteOption]] = {}
-        for offset in offsets:
-            path = route_coord_path(producer.coord, offset)
-            if path[-1] != producer.target_coord:
-                continue
-            if not all(is_global_route_coord(coord) for coord in path):
-                continue
-
-            option = _DataRouteOption(producer, offset, path, route_len(offset))
-            for suffix in _common_suffixes_for_path(option.path):
+        for offset, path in offset_paths:
+            option = _DataRouteOption(producer, offset, path, offset.l1_norm())
+            for suffix in _common_suffixes_for_path(option.path, self._scope):
                 option_groups.setdefault(suffix, []).append(option)
 
         return {
@@ -540,14 +488,14 @@ class OutputCompletionPlanner:
     def _data_route_key(
         self, option: _DataRouteOption
     ) -> tuple[int, tuple[int, int, int]]:
-        return option.path_len, option.offset.to_tuple()
+        return option.l1_norm, option.offset.to_tuple()
 
     def _best_data_route_for_suffix(
         self, options: tuple[_DataRouteOption, ...], suffix: _CommonSuffix
     ) -> tuple[_DataRouteOption, tuple[EmptyThreadCore, ...]] | None:
         for option in options:
             thread_cores = _empty_data_prefix_thread_cores(
-                option.path, suffix.join_point, self._request.pools
+                option.path, suffix.join_point, self._request.pools, self._scope
             )
             if thread_cores is not None:
                 return option, thread_cores
@@ -581,31 +529,26 @@ class OutputCompletionPlanner:
             completion_thread_cores = _sorted_empty_cores(
                 chain.from_iterable(choice[1] for choice in route_choices if choice)
             )
-            completion_thread_coords = frozenset(
-                core.coord for core in completion_thread_cores
-            )
             candidates.append(
                 _JoinCandidate(
                     suffix,
                     data_routes,
                     completion_thread_cores,
-                    completion_thread_coords,
-                    sum(route.path_len for route in data_routes),
+                    sum(route.l1_norm for route in data_routes),
                     join_tier,
-                    len(suffix.suffix) - 1,
                 )
             )
         return tuple(candidates)
 
-    def _join_selection_key(self, candidate: _JoinCandidate) -> _JoinSelectionKey:
+    def _join_selection_key(self, candidate: _JoinCandidate):
         # Prefer used M, then shorter suffix and fewer selected empty cores.
         return (
             _tier_rank(candidate.join_tier),
-            candidate.join_to_cpu_path_len,
-            len(candidate.completion_thread_core_coords),
+            len(candidate.suffix.suffix) - 1,
+            len(candidate.completion_thread_cores),
             candidate.suffix.join_point.x,
             candidate.suffix.join_point.y,
-            _coords_key(candidate.suffix.suffix),
+            to_coordxys(candidate.suffix.suffix),
         )
 
     def _build_completion_candidates(
@@ -616,44 +559,26 @@ class OutputCompletionPlanner:
         # Keep completion source and DATA join identical. Allowing a separate
         # source can satisfy suffix equality through a downstream M, but then
         # some DATA routes do not visibly intersect the global-signal root.
-        if not is_configurable_thread_core_coord(join_point):
-            return ()
-        return self._completion_candidates_for_source(
-            join_candidate, join_point, join_point, suffix
-        )
-
-    def _completion_candidates_for_source(
-        self,
-        join_candidate: _JoinCandidate,
-        source: CoordXY,
-        join_point: CoordXY,
-        suffix: tuple[CoordXY, ...],
-    ) -> tuple[_CompletionCandidate, ...]:
         candidates: list[_CompletionCandidate] = []
         pools = self._request.pools
-        source_tier = _completion_core_tier(source, pools)
-        if source_tier is None:
-            return ()
 
-        for control_offset in candidate_offsets(source, TEST_DEST_CORE):
-            control_path = route_coord_path(source, control_offset)
+        for control_offset, control_path in _candidate_offset_paths(
+            join_point, self._cpu_coord, self._scope.name
+        ):
             if _path_suffix_from(control_path, join_point) != suffix:
                 continue
 
-            if not all(is_global_route_coord(coord) for coord in control_path):
-                continue
-
-            source_core = _empty_completion_core(source, pools)
-            selected_source_cores = () if source_core is None else (source_core,)
+            join_core = _empty_completion_core(join_point, pools)
+            selected_join_cores = () if join_core is None else (join_core,)
             combined_required_cores = _sorted_empty_cores(
-                chain(join_candidate.completion_thread_cores, selected_source_cores)
+                chain(join_candidate.completion_thread_cores, selected_join_cores)
             )
             combined_required_coords = frozenset(
                 core.coord for core in combined_required_cores
             )
             combined_thread_coords = pools.configured | combined_required_coords
             global_signal_tree = solve_global_signal_tree(
-                list(combined_thread_coords), source, verbose=False
+                list(combined_thread_coords), join_point, verbose=False
             )
             global_signal_relay_cores = self._classify_global_signal_relay_cores(
                 frozenset(global_signal_tree.added),
@@ -665,14 +590,9 @@ class OutputCompletionPlanner:
             candidates.append(
                 _CompletionCandidate(
                     join_candidate,
-                    source,
-                    source_tier,
                     control_offset,
-                    control_path,
                     combined_required_cores,
                     global_signal_relay_cores,
-                    route_len(control_offset),
-                    len(combined_required_coords),
                 )
             )
         return tuple(candidates)
@@ -680,36 +600,31 @@ class OutputCompletionPlanner:
     def _select_completion_candidate(
         self, join_candidates: tuple[_JoinCandidate, ...]
     ) -> _CompletionCandidate | None:
-        candidates = tuple(
+        return min(
             chain.from_iterable(
                 self._build_completion_candidates(join_candidate)
                 for join_candidate in join_candidates
-            )
+            ),
+            key=self._completion_selection_key,
+            default=None,
         )
-        if not candidates:
-            return None
-
-        return min(candidates, key=self._completion_selection_key)
 
     def _completion_selection_key(self, candidate: _CompletionCandidate):
         join_candidate = candidate.join_candidate
-        # Rank only complete candidates: DATA cost, M quality, source quality.
+        # Rank only complete candidates: DATA cost, M quality, control path.
         return (
-            join_candidate.data_total_len,
+            join_candidate.data_total_l1_norm,
             *self._join_selection_key(join_candidate),
-            _tier_rank(candidate.source_tier),
-            candidate.control_path_len,
-            candidate.completion_thread_core_count,
+            candidate.control_offset.l1_norm(),
+            len(candidate.completion_thread_cores),
             len(candidate.global_signal_relay_cores),
-            candidate.source.x,
-            candidate.source.y,
         )
 
     def _build_plan(self, candidate: _CompletionCandidate) -> OutputCompletionPlan:
         output_routes = tuple(
             OutputRouteDecision(
                 data_route.producer.coord,
-                data_route.producer.target_coord,
+                data_route.producer.target_coord or self._cpu_coord,
                 data_route.offset,
             )
             for data_route in candidate.join_candidate.data_routes
@@ -718,7 +633,7 @@ class OutputCompletionPlanner:
             output_routes,
             candidate.control_offset,
             terminal_route_side(candidate.control_offset),
-            candidate.source,
+            candidate.join_candidate.suffix.join_point,
             candidate.join_candidate.suffix.join_point,
             candidate.completion_thread_cores,
             candidate.global_signal_relay_cores,
@@ -730,12 +645,32 @@ def validate_output_completion_plan(
     producers: tuple[OutputProducer, ...],
     configured_thread_core_coords: Set[CoordXY],
     allow_empty_online: bool = True,
+    scope: RouteScope | None = None,
 ) -> None:
-    """Validates the safety constraints of an output completion plan."""
+    """Validate the safety constraints of an output completion plan.
+
+    Args:
+        plan: Candidate output completion plan to validate.
+        producers: Output producers that must be represented by DATA routes.
+        configured_thread_core_coords: Coordinates already configured in the
+            current thread.
+        allow_empty_online: Whether selected empty online cores are legal.
+            Defaults to ``True``.
+        scope: Board route scope used for CPU target and route-grid checks.
+            Defaults to the single-chip scope.
+
+    Raises:
+        OutputCompletionError: If the plan violates target, thread membership,
+            route-scope, suffix-sharing, or ingress-side constraints.
+    """
+    resolved_scope = scope or get_route_scope("single")
+    cpu_coord = resolved_scope.default_cpu.coord
     configured_coords = frozenset(configured_thread_core_coords)
     if (
-        plan.completion_join_point == TEST_DEST_CORE
-        or not is_configurable_thread_core_coord(plan.completion_join_point)
+        plan.completion_join_point == cpu_coord
+        or not resolved_scope.is_configurable_thread_core_coord(
+            plan.completion_join_point
+        )
     ):
         raise OutputCompletionError("Completion join point must be inside the thread.")
 
@@ -751,12 +686,12 @@ def validate_output_completion_plan(
         )
 
     for core in chain(plan.completion_thread_cores, plan.global_signal_relay_cores):
-        if not is_configurable_thread_core_coord(core.coord):
+        if not resolved_scope.is_configurable_thread_core_coord(core.coord):
             raise OutputCompletionError(
                 "Empty thread core must be a configurable thread core."
             )
         expected_kind: EmptyThreadCoreKind = (
-            "online" if is_online_core_coord(core.coord) else "offline"
+            "online" if resolved_scope.is_online_core_coord(core.coord) else "offline"
         )
         if core.kind != expected_kind:
             raise OutputCompletionError(
@@ -782,8 +717,10 @@ def validate_output_completion_plan(
         )
 
     complete_path, data_paths = _plan_paths(plan)
-    if complete_path[-1] != TEST_DEST_CORE:
+    if complete_path[-1] != cpu_coord:
         raise OutputCompletionError("Completion route must target the CPU core.")
+    if not resolved_scope.route_path_valid(complete_path, cpu_coord):
+        raise OutputCompletionError("Completion route leaves the selected route scope.")
     suffix = _path_suffix_from(complete_path, plan.completion_join_point)
     if suffix is None:
         raise OutputCompletionError("Completion route must pass the join point.")
@@ -795,7 +732,8 @@ def validate_output_completion_plan(
         for route in plan.output_routes
     }
     for producer, data_path in zip(producers, data_paths, strict=True):
-        route = route_by_endpoint.get((producer.coord, producer.target_coord))
+        producer_target = producer.target_coord or cpu_coord
+        route = route_by_endpoint.get((producer.coord, producer_target))
         if route is None:
             raise OutputCompletionError(
                 "Missing output route for producer "
@@ -803,6 +741,8 @@ def validate_output_completion_plan(
             )
         if data_path[-1] != route.target_coord:
             raise OutputCompletionError("Output DATA route must target the CPU core.")
+        if not resolved_scope.route_path_valid(data_path, route.target_coord):
+            raise OutputCompletionError("Output DATA route leaves the selected scope.")
         if _path_suffix_from(data_path, plan.completion_join_point) != suffix:
             raise OutputCompletionError(
                 "Completion route must match the output DATA common suffix."
@@ -815,7 +755,7 @@ def validate_output_completion_plan(
         missing_prefix_cores = [
             coord
             for coord in prefix
-            if is_configurable_thread_core_coord(coord)
+            if resolved_scope.is_configurable_thread_core_coord(coord)
             and coord not in final_thread_coords
         ]
         if missing_prefix_cores:
@@ -835,107 +775,37 @@ def select_output_completion_plan(
     available_empty_offline_coords: Set[CoordXY],
     available_empty_online_coords: Set[CoordXY] | None = None,
     allow_empty_online: bool = False,
+    scope: RouteScope | None = None,
 ) -> OutputCompletionPlan:
-    """Chooses DATA routes, a shared join, and a completion source."""
+    """Choose DATA routes, a shared join, and a completion source.
+
+    Args:
+        producers: Output-producing cores that need DATA routes to the CPU.
+        configured_thread_core_coords: Coordinates already configured in the
+            current thread.
+        available_empty_offline_coords: Empty offline cores that may be added to
+            the current thread.
+        available_empty_online_coords: Empty online cores that may be added to
+            the current thread. When ``None`` and online relays are enabled, all
+            unused online cores in `scope` are considered available.
+        allow_empty_online: Whether empty online cores may be selected.
+            Defaults to ``False``.
+        scope: Board route scope used for CPU target and route-grid checks.
+            Defaults to the single-chip scope.
+
+    Returns:
+        Validated output completion plan.
+
+    Raises:
+        OutputCompletionNoFeasiblePlanError: If no valid shared-suffix plan can
+            be found.
+        OutputCompletionError: If a selected candidate fails validation.
+    """
     return OutputCompletionPlanner(
         producers,
         configured_thread_core_coords,
         available_empty_offline_coords,
         available_empty_online_coords,
         allow_empty_online,
+        scope,
     ).plan()
-
-
-def debug_output_completion_plan(
-    plan: OutputCompletionPlan,
-    producers: tuple[OutputProducer, ...],
-    used_core_coords: Set[CoordXY],
-) -> tuple[str, ...]:
-    """Returns stable debug lines for the selected completion plan."""
-    del producers, used_core_coords
-    complete_path, data_paths = _plan_paths(plan)
-    suffix = _path_suffix_from(complete_path, plan.completion_join_point)
-    lines = [
-        f"source=({plan.global_signal_root.x},{plan.global_signal_root.y})",
-        f"join=({plan.completion_join_point.x},{plan.completion_join_point.y})",
-        f"control_offset={plan.control_offset.to_tuple()} ingress={plan.ingress_side}",
-        "completion_thread_cores="
-        + str(
-            sorted((c.coord.x, c.coord.y, c.kind) for c in plan.completion_thread_cores)
-        ),
-        "global_signal_relay_cores="
-        + str(
-            sorted(
-                (c.coord.x, c.coord.y, c.kind) for c in plan.global_signal_relay_cores
-            )
-        ),
-        "shared_suffix=" + str([(coord.x, coord.y) for coord in (suffix or ())]),
-        "complete_path=" + str([(coord.x, coord.y) for coord in complete_path]),
-    ]
-    for route, path in zip(plan.output_routes, data_paths, strict=True):
-        lines.append(
-            "data_path "
-            f"producer=({route.producer_coord.x},{route.producer_coord.y}) "
-            f"offset={route.offset.to_tuple()} "
-            f"path={[(coord.x, coord.y) for coord in path]}"
-        )
-    return tuple(lines)
-
-
-def render_output_completion_plan_ascii(
-    plan: OutputCompletionPlan,
-    producers: tuple[OutputProducer, ...],
-    used_core_coords: Set[CoordXY],
-) -> str:
-    """Renders a compact ASCII view of DATA and complete route overlap."""
-    complete_path, data_paths = _plan_paths(plan)
-    suffix = set(_path_suffix_from(complete_path, plan.completion_join_point) or ())
-    complete_only = set(complete_path) - suffix
-    data_only: set[CoordXY] = set()
-    for path in data_paths:
-        data_only.update(set(path) - suffix)
-    completion_thread_coords = {core.coord for core in plan.completion_thread_cores}
-    producer_labels = {producer.coord: f"P{i}" for i, producer in enumerate(producers)}
-
-    def cell(coord: CoordXY) -> str:
-        if coord == TEST_DEST_CORE:
-            return "C"
-        if coord == plan.global_signal_root and coord == plan.completion_join_point:
-            return "SM"
-        if coord == plan.global_signal_root:
-            return "S"
-        if coord == plan.completion_join_point:
-            return "M"
-        if coord in producer_labels:
-            return producer_labels[coord]
-        if coord in suffix:
-            return "*"
-        if coord in complete_only:
-            return "c"
-        if coord in data_only:
-            return "d"
-        if coord in completion_thread_coords:
-            return "E"
-        if coord in used_core_coords:
-            return "U"
-        return "."
-
-    rows = []
-    for y in range(G_Y_MAX, G_Y_MIN - 1, -1):
-        cells = " ".join(
-            f"{cell(CoordXY(x, y)):>2}" for x in range(G_X_MIN, G_X_MAX + 1)
-        )
-        rows.append(f"y={y} {cells}")
-    rows.append("    " + " ".join(f"{x:>2}" for x in range(G_X_MIN, G_X_MAX + 1)))
-    rows.append(
-        "legend: C=CPU S=source M=join *=shared d=DATA-only "
-        "c=complete-only E=required-empty U=used"
-    )
-    rows.append(
-        "producers: "
-        + ", ".join(
-            f"P{i}=({producer.coord.x},{producer.coord.y})"
-            for i, producer in enumerate(producers)
-        )
-    )
-    return "\n".join(rows)

--- a/paibox/backendv2/pressure_unroll.py
+++ b/paibox/backendv2/pressure_unroll.py
@@ -11,7 +11,7 @@ from paicorelib import CSCAccelerateMode, NeuronType
 
 from .coreplacement import CorePlacement, OfflineCorePlacementV2
 from .neuron import OfflineNeuronPlacement
-from .route_solver import OFFLINE_CORE_COORDS
+from .route_scope import RouteScope, get_route_scope
 from .routing import RoutingGroup
 
 
@@ -103,11 +103,21 @@ class PressureUnroller:
 
     Each round recomputes layer pressure, tries candidates ordered by current
     peak pressure, and commits at most one successful layer split.
+
+    Parameters:
+        routing_groups: Routing groups whose offline cores may be split.
+        routing_fn: Feasibility-only routing probe called after each candidate
+            split.
+        config: Heuristic limits and selection knobs. Defaults to
+            `PressureUnrollConfig()`.
+        scope: Board route scope used to count free offline cores. Defaults to
+            the single-chip scope.
     """
 
     routing_groups: list[RoutingGroup]
     routing_fn: Callable[[], None]  # must be a feasibility-only probe
     config: PressureUnrollConfig = field(default_factory=PressureUnrollConfig)
+    scope: RouteScope = field(default_factory=lambda: get_route_scope("single"))
 
     def run(self) -> UnrollResult:
         """Run greedy split/probe rounds within the route-probe budget.
@@ -118,6 +128,9 @@ class PressureUnroller:
         3. Select high-pressure offline cores by peak ratio or quantile.
         4. Split selected cores by neuron count.
         5. Keep the split only if a feasibility-only routing probe succeeds.
+
+        Returns:
+            Summary describing committed splits and the stop reason.
         """
         result = UnrollResult()
         route_failed = False
@@ -258,7 +271,7 @@ class PressureUnroller:
         return True
 
     def _get_free_offline_core_count(self) -> int:
-        return len(OFFLINE_CORE_COORDS) - sum(
+        return len(self.scope.offline_core_coords) - sum(
             rg.n_core_required for rg in self.routing_groups
         )
 

--- a/paibox/backendv2/route_scope.py
+++ b/paibox/backendv2/route_scope.py
@@ -1,0 +1,221 @@
+"""Fixed backendv2 board route scopes.
+
+The route solver and completion planners consume a :class:`RouteScope` instead
+of hard-coded single-chip constants. Board descriptions stay internal because
+the supported hardware layouts are fixed product targets, not user-provided
+placement inputs.
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+from paicorelib import CoordXY
+
+__all__ = ["CpuEndpoint", "RouteScope", "TargetBoard", "get_route_scope"]
+
+TargetBoard = Literal["single", "array_2x2"]
+
+CHIP_ROUTE_SIZE = 9
+CHIP_ARRAY_STRIDE = (9, 9)
+
+_SINGLE_CPU = CoordXY(0, 0)
+_SINGLE_OFFLINE = frozenset(
+    CoordXY(x, y) for x in range(CHIP_ROUTE_SIZE) for y in range(2, CHIP_ROUTE_SIZE)
+)
+_SINGLE_GLOBAL = frozenset(
+    CoordXY(x, y) for x in range(CHIP_ROUTE_SIZE) for y in range(CHIP_ROUTE_SIZE)
+)
+_SINGLE_ONLINE = frozenset(
+    CoordXY(x, y)
+    for x in range(CHIP_ROUTE_SIZE)
+    for y in range(2)
+    if CoordXY(x, y) != _SINGLE_CPU
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CpuEndpoint:
+    """A CPU tile that can be selected as a board endpoint."""
+
+    chip_id: int
+    chip_x: int
+    chip_y: int
+    coord: CoordXY
+
+
+@dataclass(frozen=True, slots=True)
+class RouteScope:
+    """Resolved routing resources for one fixed backendv2 board target."""
+
+    name: TargetBoard
+    cpu_endpoints: tuple[CpuEndpoint, ...]
+    default_cpu: CpuEndpoint
+    offline_core_coords: frozenset[CoordXY]
+    online_core_coords: frozenset[CoordXY]
+    global_route_coords: frozenset[CoordXY]
+    copy_limits: tuple[int, int, int]
+
+    @property
+    def cpu_coords(self) -> frozenset[CoordXY]:
+        return frozenset(cpu.coord for cpu in self.cpu_endpoints)
+
+    @property
+    def configurable_coords(self) -> frozenset[CoordXY]:
+        return self.offline_core_coords | self.online_core_coords
+
+    @property
+    def offline_bounds(self) -> tuple[int, int, int, int]:
+        return _bounds(self.offline_core_coords)
+
+    @property
+    def global_bounds(self) -> tuple[int, int, int, int]:
+        return _bounds(self.global_route_coords | self.cpu_coords)
+
+    def is_global_route_coord(self, coord: CoordXY) -> bool:
+        return coord in self.global_route_coords
+
+    def is_online_core_coord(self, coord: CoordXY) -> bool:
+        return coord in self.online_core_coords
+
+    def is_configurable_thread_core_coord(self, coord: CoordXY) -> bool:
+        return coord in self.configurable_coords
+
+    def chip_id(self, chip_x: int, chip_y: int) -> int:
+        """Return the row-major chip id for a chip coordinate.
+
+        Args:
+            chip_x: Chip column in the selected board target.
+            chip_y: Chip row in the selected board target.
+
+        Returns:
+            Stable row-major chip identifier.
+
+        Raises:
+            ValueError: If the chip coordinate is not present in this scope.
+        """
+        for cpu in self.cpu_endpoints:
+            if cpu.chip_x == chip_x and cpu.chip_y == chip_y:
+                return cpu.chip_id
+        raise ValueError(
+            f"Chip coordinate ({chip_x}, {chip_y}) is not in target_board={self.name!r}."
+        )
+
+    def chip_xy(self, chip_id: int) -> tuple[int, int]:
+        """Return the chip coordinate for a stable chip id.
+
+        Args:
+            chip_id: Stable row-major chip identifier.
+
+        Returns:
+            ``(chip_x, chip_y)`` coordinate in the selected board target.
+
+        Raises:
+            ValueError: If the chip id is not present in this scope.
+        """
+        for cpu in self.cpu_endpoints:
+            if cpu.chip_id == chip_id:
+                return cpu.chip_x, cpu.chip_y
+        raise ValueError(f"Chip id {chip_id} is not in target_board={self.name!r}.")
+
+    def route_path_valid(self, path: tuple[CoordXY, ...], target: CoordXY) -> bool:
+        """Return whether a Z/X/Y route path stays inside this scope.
+
+        CPU tiles are endpoints, not pass-through coordinates. The final target
+        may be a CPU coordinate; every other coordinate must be in
+        ``global_route_coords``.
+
+        Args:
+            path: Absolute coordinate path produced by route-offset expansion.
+            target: Required final coordinate of the path.
+
+        Returns:
+            Whether the path ends at `target` and stays within the selected
+            route scope.
+        """
+        if not path or path[-1] != target:
+            return False
+        for idx, coord in enumerate(path):
+            if coord in self.global_route_coords:
+                continue
+            if idx == len(path) - 1 and coord == target and coord in self.cpu_coords:
+                continue
+            return False
+        return True
+
+
+def get_route_scope(target_board: TargetBoard = "single") -> RouteScope:
+    """Return the internal route scope for a supported fixed board target.
+
+    Args:
+        target_board: Fixed board topology to resolve. Defaults to ``"single"``.
+
+    Returns:
+        Immutable `RouteScope` for the selected board target.
+    """
+    if target_board not in _ROUTE_SCOPES:
+        supported = ", ".join(sorted(_ROUTE_SCOPES))
+        raise ValueError(
+            f"Unsupported target_board {target_board!r}; expected one of: {supported}."
+        )
+    return _ROUTE_SCOPES[target_board]
+
+
+def _bounds(coords: frozenset[CoordXY]) -> tuple[int, int, int, int]:
+    if not coords:
+        raise ValueError("Route scope coordinate set cannot be empty.")
+    xs = [coord.x for coord in coords]
+    ys = [coord.y for coord in coords]
+    return min(xs), max(xs), min(ys), max(ys)
+
+
+def _shift(coords: frozenset[CoordXY], dx: int, dy: int) -> frozenset[CoordXY]:
+    return frozenset(CoordXY(coord.x + dx, coord.y + dy) for coord in coords)
+
+
+def _single_scope() -> RouteScope:
+    cpu = CpuEndpoint(0, 0, 0, _SINGLE_CPU)
+    return RouteScope(
+        "single",
+        (cpu,),
+        cpu,
+        _SINGLE_OFFLINE,
+        _SINGLE_ONLINE,
+        _SINGLE_GLOBAL - frozenset((cpu.coord,)),
+        (6, 8, 6),
+    )
+
+
+def _array_2x2_scope() -> RouteScope:
+    offline: set[CoordXY] = set()
+    online: set[CoordXY] = set()
+    global_route: set[CoordXY] = set()
+    cpus: list[CpuEndpoint] = []
+
+    stride_x, stride_y = CHIP_ARRAY_STRIDE
+    for chip_y in range(2):
+        for chip_x in range(2):
+            chip_id = chip_y * 2 + chip_x
+            dx = chip_x * stride_x
+            dy = chip_y * stride_y
+            cpu = CpuEndpoint(chip_id, chip_x, chip_y, CoordXY(dx, dy))
+            cpus.append(cpu)
+            offline.update(_shift(_SINGLE_OFFLINE, dx, dy))
+            online.update(_shift(_SINGLE_ONLINE, dx, dy))
+            global_route.update(_shift(_SINGLE_GLOBAL, dx, dy))
+
+    cpu_coords = {cpu.coord for cpu in cpus}
+    return RouteScope(
+        "array_2x2",
+        tuple(cpus),
+        cpus[0],
+        frozenset(offline),
+        frozenset(online),
+        frozenset(global_route - cpu_coords),
+        (6, 17, 6),
+    )
+
+
+_ROUTE_SCOPES: dict[TargetBoard, RouteScope] = {
+    "single": _single_scope(),
+    "array_2x2": _array_2x2_scope(),
+}

--- a/paibox/backendv2/route_solver.py
+++ b/paibox/backendv2/route_solver.py
@@ -1,307 +1,566 @@
+"""CP-SAT placement solver for backendv2 routing groups."""
+
 import itertools
 import os
-from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from functools import cache
 
 from ortools.sat.python import cp_model
-from paicorelib.coordinate import CoordXY
-from paicorelib.routing_hexa import (
-    AERPacket,
+from paicorelib import (
     AERPacketZXYCopy,
+    CoordXY,
+    CoordXYLike,
+    CoordXYOffset,
     aer_packet_area,
-    aer_packet_walk,
+    aer_packet_copy_offsets,
+    to_coordxy,
 )
 
-# ---------------- 网格定义 ----------------
-# HIVE: area 实际可放置的格子范围
-X_START, X_END = 0, 9
-Y_START, Y_END = 2, 9
+from .route_scope import RouteScope, TargetBoard, get_route_scope
+from .routing import InputGroup, OutputGroup, RoutingGroup
 
-# G: 数据包合法可达的全局网格 (用于新约束)
-G_X_MIN, G_X_MAX = 0, 8  # x ∈ [0, 8]
-G_Y_MIN, G_Y_MAX = 0, 8  # y ∈ [0, 8]
-
-HIVE = set()
-for i in range(X_START, X_END):
-    for j in range(Y_START, Y_END):
-        HIVE.add((i, j))
-
-HIVE_LIST = list(HIVE)
-HIVE_INDEX = {h: i for i, h in enumerate(HIVE_LIST)}
-
-# CPU is outside the configurable-core pools. The row bands below match the
-# hardware split used by backendv2 planning: y >= 2 are offline cores, while
-# y in {0, 1} (except the CPU) are online cores.
-CPU_COORD = CoordXY(0, 0)
-OFFLINE_CORE_COORDS = frozenset(CoordXY(x, y) for x, y in HIVE)
-ONLINE_CORE_COORDS = frozenset(
-    CoordXY(x, y)
-    for x in range(G_X_MIN, G_X_MAX + 1)
-    for y in range(G_Y_MIN, min(G_Y_MAX, 1) + 1)
-    if (x, y) != (CPU_COORD.x, CPU_COORD.y)
-)
+__all__ = ["RouteSolver", "route_solve"]
 
 
-def is_global_route_coord(coord: CoordXY) -> bool:
-    return G_X_MIN <= coord.x <= G_X_MAX and G_Y_MIN <= coord.y <= G_Y_MAX
+@dataclass(frozen=True, slots=True)
+class RouteShape:
+    """One AER multicast copy shape, represented as offsets from its base.
 
-
-def is_offline_core_coord(coord: CoordXY) -> bool:
-    return coord in OFFLINE_CORE_COORDS
-
-
-def is_online_core_coord(coord: CoordXY) -> bool:
-    return coord in ONLINE_CORE_COORDS
-
-
-def is_configurable_thread_core_coord(coord: CoordXY) -> bool:
-    return is_offline_core_coord(coord) or is_online_core_coord(coord)
-
-
-# ---------------- Shape 枚举 ----------------
-def get_shapes_by_area():
+    Parameters:
+        area: Number of offline cores covered by the shape.
+        copy_config: Hardware AER packet copy configuration for the shape.
+        offsets: Relative core coordinates covered from a selected base core.
     """
-    枚举所有合法 AER 复制形状，并按面积分桶。
-    额外返回每个 shape 的相对偏移包围盒 (sxmin, sxmax, symin, symax)。
+
+    area: int
+    copy_config: AERPacketZXYCopy
+    offsets: tuple[CoordXYOffset, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _Placement:
+    area_id: int
+    shape: RouteShape
+    coords: tuple[CoordXY, ...]
+    center_x: int
+    center_y: int
+
+
+@cache
+def _copy_candidates(
+    scope_name: TargetBoard,
+) -> tuple[tuple[int, tuple[int, int, int]], ...]:
+    scope = get_route_scope(scope_name)
+    z_limit, x_limit, y_limit = scope.copy_limits
+    offline_capacity = len(scope.offline_core_coords)
+    candidates = []
+    for copy_tuple in itertools.product(
+        range(-z_limit, z_limit + 1),
+        range(-x_limit, x_limit + 1),
+        range(-y_limit, y_limit + 1),
+    ):
+        area = aer_packet_area(copy_tuple)
+        if area <= offline_capacity:
+            candidates.append((area, copy_tuple))
+    return tuple(sorted(candidates, key=lambda item: (item[0], item[1])))
+
+
+@cache
+def _smallest_shapes_for_area(
+    scope_name: TargetBoard, min_area: int
+) -> tuple[RouteShape, ...]:
+    scope = get_route_scope(scope_name)
+    selected_area = None
+    shapes: list[RouteShape] = []
+
+    for area, copy_tuple in _copy_candidates(scope_name):
+        if area < min_area:
+            continue
+        if selected_area is not None and area > selected_area:
+            break
+
+        offsets = tuple(
+            CoordXYOffset(off.x, off.y) for off in aer_packet_copy_offsets(copy_tuple)
+        )
+        if area != len(offsets) or not _shape_has_placement(scope, offsets):
+            continue
+
+        selected_area = area
+        copy_config = AERPacketZXYCopy(*copy_tuple)
+        shapes.append(RouteShape(area, copy_config.copy(), offsets))
+
+    if selected_area is None:
+        raise RuntimeError(f"No shape found for area size>={min_area}.")
+
+    return tuple(sorted(shapes, key=_shape_key))
+
+
+def _shape_key(shape: RouteShape) -> tuple[int, tuple[int, int, int]]:
+    return shape.area, shape.copy_config.to_tuple()
+
+
+def _shape_has_placement(scope: RouteScope, offsets: tuple[CoordXYOffset, ...]) -> bool:
+    """Return whether one AER shape can live wholly on offline compute cores."""
+    offline = scope.offline_core_coords
+    return any(all(base + off in offline for off in offsets) for base in offline)
+
+
+class RouteSolver:
+    """Assign routing-group multicast shapes to one selected board scope.
+
+    The solver models offline-core exclusivity, one placement per route area,
+    and legal successor AER expansion as hard constraints. The optimization
+    objective only biases valid placements toward shorter logical edges and
+    input/output areas near a selected CPU endpoint.
     """
-    shapes = defaultdict(list)
-    copy_configs = defaultdict(list)
-    shape_bboxes = defaultdict(list)
 
-    for coord in itertools.product(range(0, 5), range(0, 5), range(0, 5)):
-        n = aer_packet_area(coord)
-        copy_config = AERPacketZXYCopy(*coord)
-        copy_configs[n].append(copy_config.copy())
-        packet = AERPacket(ncopy=copy_config)
-        covered = aer_packet_walk(packet)
-        n_covered = len(covered)
+    def __init__(
+        self,
+        areas: Sequence[int] | None = None,
+        next_area_id: Mapping[int, Sequence[int]] | None = None,
+        scope: RouteScope | None = None,
+        io_bias_coord: CoordXYLike | None = None,
+        input_area_ids: Sequence[int] | None = None,
+        output_area_ids: Sequence[int] | None = None,
+        *,
+        feasibility_only: bool = False,
+        max_time_in_seconds: float = 120.0,
+        max_memory_in_mb: int = 4096,
+    ) -> None:
+        """Initialize the route placement solver.
 
-        assert n == n_covered
-        shapes[n].append(covered)
+        Args:
+            areas: Required offline-core count for each route area. Defaults to
+                one area requiring one core.
+            next_area_id: Area-level successor graph, keyed by source area id.
+            scope: Board route scope that defines offline cores, CPU endpoints,
+                and the global route grid. Defaults to the single-chip scope.
+            io_bias_coord: Route coordinate or CPU endpoint used by the soft
+                input/output placement bias. Defaults to the scope's default
+                CPU coordinate.
+            input_area_ids: Area ids that receive external input and should be
+                softly biased toward `io_bias_coord`.
+            output_area_ids: Area ids that produce external output and should be
+                softly biased toward `io_bias_coord`.
+            feasibility_only: Whether to stop after the first feasible solution
+                and skip soft objective construction.
+            max_time_in_seconds: CP-SAT solve time limit. Defaults to ``120.0``.
+            max_memory_in_mb: CP-SAT memory limit. Defaults to ``4096``.
 
-        xs = [s.x for s in covered]
-        ys = [s.y for s in covered]
-        shape_bboxes[n].append((min(xs), max(xs), min(ys), max(ys)))
+        Raises:
+            ValueError: If area sizes, area ids, or IO bias coordinate are
+                invalid for the selected scope.
+        """
+        self.scope = scope or get_route_scope("single")
+        self.areas = tuple((1,) if areas is None else areas)
+        self.num_areas = len(self.areas)
+        self.next_area_id = {
+            int(area_id): tuple(next_ids)
+            for area_id, next_ids in (next_area_id or {}).items()
+        }
+        self.io_bias_coord = self._resolve_io_bias_coord(io_bias_coord)
+        self.input_area_ids = tuple(input_area_ids or ())
+        self.output_area_ids = tuple(output_area_ids or ())
+        self.feasibility_only = feasibility_only
+        self.max_time_in_seconds = max_time_in_seconds
+        self.max_memory_in_mb = max_memory_in_mb
 
-    return shapes, copy_configs, shape_bboxes
+        self.offline_coords = tuple(
+            sorted(self.scope.offline_core_coords, key=lambda coord: (coord.x, coord.y))
+        )
+        self.offline_index = {
+            coord: idx for idx, coord in enumerate(self.offline_coords)
+        }
+        self.model = cp_model.CpModel()
+        self.placements: list[_Placement] = []
+        self.x: list[cp_model.IntVar] = []
+        self.area_to_placements: list[list[int]] = []
+        self.cx: list[cp_model.IntVar] = []
+        self.cy: list[cp_model.IntVar] = []
+
+        self._validate_inputs()
+
+    def solve(self) -> tuple[list[AERPacketZXYCopy], list[list[CoordXY]]]:
+        """Solve route placement.
+
+        Returns:
+            Pair of multicast copy configs and absolute offline-core
+            coordinates, ordered by route area id.
+
+        Raises:
+            RuntimeError: If no legal placement candidates exist, CP-SAT cannot
+                find a solution, or the solve times out without a solution.
+        """
+        if self.num_areas == 0:
+            return [], []
+
+        self._generate_placements()
+        self._build_variables()
+        self._add_cell_constraints()
+        self._add_uniqueness_constraints()
+        if any(self.next_area_id.values()):
+            self._add_successor_route_constraints()
+        if not self.feasibility_only:
+            # Feasibility mode needs only hard hardware legality. Centers and
+            # distances are soft placement-quality terms, so building them would
+            # enlarge the CP-SAT model without changing feasible/invalid routes.
+            self._build_center_variables()
+            self._add_placement_binding_constraints()
+            self._set_objective()
+        return self._run_solver()
+
+    def _resolve_io_bias_coord(self, io_bias_coord: CoordXYLike | None) -> CoordXY:
+        if io_bias_coord is None:
+            return self.scope.default_cpu.coord
+        return to_coordxy(io_bias_coord)
+
+    def _validate_inputs(self) -> None:
+        invalid_sizes = [
+            (area_id, area) for area_id, area in enumerate(self.areas) if area <= 0
+        ]
+        if invalid_sizes:
+            raise ValueError(f"Area sizes must be positive: {invalid_sizes}.")
+
+        area_ids = set(self.next_area_id)
+        area_ids.update(
+            next_id for next_ids in self.next_area_id.values() for next_id in next_ids
+        )
+        area_ids.update(self.input_area_ids)
+        area_ids.update(self.output_area_ids)
+        invalid_ids = sorted(
+            area_id for area_id in area_ids if not 0 <= area_id < self.num_areas
+        )
+        if invalid_ids:
+            raise ValueError(
+                f"Area ids out of range for {self.num_areas} areas: {invalid_ids}."
+            )
+
+        if not (
+            self.scope.is_global_route_coord(self.io_bias_coord)
+            or self.io_bias_coord in self.scope.cpu_coords
+        ):
+            raise ValueError(
+                "io_bias_coord must be a route coordinate or CPU endpoint in "
+                f"scope {self.scope.name!r}: {self.io_bias_coord}."
+            )
+
+    def _generate_placements(self) -> None:
+        for area_id, area in enumerate(self.areas):
+            shapes = self._find_shapes_for_area(area_id, area)
+            for shape in shapes:
+                self._try_place_shape(area_id, shape)
+
+    def _find_shapes_for_area(self, area_id: int, area: int) -> tuple[RouteShape, ...]:
+        try:
+            return _smallest_shapes_for_area(self.scope.name, area)
+        except RuntimeError as exc:
+            raise RuntimeError(
+                f"No shape found for area_id={area_id} size>={area}."
+            ) from exc
+
+    def _try_place_shape(self, area_id: int, shape: RouteShape) -> None:
+        """Create only placements whose copied cores fit in offline silicon."""
+        for base in self.offline_coords:
+            coords = tuple(base + offset for offset in shape.offsets)
+            if not all(coord in self.scope.offline_core_coords for coord in coords):
+                continue
+
+            center_x = round(sum(coord.x for coord in coords) / len(coords))
+            center_y = round(sum(coord.y for coord in coords) / len(coords))
+            placement = _Placement(area_id, shape, coords, center_x, center_y)
+            self.placements.append(placement)
+
+    def _build_variables(self) -> None:
+        """Create one Boolean variable per legal placement candidate."""
+        self.x = [
+            self.model.new_bool_var(f"x_{i}") for i in range(len(self.placements))
+        ]
+        self.area_to_placements = [[] for _ in range(self.num_areas)]
+        for i, placement in enumerate(self.placements):
+            self.area_to_placements[placement.area_id].append(i)
+
+        empty_area_ids = [
+            area_id
+            for area_id, area_placements in enumerate(self.area_to_placements)
+            if not area_placements
+        ]
+        if empty_area_ids:
+            raise RuntimeError(
+                f"No placement candidates for area ids {empty_area_ids}."
+            )
+
+    def _build_center_variables(self) -> None:
+        """Create selected-area center coordinates for soft distance costs."""
+        x_min, x_max, y_min, y_max = self.scope.offline_bounds
+        self.cx = [
+            self.model.new_int_var(x_min, x_max, f"cx_{a}")
+            for a in range(self.num_areas)
+        ]
+        self.cy = [
+            self.model.new_int_var(y_min, y_max, f"cy_{a}")
+            for a in range(self.num_areas)
+        ]
+
+    def _io_distance(self, placement: _Placement) -> int:
+        return abs(placement.center_x - self.io_bias_coord.x) + abs(
+            placement.center_y - self.io_bias_coord.y
+        )
+
+    def _add_cell_constraints(self) -> None:
+        """Hard constraint: each offline core is used at most once.
+
+        In one compile artifact, an offline core is a unique physical resource:
+        its config, neuron state, weights, axons, and output bindings belong to
+        one routing group placement. RouteSolver does not model temporal
+        multiplexing or context switching, so overlapping routing groups would
+        alias hardware state. Multi-chip scopes only enlarge the absolute-core
+        coordinate set; uniqueness still applies per absolute offline core.
+        """
+        cell_to_xs = [[] for _ in range(len(self.offline_coords))]
+        for i, placement in enumerate(self.placements):
+            for coord in placement.coords:
+                cell_to_xs[self.offline_index[coord]].append(self.x[i])
+
+        for covering_xs in cell_to_xs:
+            if len(covering_xs) > 1:
+                self.model.add_at_most_one(covering_xs)
+
+    def _add_uniqueness_constraints(self) -> None:
+        """Hard constraint: every routing area chooses exactly one placement.
+
+        A routing group must have one concrete AER copy shape and one base
+        coordinate. Zero placements drops the computation; multiple placements
+        duplicate the same logical group on hardware.
+        """
+        for area_placements in self.area_to_placements:
+            self.model.add_exactly_one([self.x[i] for i in area_placements])
+
+    def _add_placement_binding_constraints(self) -> None:
+        """Bind center variables to the exactly-one selected placement.
+
+        The one-hot placement variables make the weighted sum equal to the
+        chosen placement center. These centers are not hardware resources; they
+        are the small proxy used by the soft distance objective.
+        """
+        for area_id, area_placements in enumerate(self.area_to_placements):
+            self.model.add(
+                self.cx[area_id]
+                == sum(self.placements[i].center_x * self.x[i] for i in area_placements)
+            )
+            self.model.add(
+                self.cy[area_id]
+                == sum(self.placements[i].center_y * self.x[i] for i in area_placements)
+            )
+
+    def _add_successor_route_constraints(self) -> None:
+        """Hard constraint: every producer-to-successor expansion stays routable.
+
+        For edge i -> j, each source core of i may emit an AER packet using j's
+        copy shape. Every expanded coordinate must stay inside the selected
+        board's global route grid; CPU tiles are endpoints, not pass-through
+        route cells.
+        """
+        for src_id, next_ids in self.next_area_id.items():
+            for dst_id in next_ids:
+                self._ban_invalid_successor_pairs(src_id, dst_id)
+
+    def _ban_invalid_successor_pairs(self, src_id: int, dst_id: int) -> None:
+        """Forbid producer placements incompatible with each consumer shape.
+
+        The hardware legality check depends on the producer coords and the
+        consumer AER copy offsets, not on the consumer base coordinate. Grouping
+        destination placements by copy shape therefore expresses the same logic
+        as pairwise forbidden placement tuples: when shape S is selected, every
+        producer placement that would expand outside the global route grid under
+        S must be false.
+
+        This deliberately uses a grouped `add_at_most_one` instead of
+        `add_forbidden_assignments`. OR-Tools expands negated table constraints
+        into a large SAT encoding on medium route cases; the grouped form keeps
+        the model Boolean-native and much smaller.
+        """
+        dst_by_shape: dict[
+            tuple[int, int, int], tuple[list[int], tuple[CoordXYOffset, ...]]
+        ] = {}
+        for dst_i in self.area_to_placements[dst_id]:
+            dst_shape = self.placements[dst_i].shape
+            shape_key = dst_shape.copy_config.to_tuple()
+            dst_placement_ids, _ = dst_by_shape.setdefault(
+                shape_key, ([], dst_shape.offsets)
+            )
+            dst_placement_ids.append(dst_i)
+
+        for dst_placement_ids, dst_offsets in dst_by_shape.values():
+            invalid_src_xs = [
+                self.x[src_i]
+                for src_i in self.area_to_placements[src_id]
+                if not self._successor_pair_valid(
+                    self.placements[src_i].coords, dst_offsets
+                )
+            ]
+            if invalid_src_xs:
+                self.model.add_at_most_one(
+                    [
+                        *(self.x[dst_i] for dst_i in dst_placement_ids),
+                        *invalid_src_xs,
+                    ]
+                )
+
+    def _successor_pair_valid(
+        self, src_coords: tuple[CoordXY, ...], dst_offsets: tuple[CoordXYOffset, ...]
+    ) -> bool:
+        """Check the hardware route grid for one producer placement and shape."""
+        for src_coord in src_coords:
+            for offset in dst_offsets:
+                routed_coord = src_coord + offset
+                if not self.scope.is_global_route_coord(routed_coord):
+                    return False
+        return True
+
+    def _set_objective(self) -> None:
+        """Soft objective: prefer shorter logical edges and CPU-adjacent IO."""
+        self.model.minimize(self._build_distance_terms())
+
+    def _build_distance_terms(self):
+        """Build Manhattan distance terms over selected placement centers.
+
+        This does not decide hardware legality; hard constraints already did
+        that. It only biases among valid placements toward shorter inter-area
+        routes and input/output areas near the selected CPU endpoint. It is not
+        a hard CPU ingress/egress path-validity constraint.
+        """
+        total_distance = 0
+        x_min, x_max, y_min, y_max = self.scope.offline_bounds
+        dx_bound = x_max - x_min
+        dy_bound = y_max - y_min
+        for src_id, next_ids in self.next_area_id.items():
+            for dst_id in next_ids:
+                dx = self.model.new_int_var(0, dx_bound, f"dx_{src_id}_{dst_id}")
+                dy = self.model.new_int_var(0, dy_bound, f"dy_{src_id}_{dst_id}")
+                self.model.add_abs_equality(dx, self.cx[dst_id] - self.cx[src_id])
+                self.model.add_abs_equality(dy, self.cy[dst_id] - self.cy[src_id])
+                # TODO(route): weight this edge by measured traffic, e.g. the
+                # number of source elems targeting dst or their output-bit sum.
+                # This should remain objective-only, so feasibility is unchanged.
+                total_distance += dx + dy
+
+        for area_id in itertools.chain(self.input_area_ids, self.output_area_ids):
+            total_distance += sum(
+                self._io_distance(self.placements[i]) * self.x[i]
+                for i in self.area_to_placements[area_id]
+            )
+
+        return total_distance
+
+    def _run_solver(self) -> tuple[list[AERPacketZXYCopy], list[list[CoordXY]]]:
+        solver = cp_model.CpSolver()
+        num_cpu_threads = os.cpu_count() or 2
+        solver.parameters.num_workers = min(8, max(1, num_cpu_threads // 2))
+        solver.parameters.max_time_in_seconds = self.max_time_in_seconds
+        solver.parameters.max_memory_in_mb = self.max_memory_in_mb
+        if self.feasibility_only:
+            solver.parameters.stop_after_first_solution = True
+
+        status = solver.solve(self.model)
+        if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+            raise RuntimeError(
+                f"No solution found. Solver status: {solver.StatusName(status)}."
+            )
+
+        copy_configs: list[AERPacketZXYCopy] = []
+        coords: list[list[CoordXY]] = []
+        for area_placements in self.area_to_placements:
+            for placement_id in area_placements:
+                if solver.value(self.x[placement_id]) != 1:
+                    continue
+                placement = self.placements[placement_id]
+                copy_configs.append(placement.shape.copy_config.copy())
+                coords.append(list(placement.coords))
+                break
+
+        return copy_configs, coords
 
 
-SHAPES_BY_AREA, COPY_CONFIGS, SHAPE_BBOXES = get_shapes_by_area()
-MAX_AREA = max(SHAPES_BY_AREA.keys())
+def _route_io_area_ids(
+    routing_groups: Sequence[RoutingGroup], input_groups: Sequence[InputGroup]
+) -> tuple[list[int], list[int]]:
+    """Derive route area ids that should stay near the selected IO endpoint."""
+    area_by_rg = {rg: area_id for area_id, rg in enumerate(routing_groups)}
+
+    input_area_ids: set[int] = set()
+    for in_grp in input_groups:
+        for elem in in_grp.raw_elems:
+            dest_group = in_grp.get_dest(elem)
+            if isinstance(dest_group, RoutingGroup):
+                input_area_ids.add(area_by_rg[dest_group])
+
+    output_area_ids: set[int] = set()
+    for rg, area_id in area_by_rg.items():
+        for elem in rg.raw_elems:
+            if isinstance(rg.get_dest(elem), OutputGroup):
+                output_area_ids.add(area_id)
+                break
+
+    return sorted(input_area_ids), sorted(output_area_ids)
 
 
-# ---------------- 主求解函数 ----------------
 def route_solve(
-    areas=[1],
-    next_area_id={},
-    io_target=(0, 0),
-    input_area_ids=[],
-    output_area_ids=[],
+    routing_groups: Sequence[RoutingGroup],
+    next_area_id: Mapping[int, Sequence[int]],
+    input_groups: Sequence[InputGroup],
+    scope: RouteScope | None = None,
+    io_bias_coord: CoordXYLike | None = None,
     *,
     feasibility_only: bool = False,
     max_time_in_seconds: float = 120.0,
     max_memory_in_mb: int = 4096,
-):
-    num_areas = len(areas)
+) -> tuple[list[AERPacketZXYCopy], list[list[CoordXY]]]:
+    """Solve route placement for backendv2 routing groups.
 
-    # ---- 生成 placement ----
-    placements = []
-    placement_cells = []
+    Args:
+        routing_groups: Topologically ordered backendv2 routing groups to
+            place.
+        next_area_id: Area-level successor graph using indexes into
+            `routing_groups`.
+        input_groups: Backend input groups used to derive input-side route area
+            ids for IO placement bias.
+        scope: Board route scope for placement and route-grid legality.
+            Defaults to the single-chip scope.
+        io_bias_coord: Route coordinate or CPU endpoint used by the soft
+            input/output placement bias.
+        feasibility_only: Whether to stop after the first feasible solution and
+            skip soft objective construction.
+        max_time_in_seconds: CP-SAT solve time limit. Defaults to ``120.0``.
+        max_memory_in_mb: CP-SAT memory limit. Defaults to ``4096``.
 
-    for area_id, area in enumerate(areas):
-        # 找到 ≥ 需求面积的最小可用面积
-        shapes = []
-        bboxes = []
-        chosen_area_size = None
-        for selected_area in range(area, MAX_AREA + 1):
-            if selected_area in SHAPES_BY_AREA:
-                shapes = SHAPES_BY_AREA[selected_area]
-                bboxes = SHAPE_BBOXES[selected_area]
-                chosen_area_size = selected_area
-                break
-        if chosen_area_size is None:
-            raise RuntimeError(f"No shape found for area_id={area_id} size>={area}")
+    Returns:
+        Pair of multicast copy configs and absolute offline-core coordinates,
+        ordered to match `routing_groups`.
 
-        for shape_id, shape in enumerate(shapes):
-            sb = bboxes[shape_id]  # (sxmin, sxmax, symin, symax)
-            for h in HIVE:
-                shifted = [(h[0] + s.x, h[1] + s.y) for s in shape]
-                if all(c in HIVE for c in shifted):
-                    xs = [c[0] for c in shifted]
-                    ys = [c[1] for c in shifted]
-                    placement_dict = {
-                        "actual_area": chosen_area_size,
-                        "area_id": area_id,
-                        "shape_id": shape_id,
-                        "cells": [HIVE_INDEX[c] for c in shifted],
-                        "area": len(shifted),
-                        "absolute_coords": shifted,
-                        "center_r": round(sum(xs) / len(shifted)),
-                        "center_c": round(sum(ys) / len(shifted)),
-                        "bbox_x_min": min(xs),
-                        "bbox_x_max": max(xs),
-                        "bbox_y_min": min(ys),
-                        "bbox_y_max": max(ys),
-                        "shape_bbox": sb,
-                    }
-                    placements.append(placement_dict)
-                    placement_cells.append(placement_dict["cells"])
-
-    N = len(placements)
-
-    model = cp_model.CpModel()
-
-    # x present whether each placement is used
-    x = [model.new_bool_var(f"x_{i}") for i in range(N)]
-
-    cell_to_xs = [[] for _ in range(len(HIVE_LIST))]
-    area_to_xs = [[] for _ in range(num_areas)]
-    area_to_placements = [[] for _ in range(num_areas)]
-    for i, p in enumerate(placements):
-        area_to_xs[p["area_id"]].append(x[i])
-        area_to_placements[p["area_id"]].append(i)
-        for h_idx in placement_cells[i]:
-            cell_to_xs[h_idx].append(x[i])
-
-    # each hive cell can be covered at most once
-    for covering_xs in cell_to_xs:
-        if len(covering_xs) > 1:
-            model.add_at_most_one(covering_xs)
-
-    # each area is placed exactly once
-    for area_xs in area_to_xs:
-        model.add_exactly_one(area_xs)
-
-    # ---- 中心坐标 ----
-    cx = [model.new_int_var(X_START, X_END - 1, f"cx_{a}") for a in range(num_areas)]
-    cy = [model.new_int_var(Y_START, Y_END - 1, f"cy_{a}") for a in range(num_areas)]
-
-    # ---- 新增: 每个 area 的 shape bbox 与占位 bbox ----
-    # shape bbox 取值范围: shape 偏移 ∈ [0, 8] 这里用 [-8, 8] 安全
-    sxmin = [model.new_int_var(-8, 8, f"sxmin_{a}") for a in range(num_areas)]
-    sxmax = [model.new_int_var(-8, 8, f"sxmax_{a}") for a in range(num_areas)]
-    symin = [model.new_int_var(-8, 8, f"symin_{a}") for a in range(num_areas)]
-    symax = [model.new_int_var(-8, 8, f"symax_{a}") for a in range(num_areas)]
-
-    bx_min = [
-        model.new_int_var(X_START, X_END - 1, f"bxmin_{a}") for a in range(num_areas)
-    ]
-    bx_max = [
-        model.new_int_var(X_START, X_END - 1, f"bxmax_{a}") for a in range(num_areas)
-    ]
-    by_min = [
-        model.new_int_var(Y_START, Y_END - 1, f"bymin_{a}") for a in range(num_areas)
-    ]
-    by_max = [
-        model.new_int_var(Y_START, Y_END - 1, f"bymax_{a}") for a in range(num_areas)
-    ]
-
-    # Exactly-one placement lets us bind selected attributes with one weighted sum.
-    for a, area_placements in enumerate(area_to_placements):
-        model.add(
-            cx[a] == sum(placements[i]["center_r"] * x[i] for i in area_placements)
-        )
-        model.add(
-            cy[a] == sum(placements[i]["center_c"] * x[i] for i in area_placements)
-        )
-        model.add(
-            sxmin[a]
-            == sum(placements[i]["shape_bbox"][0] * x[i] for i in area_placements)
-        )
-        model.add(
-            sxmax[a]
-            == sum(placements[i]["shape_bbox"][1] * x[i] for i in area_placements)
-        )
-        model.add(
-            symin[a]
-            == sum(placements[i]["shape_bbox"][2] * x[i] for i in area_placements)
-        )
-        model.add(
-            symax[a]
-            == sum(placements[i]["shape_bbox"][3] * x[i] for i in area_placements)
-        )
-        model.add(
-            bx_min[a]
-            == sum(placements[i]["bbox_x_min"] * x[i] for i in area_placements)
-        )
-        model.add(
-            bx_max[a]
-            == sum(placements[i]["bbox_x_max"] * x[i] for i in area_placements)
-        )
-        model.add(
-            by_min[a]
-            == sum(placements[i]["bbox_y_min"] * x[i] for i in area_placements)
-        )
-        model.add(
-            by_max[a]
-            == sum(placements[i]["bbox_y_max"] * x[i] for i in area_placements)
+    Raises:
+        ValueError: If required offline cores exceed the selected scope's
+            offline capacity.
+    """
+    resolved_scope = scope or get_route_scope("single")
+    areas = [rg.n_core_required for rg in routing_groups]
+    if sum(areas) > len(resolved_scope.offline_core_coords):
+        raise ValueError(
+            f"Total cores needed {sum(areas)} exceeds the "
+            f"{len(resolved_scope.offline_core_coords)} offline cores "
+            f"available on target_board={resolved_scope.name!r}."
         )
 
-    # ---- 新增约束 A: 通信约束 i -> j ----
-    # area i 中每个点按 area j 的 shape 展开都必须落在 G 内
-    for i, succs in next_area_id.items():
-        for j in succs:
-            model.add(bx_min[i] + sxmin[j] >= G_X_MIN)
-            model.add(bx_max[i] + sxmax[j] <= G_X_MAX)
-            model.add(by_min[i] + symin[j] >= G_Y_MIN)
-            model.add(by_max[i] + symax[j] <= G_Y_MAX)
-
-    # ---- 新增约束 B: 源 area (无入边) 以 (0,0) 为基点展开必须在 G 内 ----
-    has_incoming = {j for succs in next_area_id.values() for j in succs}
-    sources = [a for a in range(num_areas) if a not in has_incoming]
-
-    for a in sources:
-        model.add(0 + sxmin[a] >= G_X_MIN)
-        model.add(0 + sxmax[a] <= G_X_MAX)
-        model.add(0 + symin[a] >= G_Y_MIN)
-        model.add(0 + symax[a] <= G_Y_MAX)
-
-    # ---- 距离建模 ----
-    total_distance = 0
-    for i, next_list in next_area_id.items():
-        for j in next_list:
-            dx = model.new_int_var(0, X_END - 1, f"dx_{i}_{j}")
-            dy = model.new_int_var(0, Y_END - 1, f"dy_{i}_{j}")
-            model.add_abs_equality(dx, cx[j] - cx[i])
-            model.add_abs_equality(dy, cy[j] - cy[i])
-            total_distance += dx + dy
-
-    for area_id in itertools.chain(input_area_ids, output_area_ids):
-        total_distance += sum(
-            (
-                abs(placements[i]["center_r"] - io_target[0])
-                + abs(placements[i]["center_c"] - io_target[1])
-            )
-            * x[i]
-            for i in area_to_placements[area_id]
-        )
-
-    model.minimize(total_distance)
-
-    solver = cp_model.CpSolver()
-
-    num_cpu_threads = os.cpu_count() or 2
-    solver.parameters.num_search_workers = min(8, max(1, num_cpu_threads // 2))
-    solver.parameters.max_time_in_seconds = max_time_in_seconds
-    solver.parameters.max_memory_in_mb = max_memory_in_mb
-    if feasibility_only:
-        # feasibility_only keeps the objective but skips proving optimality.
-        solver.parameters.stop_after_first_solution = True
-    # solver.parameters.log_search_progress = True
-    status = solver.solve(model)
-
-    copy_configs: list[AERPacketZXYCopy] = []
-    coords: list[list[CoordXY]] = []
-
-    if status in (cp_model.OPTIMAL, cp_model.FEASIBLE):
-        for i in range(N):
-            if solver.value(x[i]) == 1:
-                p = placements[i]
-                copy_config = COPY_CONFIGS[p["actual_area"]][p["shape_id"]]
-                copy_configs.append(copy_config)
-                coords.append([CoordXY(r, c) for r, c in p["absolute_coords"]])
-    else:
-        print("No solution found or solver timed out.")
-        print(f"Solver status: {solver.StatusName(status)}")
-        raise RuntimeError("No solution found or solver timed out.")
-
-    return copy_configs, coords
+    input_area_ids, output_area_ids = _route_io_area_ids(routing_groups, input_groups)
+    solver = RouteSolver(
+        areas,
+        next_area_id,
+        resolved_scope,
+        io_bias_coord,
+        input_area_ids,
+        output_area_ids,
+        feasibility_only=feasibility_only,
+        max_time_in_seconds=max_time_in_seconds,
+        max_memory_in_mb=max_memory_in_mb,
+    )
+    return solver.solve()

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -214,9 +214,9 @@ class SourceGroup(Generic[SOURCE_ELEM, SOURCE_NODE]):
         if isinstance(dest_routing_group, RoutingGroup):
             axon_addr_logic = dest_routing_group.index_map.get(axon_elem, -1)
             assert axon_addr_logic >= 0, "axon_addr_logic should be non-negative"
-            assert elems[0].output_bit_num == dest_routing_group.input_bit_num, (
-                "Output bit num of elem must match input bit num of dest routing group"
-            )
+            assert (
+                elems[0].output_bit_num == dest_routing_group.input_bit_num
+            ), "Output bit num of elem must match input bit num of dest routing group"
             axon_bit_count = axon_addr_logic * dest_routing_group.input_bit_num
         elif isinstance(dest_routing_group, OutputGroup):
             axon_bit_count = -1
@@ -300,12 +300,12 @@ class RemapGroup(
         for node in self.nodes:
             remap_info = node.get_remap_info()
             self.remap_dict.update(remap_info)
-        assert set(self.remap_dict.keys()) == self.input_set, (
-            "remap_info keys must match input_set"
-        )
-        assert set(self.remap_dict.values()).issubset(set(self.raw_elems)), (
-            "remap_info values must match raw_neus"
-        )
+        assert (
+            set(self.remap_dict.keys()) == self.input_set
+        ), "remap_info keys must match input_set"
+        assert set(self.remap_dict.values()).issubset(
+            set(self.raw_elems)
+        ), "remap_info values must match raw_neus"
 
         for src, dst in self.remap_dict.items():
             self.source_dict[dst] = src
@@ -417,19 +417,19 @@ class RoutingGroup(
         pred_output_bit_nums: set[int] = set(
             [src.output_bit_num for src in self.input_list]
         )
-        assert len(intput_bit_nums) == 1, (
-            "All neurons in the routing group must have the same input bit num."
-        )
-        assert len(pred_output_bit_nums) == 1, (
-            "All input elements in the routing group must have the same output bit num."
-        )
+        assert (
+            len(intput_bit_nums) == 1
+        ), "All neurons in the routing group must have the same input bit num."
+        assert (
+            len(pred_output_bit_nums) == 1
+        ), "All input elements in the routing group must have the same output bit num."
         # print(f"{self.raw_elems[0]}: input_bit_nums: {intput_bit_nums}")
         # print(f"{self.input_list[0]}: pred_output_bit_nums: {pred_output_bit_nums}")
 
         self.input_bit_num = intput_bit_nums.pop()
-        assert self.input_bit_num == pred_output_bit_nums.pop(), (
-            "Input bit num of neurons must match output bit num of input elements."
-        )
+        assert (
+            self.input_bit_num == pred_output_bit_nums.pop()
+        ), "Input bit num of neurons must match output bit num of input elements."
         max_axon_addr = len(self.input_list) * self.input_bit_num
         lcn = ((max_axon_addr - 1) // FANIN_BASE).bit_length()
         if self.recommand_lcn is not None and lcn < self.recommand_lcn.value:
@@ -679,9 +679,7 @@ class RoutingGroup(
                         1,
                         1,
                         1,
-                    ], (
-                        "Folded neurons sending to output group should have axon skew of 1"
-                    )
+                    ], "Folded neurons sending to output group should have axon skew of 1"
 
                 fold_attrs_part1 = OfflineNeuFoldedAttrsV2Part1(
                     fold_axon_y=fold_axon_skews[0] * dest_group.input_bit_num,
@@ -891,9 +889,9 @@ class RoutingGroup(
             core_placement.set_weight_address()
 
     def assign_coord(self, coords: list[CoordXY], copy_config: AERPacketZXYCopy):
-        assert len(coords) >= len(self.core_placements), (
-            "Not enough coordinates provided to assign."
-        )
+        assert len(coords) >= len(
+            self.core_placements
+        ), "Not enough coordinates provided to assign."
         for i, coord in enumerate(coords):
             if i < len(self.core_placements):
                 self.assigned_cores[coord] = self.core_placements[i]

--- a/paibox/backendv2/routing.py
+++ b/paibox/backendv2/routing.py
@@ -214,9 +214,9 @@ class SourceGroup(Generic[SOURCE_ELEM, SOURCE_NODE]):
         if isinstance(dest_routing_group, RoutingGroup):
             axon_addr_logic = dest_routing_group.index_map.get(axon_elem, -1)
             assert axon_addr_logic >= 0, "axon_addr_logic should be non-negative"
-            assert (
-                elems[0].output_bit_num == dest_routing_group.input_bit_num
-            ), "Output bit num of elem must match input bit num of dest routing group"
+            assert elems[0].output_bit_num == dest_routing_group.input_bit_num, (
+                "Output bit num of elem must match input bit num of dest routing group"
+            )
             axon_bit_count = axon_addr_logic * dest_routing_group.input_bit_num
         elif isinstance(dest_routing_group, OutputGroup):
             axon_bit_count = -1
@@ -300,12 +300,12 @@ class RemapGroup(
         for node in self.nodes:
             remap_info = node.get_remap_info()
             self.remap_dict.update(remap_info)
-        assert (
-            set(self.remap_dict.keys()) == self.input_set
-        ), "remap_info keys must match input_set"
-        assert set(self.remap_dict.values()).issubset(
-            set(self.raw_elems)
-        ), "remap_info values must match raw_neus"
+        assert set(self.remap_dict.keys()) == self.input_set, (
+            "remap_info keys must match input_set"
+        )
+        assert set(self.remap_dict.values()).issubset(set(self.raw_elems)), (
+            "remap_info values must match raw_neus"
+        )
 
         for src, dst in self.remap_dict.items():
             self.source_dict[dst] = src
@@ -417,19 +417,19 @@ class RoutingGroup(
         pred_output_bit_nums: set[int] = set(
             [src.output_bit_num for src in self.input_list]
         )
-        assert (
-            len(intput_bit_nums) == 1
-        ), "All neurons in the routing group must have the same input bit num."
-        assert (
-            len(pred_output_bit_nums) == 1
-        ), "All input elements in the routing group must have the same output bit num."
+        assert len(intput_bit_nums) == 1, (
+            "All neurons in the routing group must have the same input bit num."
+        )
+        assert len(pred_output_bit_nums) == 1, (
+            "All input elements in the routing group must have the same output bit num."
+        )
         # print(f"{self.raw_elems[0]}: input_bit_nums: {intput_bit_nums}")
         # print(f"{self.input_list[0]}: pred_output_bit_nums: {pred_output_bit_nums}")
 
         self.input_bit_num = intput_bit_nums.pop()
-        assert (
-            self.input_bit_num == pred_output_bit_nums.pop()
-        ), "Input bit num of neurons must match output bit num of input elements."
+        assert self.input_bit_num == pred_output_bit_nums.pop(), (
+            "Input bit num of neurons must match output bit num of input elements."
+        )
         max_axon_addr = len(self.input_list) * self.input_bit_num
         lcn = ((max_axon_addr - 1) // FANIN_BASE).bit_length()
         if self.recommand_lcn is not None and lcn < self.recommand_lcn.value:
@@ -679,7 +679,9 @@ class RoutingGroup(
                         1,
                         1,
                         1,
-                    ], "Folded neurons sending to output group should have axon skew of 1"
+                    ], (
+                        "Folded neurons sending to output group should have axon skew of 1"
+                    )
 
                 fold_attrs_part1 = OfflineNeuFoldedAttrsV2Part1(
                     fold_axon_y=fold_axon_skews[0] * dest_group.input_bit_num,
@@ -889,9 +891,9 @@ class RoutingGroup(
             core_placement.set_weight_address()
 
     def assign_coord(self, coords: list[CoordXY], copy_config: AERPacketZXYCopy):
-        assert len(coords) >= len(
-            self.core_placements
-        ), "Not enough coordinates provided to assign."
+        assert len(coords) >= len(self.core_placements), (
+            "Not enough coordinates provided to assign."
+        )
         for i, coord in enumerate(coords):
             if i < len(self.core_placements):
                 self.assigned_cores[coord] = self.core_placements[i]
@@ -1012,9 +1014,9 @@ class InputGroup(Group, SourceGroup[InputElem, InNode]):
     def __str__(self) -> str:
         return self.info()
 
-    def set_detail_dest(self) -> None:
+    def set_detail_dest(self, input_coord: CoordXY = CoordXY(0, 0)) -> None:
         for elem in self.raw_elems:
-            dest_info = self.get_detail_dest([elem])
+            dest_info = self.get_detail_dest([elem], input_coord)
             self.dest_infos[elem] = dest_info
             dest_rg = self.get_dest(elem)
             self.dest_lcn[elem] = dest_rg.lcn
@@ -1218,6 +1220,15 @@ class OutputGroup(Group, DestGroup[SourceElem, SourceNode]):
     @property
     def base_coord(self) -> CoordXY:
         return self._base_coord
+
+    def set_base_coord(self, coord: CoordXY) -> None:
+        """Set the CPU endpoint used as this output group's destination.
+
+        Args:
+            coord: CPU endpoint coordinate used by output DATA routes.
+        """
+
+        self._base_coord = coord
 
 
 def toposort_for_rg(

--- a/paibox/visualizer/backends/v2/frame_parser.py
+++ b/paibox/visualizer/backends/v2/frame_parser.py
@@ -1,37 +1,31 @@
+from paicorelib import (
+    global_signal_direction_from_name,
+    global_signal_direction_name,
+    global_signal_direction_names,
+    global_signal_directions,
+    global_signal_opposite_direction,
+)
+
 from ...model import CoreRole
 
 GRID_WIDTH = 9
 GRID_HEIGHT = 9
 CHIP_ID = 0
 
-_DIRS_BY_BIT = {
-    5: ("+xy", (1, 1)),
-    4: ("-xy", (-1, -1)),
-    3: ("+x", (1, 0)),
-    2: ("-x", (-1, 0)),
-    1: ("+y", (0, 1)),
-    0: ("-y", (0, -1)),
+GLOBAL_SIGNAL_DIRECTIONS = {
+    global_signal_direction_name(direction): (direction.value.x, direction.value.y)
+    for direction in global_signal_directions()
 }
-GLOBAL_SIGNAL_DIRECTIONS = {name: delta for _, (name, delta) in _DIRS_BY_BIT.items()}
 GLOBAL_SIGNAL_REVERSE_DIRECTIONS = {
-    "+xy": "-xy",
-    "-xy": "+xy",
-    "+x": "-x",
-    "-x": "+x",
-    "+y": "-y",
-    "-y": "+y",
+    name: global_signal_direction_name(
+        global_signal_opposite_direction(global_signal_direction_from_name(name))
+    )
+    for name in GLOBAL_SIGNAL_DIRECTIONS
 }
 
 
 def global_signal_dirs(bits: int, *, include_local: bool = False) -> list[str]:
-    dirs = [
-        name
-        for bit, (name, _) in sorted(_DIRS_BY_BIT.items(), reverse=True)
-        if bits & (1 << bit)
-    ]
-    if include_local and bits & (1 << 6):
-        dirs.insert(0, "local")
-    return dirs
+    return list(global_signal_direction_names(bits, include_local=include_local))
 
 
 def reverse_global_signal_dir(direction: str) -> str:

--- a/paibox/visualizer/backends/v2/offline_v2.py
+++ b/paibox/visualizer/backends/v2/offline_v2.py
@@ -13,6 +13,7 @@ from paicorelib import (
     PoolingMode,
     SNNMode,
     ZeroOutputMode,
+    global_signal_direction_names,
 )
 from paicorelib.framelib.frame_defs import OfflineConfigFrame3FormatV2
 from paicorelib.framelib.parser_v2 import (
@@ -851,16 +852,6 @@ def build_raw_frame_records(
 _F3 = OfflineConfigFrame3FormatV2
 
 
-_DIRS_BY_BIT = {
-    5: "+xy",
-    4: "-xy",
-    3: "+x",
-    2: "-x",
-    1: "+y",
-    0: "-y",
-}
-
-
 def bit_field(value: int, offset: int, mask: int) -> int:
     return (value >> offset) & mask
 
@@ -869,17 +860,6 @@ def sign_magnitude_to_int(value: int, bits: int = 6) -> int:
     sign = value >> (bits - 1)
     magnitude = value & ((1 << (bits - 1)) - 1)
     return -magnitude if sign else magnitude
-
-
-def _global_signal_dirs(bits: int, *, include_local: bool = False) -> list[str]:
-    dirs = [
-        name
-        for bit, name in sorted(_DIRS_BY_BIT.items(), reverse=True)
-        if bits & (1 << bit)
-    ]
-    if include_local and bits & (1 << 6):
-        dirs.insert(0, "local")
-    return dirs
 
 
 def _decode_half_or_full_record(
@@ -1688,7 +1668,7 @@ def _bitset_field(
     include_local: bool,
 ) -> DecodedField:
     raw = values.get(name, 0)
-    dirs = _global_signal_dirs(raw, include_local=include_local)
+    dirs = global_signal_direction_names(raw, include_local=include_local)
     label = ", ".join(dirs) if dirs else "none"
     return DecodedField(
         name=name,

--- a/poetry.lock
+++ b/poetry.lock
@@ -41,12 +41,12 @@ version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
+markers = "platform_machine != \"armv7l\" or extra == \"visualizer\""
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
 ]
-markers = {main = "extra == \"visualizer\"", dev = "platform_machine != \"armv7l\""}
 
 [package.source]
 type = "legacy"
@@ -90,7 +90,7 @@ files = [
     {file = "certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"},
     {file = "certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"},
 ]
-markers = {main = "python_version < \"3.12\" and extra == \"spikingjelly\"", dev = "python_version < \"3.12\""}
+markers = {main = "extra == \"spikingjelly\" and python_version < \"3.12\"", dev = "python_version < \"3.12\""}
 
 [package.source]
 type = "legacy"
@@ -219,7 +219,7 @@ files = [
     {file = "charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f"},
     {file = "charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a"},
 ]
-markers = {main = "python_version < \"3.12\" and extra == \"spikingjelly\"", dev = "python_version < \"3.12\""}
+markers = {main = "extra == \"spikingjelly\" and python_version < \"3.12\"", dev = "python_version < \"3.12\""}
 
 [package.source]
 type = "legacy"
@@ -909,7 +909,7 @@ files = [
     {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
     {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
 ]
-markers = {main = "(python_version < \"3.12\" or extra == \"visualizer\") and (extra == \"visualizer\" or extra == \"spikingjelly\")", dev = "python_version < \"3.12\""}
+markers = {main = "(extra == \"visualizer\" or extra == \"spikingjelly\") and (python_version < \"3.12\" or extra == \"visualizer\")", dev = "python_version < \"3.12\""}
 
 [package.extras]
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
@@ -1923,16 +1923,16 @@ reference = "tsinghua"
 
 [[package]]
 name = "paicorelib"
-version = "2.0.0rc3"
+version = "2.0.0"
 description = "Library of PAICORE"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["main"]
+markers = "platform_machine != \"armv7l\""
 files = [
-    {file = "paicorelib-2.0.0rc3-py3-none-any.whl", hash = "sha256:8edf170025830395ee25f0690953ddfc53be8ffec17900ffc5da29aab31a8b28"},
-    {file = "paicorelib-2.0.0rc3.tar.gz", hash = "sha256:86fd0131e5c27a2bc90eeefb6a3d479ea9a908c35cffbaa00f3fd56f7e4e582a"},
+    {file = "paicorelib-2.0.0-py3-none-any.whl", hash = "sha256:5d200adfe15ffb2b3a92d2f7f4ea24d25cbecaf29a3ffe6ee16e1c6b4a69000e"},
+    {file = "paicorelib-2.0.0.tar.gz", hash = "sha256:9a41a1524025d8ab5955014569fde35ba5f0af7607c608bfd5a7cd3eb2899fe5"},
 ]
-markers = {main = "extra == \"visualizer\" and platform_machine != \"armv7l\"", dev = "platform_machine != \"armv7l\""}
 
 [package.dependencies]
 numpy = [
@@ -2339,12 +2339,12 @@ version = "2.12.5"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
+markers = "platform_machine != \"armv7l\" or extra == \"visualizer\""
 files = [
     {file = "pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d"},
     {file = "pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49"},
 ]
-markers = {main = "extra == \"visualizer\"", dev = "platform_machine != \"armv7l\""}
 
 [package.dependencies]
 annotated-types = ">=0.6.0"
@@ -2367,7 +2367,8 @@ version = "2.41.5"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
+markers = "platform_machine != \"armv7l\" or extra == \"visualizer\""
 files = [
     {file = "pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146"},
     {file = "pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2"},
@@ -2491,7 +2492,6 @@ files = [
     {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51"},
     {file = "pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e"},
 ]
-markers = {main = "extra == \"visualizer\"", dev = "platform_machine != \"armv7l\""}
 
 [package.dependencies]
 typing-extensions = ">=4.14.1"
@@ -2692,7 +2692,7 @@ files = [
     {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
     {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
 ]
-markers = {main = "python_version < \"3.12\" and extra == \"spikingjelly\"", dev = "python_version < \"3.12\""}
+markers = {main = "extra == \"spikingjelly\" and python_version < \"3.12\"", dev = "python_version < \"3.12\""}
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -3121,7 +3121,7 @@ files = [
     {file = "torch-2.1.2+cpu-cp39-cp39-linux_x86_64.whl", hash = "sha256:10df25736edb00852eca6041941e99d13502e65773d5c6164372eaaab83d976b"},
     {file = "torch-2.1.2+cpu-cp39-cp39-win_amd64.whl", hash = "sha256:83bac7f809c09700c227abc9e3474e3a847a3f4c1bb2443aa16004f36a1e7e43"},
 ]
-markers = {main = "python_version < \"3.12\" and extra == \"spikingjelly\"", dev = "python_version < \"3.12\""}
+markers = {main = "extra == \"spikingjelly\" and python_version < \"3.12\"", dev = "python_version < \"3.12\""}
 
 [package.dependencies]
 filelock = "*"
@@ -3217,7 +3217,7 @@ files = [
     {file = "torchvision-0.16.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:8199acdf8ab066a28b84a5b6f4d97b58976d9e164b1acc3a9d14fccfaf74bb3a"},
     {file = "torchvision-0.16.2-cp39-cp39-win_amd64.whl", hash = "sha256:41dd4fa9f176d563fe9f1b9adef3b7e582cdfb60ce8c9bc51b094a025be687c9"},
 ]
-markers = {main = "python_version < \"3.12\" and extra == \"spikingjelly\"", dev = "python_version < \"3.12\""}
+markers = {main = "extra == \"spikingjelly\" and python_version < \"3.12\"", dev = "python_version < \"3.12\""}
 
 [package.dependencies]
 numpy = "*"
@@ -3321,7 +3321,7 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {main = "extra == \"visualizer\" or extra == \"spikingjelly\""}
+markers = {main = "platform_machine != \"armv7l\" or extra == \"visualizer\" or extra == \"spikingjelly\""}
 
 [package.source]
 type = "legacy"
@@ -3334,12 +3334,12 @@ version = "0.4.2"
 description = "Runtime typing introspection tools"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
+markers = "platform_machine != \"armv7l\" or extra == \"visualizer\""
 files = [
     {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
     {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
 ]
-markers = {main = "extra == \"visualizer\"", dev = "platform_machine != \"armv7l\""}
 
 [package.dependencies]
 typing-extensions = ">=4.12.0"
@@ -3378,7 +3378,7 @@ files = [
     {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
     {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
 ]
-markers = {main = "python_version < \"3.12\" and extra == \"spikingjelly\"", dev = "python_version < \"3.12\""}
+markers = {main = "extra == \"spikingjelly\" and python_version < \"3.12\"", dev = "python_version < \"3.12\""}
 
 [package.extras]
 brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
@@ -3421,9 +3421,9 @@ reference = "tsinghua"
 nir = ["nir"]
 snntorch = ["snntorch"]
 spikingjelly = ["spikingjelly"]
-visualizer = ["fastapi", "paicorelib", "uvicorn"]
+visualizer = ["fastapi", "uvicorn"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "8e2ca25314a0904d2e95506a220db0d8c0e093df4725993bdf647dd0fb756d15"
+content-hash = "6b10c91172143a31703021e81ec774fd4a73de761931db0f585e82cdf3cd919d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "click>=8.1.0,<9",
     "flatbuffers==25.12.19",
     "numpy>=2.1.0,<3.0.0",
+    "paicorelib>=2.0.0; platform_machine != 'armv7l'",
     "protobuf>=5.27.1,<7",
     "rich>=14.0.0",
 ]
@@ -38,11 +39,7 @@ keywords = ["PAICORE", "neuromorphic-chip", "toolchain", "brain-inspired-ai"]
 paiviz = "paibox.visualizer.cli:main"
 
 [project.optional-dependencies]
-visualizer = [
-    "fastapi>=0.128.0,<1",
-    "paicorelib>=2.0.0rc3 ; platform_machine != 'armv7l'",
-    "uvicorn>=0.38.0,<1",
-]
+visualizer = ["fastapi>=0.128.0,<1", "uvicorn>=0.38.0,<1"]
 snntorch = ["snntorch>=0.9.0"]
 spikingjelly = ["spikingjelly>=0.0.0.0.12"]
 nir = ["nir>=1.0.6,<2"]
@@ -62,7 +59,6 @@ dev = [
     "pytest-md>=0.2",
     "pytest-xdist>=3.7.0",
     "orjson>=3.11.6",
-    "paicorelib>=2.0.0rc3 ; platform_machine != 'armv7l'",
     "torch>=2.0.0,<2.2.0 ; python_full_version < '3.12'",
     "torch>=2.2.0 ; python_full_version >= '3.12'",
     "spikingjelly>=0.0.0.0.12",

--- a/tests/backendv2/test_global_signal.py
+++ b/tests/backendv2/test_global_signal.py
@@ -1,5 +1,5 @@
 import pytest
-from paicorelib import CoordXY
+from paicorelib import CoordXY, global_signal_direction_names
 
 from paibox.backendv2.coreplacement import (
     EmptyOfflineCorePlacementV2,
@@ -41,3 +41,18 @@ def test_set_global_signal_is_quiet_by_default(capsys):
     set_global_signal(cores, root, {root: "offline"})
 
     assert capsys.readouterr().out == ""
+
+
+def test_set_global_signal_local_bit_stays_off_for_added_relay_core():
+    root = CoordXY(1, 1)
+    cores = [_offline_core(CoordXY(3, 3))]
+
+    placements, _ = set_global_signal(cores, root, {root: "offline"})
+
+    by_coord = {placement.coord: placement for placement in placements}
+    assert "local" in global_signal_direction_names(
+        by_coord[CoordXY(3, 3)].auto_core_config.global_send, include_local=True
+    )
+    assert "local" not in global_signal_direction_names(
+        by_coord[CoordXY(2, 2)].auto_core_config.global_send, include_local=True
+    )

--- a/tests/backendv2/test_mapper.py
+++ b/tests/backendv2/test_mapper.py
@@ -33,7 +33,13 @@ from paibox.backendv2.output_completion_planner import (
     OutputProducer,
 )
 from paibox.backendv2.pressure_unroll import PressureUnrollConfig, PressureUnroller
-from paibox.backendv2.routing import FANIN_BASE, OutputGroup, RoutingGroup
+from paibox.backendv2.routing import (
+    FANIN_BASE,
+    InputGroup,
+    OutputGroup,
+    RemapGroup,
+    RoutingGroup,
+)
 from paibox.paiir import (
     LUT_TABLE_SIZE,
     ANNNodeV25,
@@ -133,6 +139,86 @@ def test_mapper_unroll_pressure_delegates_to_pressure_unroller(monkeypatch):
     )
     calls[0].routing_fn()
     assert routing_calls == [{"feasibility_only": True, "max_time_in_seconds": 30}]
+
+
+def _capture_mapper_route_call(monkeypatch):
+    route_kwargs = {}
+
+    def fake_route_solve(
+        routing_groups=None,
+        next_area_id=None,
+        input_groups=None,
+        scope=None,
+        **kwargs,
+    ):
+        route_kwargs.update(
+            routing_groups=routing_groups,
+            next_area_id=next_area_id,
+            input_groups=input_groups,
+            scope=scope,
+            **kwargs,
+        )
+        return [], []
+
+    monkeypatch.setattr("paibox.backendv2.mapper.route_solve", fake_route_solve)
+    return route_kwargs
+
+
+def test_mapper_passes_routing_context_to_solver(monkeypatch):
+    mapper = Mapper()
+    input_a = object()
+    input_b = object()
+    output_a = object()
+    output_b = object()
+    input_group = InputGroup([input_a, input_b])
+    rg = RoutingGroup([output_a, output_b], [input_a, input_b])
+    output_group = OutputGroup([output_a, output_b])
+
+    input_group.dests[input_a] = rg
+    input_group.dests[input_b] = rg
+    rg.dests[output_a] = output_group
+    rg.dests[output_b] = output_group
+    rg.core_placements = [OfflineCorePlacementV2()]
+
+    mapper.input_groups = [input_group]
+    mapper.output_groups = [output_group]
+    mapper.routing_groups = [rg]
+    mapper.next_rg_group = {0: []}
+    route_kwargs = _capture_mapper_route_call(monkeypatch)
+
+    mapper.routing()
+
+    assert route_kwargs["routing_groups"] == [rg]
+    assert route_kwargs["input_groups"] == [input_group]
+    assert route_kwargs["scope"] is mapper.route_scope
+
+
+def test_mapper_passes_remap_input_context_to_solver(monkeypatch):
+    mapper = Mapper()
+    input_elem = object()
+    input_group = InputGroup([input_elem])
+    rg = RoutingGroup([], [input_elem])
+    remap_group = RemapGroup.__new__(RemapGroup)
+
+    def remap_dest(_elem):
+        return rg
+
+    remap_group.remap_dest = remap_dest
+
+    input_group.dests[input_elem] = remap_group
+    rg.core_placements = [OfflineCorePlacementV2()]
+
+    mapper.input_groups = [input_group]
+    mapper.output_groups = []
+    mapper.routing_groups = [rg]
+    mapper.next_rg_group = {0: []}
+    route_kwargs = _capture_mapper_route_call(monkeypatch)
+
+    mapper.routing()
+
+    assert route_kwargs["routing_groups"] == [rg]
+    assert route_kwargs["input_groups"] == [input_group]
+    assert route_kwargs["scope"] is mapper.route_scope
 
 
 class DefaultMixedSparseDenseLinear(nn.Module):

--- a/tests/backendv2/test_output_completion_planner.py
+++ b/tests/backendv2/test_output_completion_planner.py
@@ -1,5 +1,5 @@
 import pytest
-from paicorelib import CoordXY, CoordZXYOffset
+from paicorelib import CoordXY, CoordZXYOffset, route_coord_path
 
 from paibox.backendv2 import output_completion_planner as planner_mod
 from paibox.backendv2.output_completion_planner import (
@@ -10,31 +10,25 @@ from paibox.backendv2.output_completion_planner import (
     OutputProducer,
     OutputRouteDecision,
     candidate_offsets,
-    debug_output_completion_plan,
-    render_output_completion_plan_ascii,
-    route_coord_path,
-    route_len,
-    route_stays_in_grid,
     select_output_completion_plan,
     terminal_route_side,
     validate_output_completion_plan,
 )
-from paibox.backendv2.route_solver import (
-    CPU_COORD,
-    OFFLINE_CORE_COORDS,
-    ONLINE_CORE_COORDS,
-    is_configurable_thread_core_coord,
-)
+from paibox.backendv2.route_scope import get_route_scope
+
+SINGLE_SCOPE = get_route_scope("single")
 
 
 def _all_empty_offline_except(*used: CoordXY) -> set[CoordXY]:
     used_set = set(used)
-    return {coord for coord in OFFLINE_CORE_COORDS if coord not in used_set}
+    return {
+        coord for coord in SINGLE_SCOPE.offline_core_coords if coord not in used_set
+    }
 
 
 def _all_empty_online_except(*used: CoordXY) -> set[CoordXY]:
     used_set = set(used)
-    return {coord for coord in ONLINE_CORE_COORDS if coord not in used_set}
+    return {coord for coord in SINGLE_SCOPE.online_core_coords if coord not in used_set}
 
 
 def _coord_set(cores: tuple[EmptyThreadCore, ...]) -> set[CoordXY]:
@@ -70,7 +64,10 @@ def _assert_data_prefix_cores_are_required(
         path = route_coord_path(route.producer_coord, route.offset)
         prefix = path[: path.index(plan.completion_join_point) + 1]
         for coord in prefix:
-            if coord != CPU_COORD and is_configurable_thread_core_coord(coord):
+            if (
+                coord not in SINGLE_SCOPE.cpu_coords
+                and SINGLE_SCOPE.is_configurable_thread_core_coord(coord)
+            ):
                 assert coord in final_thread
 
 
@@ -105,15 +102,18 @@ def test_route_coord_path_follows_z_x_y_order():
     )
 
 
-def test_candidate_offsets_are_sorted_by_length_then_offset_tuple():
+def test_candidate_offsets_are_sorted_by_l1_norm_then_offset_tuple():
     offsets = candidate_offsets(CoordXY(3, 4), CoordXY(0, 0))
 
     assert offsets[0] == CoordZXYOffset(-3, 0, -1)
-    assert [route_len(offset) for offset in offsets] == sorted(
-        route_len(offset) for offset in offsets
+    assert [offset.l1_norm() for offset in offsets] == sorted(
+        offset.l1_norm() for offset in offsets
     )
     assert all(
-        route_stays_in_grid(CoordXY(3, 4), offset, CoordXY(0, 0)) for offset in offsets
+        SINGLE_SCOPE.route_path_valid(
+            route_coord_path(CoordXY(3, 4), offset), CoordXY(0, 0)
+        )
+        for offset in offsets
     )
 
 
@@ -421,7 +421,8 @@ def test_same_suffix_falls_back_to_longer_data_route_when_prefix_core_unavailabl
     suffix = next(
         suffix
         for suffix in planner_mod._common_suffixes_for_path(
-            route_coord_path(producer, CoordZXYOffset(2, -2, -3))
+            route_coord_path(producer, CoordZXYOffset(2, -2, -3)),
+            SINGLE_SCOPE,
         )
         if suffix.join_point == join_point
     )
@@ -570,27 +571,3 @@ def test_validate_rejects_online_required_core_when_disabled():
         validate_output_completion_plan(
             plan, (producer,), {CoordXY(1, 1)}, allow_empty_online=False
         )
-
-
-def test_debug_trace_and_ascii_render_show_key_route_points():
-    producers = (OutputProducer(CoordXY(3, 4)), OutputProducer(CoordXY(5, 6)))
-    used = {producer.coord for producer in producers}
-    plan = select_output_completion_plan(
-        list(producers),
-        used,
-        _all_empty_offline_except(*used),
-        _all_empty_online_except(*used),
-    )
-
-    trace = "\n".join(debug_output_completion_plan(plan, producers, used))
-    rendered = render_output_completion_plan_ascii(plan, producers, used)
-
-    assert "source=(3,4)" in trace
-    assert "join=(3,4)" in trace
-    assert "completion_thread_cores" in trace
-    assert "S" in rendered
-    assert "M" in rendered
-    assert "C" in rendered
-    assert "P0=(3,4)" in rendered
-    assert "P1=(5,6)" in rendered
-    assert "*" in rendered

--- a/tests/backendv2/test_pressure_unroll.py
+++ b/tests/backendv2/test_pressure_unroll.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from dataclasses import replace
 
 import pytest
 import torch.nn as nn
@@ -33,6 +34,7 @@ from paibox.backendv2.pressure_unroll import (
     PressureUnroller,
     PressureUnrollStopReason,
 )
+from paibox.backendv2.route_scope import get_route_scope
 from paibox.backendv2.routing import RoutingGroup
 from paibox.backendv2.weight import Weight
 from paibox.paiir.ir.op_node import StandaloneCompOp
@@ -44,8 +46,9 @@ PRESSURE_PER_UNIT = 2048
 @pytest.fixture
 def offline_core_count(monkeypatch: pytest.MonkeyPatch) -> Callable[[int], None]:
     def set_count(count: int) -> None:
-        coords = [CoordXY(i, 0) for i in range(count)]
-        monkeypatch.setattr(pressure_unroll_module, "OFFLINE_CORE_COORDS", coords)
+        coords = frozenset(CoordXY(i, 2) for i in range(count))
+        scope = replace(get_route_scope("single"), offline_core_coords=coords)
+        monkeypatch.setattr(pressure_unroll_module, "get_route_scope", lambda _: scope)
 
     return set_count
 

--- a/tests/backendv2/test_route_scope.py
+++ b/tests/backendv2/test_route_scope.py
@@ -1,0 +1,39 @@
+from paicorelib import CoordXY
+
+from paibox.backendv2.route_scope import get_route_scope
+
+
+def test_single_scope_excludes_cpu_from_route_and_core_pools():
+    scope = get_route_scope("single")
+
+    assert scope.default_cpu.coord == CoordXY(0, 0)
+    assert scope.default_cpu.chip_id == 0
+    assert scope.chip_id(0, 0) == 0
+    assert scope.chip_xy(0) == (0, 0)
+    assert scope.default_cpu.coord not in scope.offline_core_coords
+    assert scope.default_cpu.coord not in scope.online_core_coords
+    assert scope.default_cpu.coord not in scope.global_route_coords
+    assert scope.copy_limits == (6, 8, 6)
+
+
+def test_array_2x2_scope_uses_row_major_chip_ids_and_stride():
+    scope = get_route_scope("array_2x2")
+
+    assert [
+        (cpu.chip_id, cpu.chip_x, cpu.chip_y, cpu.coord) for cpu in scope.cpu_endpoints
+    ] == [
+        (0, 0, 0, CoordXY(0, 0)),
+        (1, 1, 0, CoordXY(9, 0)),
+        (2, 0, 1, CoordXY(0, 9)),
+        (3, 1, 1, CoordXY(9, 9)),
+    ]
+    assert scope.chip_id(1, 0) == 1
+    assert scope.chip_id(0, 1) == 2
+    assert scope.chip_xy(3) == (1, 1)
+    assert len(scope.offline_core_coords) == 4 * len(
+        get_route_scope("single").offline_core_coords
+    )
+    assert all(
+        cpu.coord not in scope.global_route_coords for cpu in scope.cpu_endpoints
+    )
+    assert scope.copy_limits == (6, 17, 6)

--- a/tests/backendv2/test_route_solver.py
+++ b/tests/backendv2/test_route_solver.py
@@ -3,46 +3,80 @@ import os
 import time
 
 import pytest
-from paicorelib.coordinate import CoordXY
-from paicorelib.routing_hexa import AERPacket, aer_packet_walk
+from paicorelib import CoordXY, CoordXYOffset, aer_packet_copy_offsets
 
-from paibox.backendv2.route_solver import (
-    MAX_AREA,
-    OFFLINE_CORE_COORDS,
-    is_global_route_coord,
-    route_solve,
-)
+from paibox.backendv2 import route_solver as route_solver_module
+from paibox.backendv2.coreplacement import OfflineCorePlacementV2
+from paibox.backendv2.route_scope import get_route_scope
+from paibox.backendv2.route_solver import RouteSolver
+from paibox.backendv2.routing import InputGroup, OutputGroup, RemapGroup, RoutingGroup
 
 RUN_ROUTE_SOLVER_PERF = "PAIBOX_RUN_ROUTE_SOLVER_PERF"
+SINGLE_SCOPE = get_route_scope("single")
 
 
 def _solve(**kwargs):
-    return route_solve(max_time_in_seconds=30.0, **kwargs)
+    return RouteSolver(max_time_in_seconds=30.0, **kwargs).solve()
+
+
+def _capture_route_solver_init(monkeypatch):
+    captured = {}
+
+    class FakeRouteSolver:
+        def __init__(
+            self,
+            areas=None,
+            next_area_id=None,
+            scope=None,
+            io_bias_coord=None,
+            input_area_ids=None,
+            output_area_ids=None,
+            **kwargs,
+        ):
+            captured.update(
+                {
+                    "areas": areas,
+                    "next_area_id": next_area_id,
+                    "scope": scope,
+                    "io_bias_coord": io_bias_coord,
+                    "input_area_ids": input_area_ids,
+                    "output_area_ids": output_area_ids,
+                    **kwargs,
+                }
+            )
+
+        def solve(self):
+            return [], []
+
+    monkeypatch.setattr(route_solver_module, "RouteSolver", FakeRouteSolver)
+    return captured
 
 
 def _flatten(coords: list[list[CoordXY]]) -> list[CoordXY]:
     return [coord for area_coords in coords for coord in area_coords]
 
 
-def _assert_valid_coords(coords: list[list[CoordXY]]) -> None:
+def _assert_valid_coords(coords: list[list[CoordXY]], scope=SINGLE_SCOPE) -> None:
     flat = _flatten(coords)
     assert len(flat) == len(set(flat))
-    assert all(coord in OFFLINE_CORE_COORDS for coord in flat)
+    assert all(coord in scope.offline_core_coords for coord in flat)
 
 
 def _assert_valid_successor_expansion(
-    coords: list[list[CoordXY]], copy_configs, next_area_id: dict[int, list[int]]
+    coords: list[list[CoordXY]],
+    copy_configs,
+    next_area_id: dict[int, list[int]],
+    scope=SINGLE_SCOPE,
 ) -> None:
     for src_id, dst_ids in next_area_id.items():
         for dst_id in dst_ids:
-            packet = AERPacket(ncopy=copy_configs[dst_id])
-            offsets = aer_packet_walk(packet)
+            offsets = tuple(
+                CoordXYOffset(offset.x, offset.y)
+                for offset in aer_packet_copy_offsets(copy_configs[dst_id])
+            )
             for src_coord in coords[src_id]:
-                expanded = [
-                    CoordXY(src_coord.x + offset.x, src_coord.y + offset.y)
-                    for offset in offsets
-                ]
-                assert all(is_global_route_coord(coord) for coord in expanded)
+                expanded = [src_coord + offset for offset in offsets]
+                assert all(scope.is_global_route_coord(coord) for coord in expanded)
 
 
 def _center(area_coords: list[CoordXY]) -> tuple[int, int]:
@@ -63,6 +97,46 @@ def test_route_solve_feasibility_only_returns_solution():
     _assert_valid_successor_expansion(coords, copy_configs, {0: [1]})
 
 
+def test_route_solve_feasibility_only_skips_distance_model():
+    solver = RouteSolver(
+        areas=[1, 1],
+        next_area_id={0: [1]},
+        feasibility_only=True,
+        max_time_in_seconds=30.0,
+    )
+
+    solver.solve()
+
+    variable_names = [variable.name for variable in solver.model.Proto().variables]
+    assert not any(
+        name.startswith(("cx_", "cy_", "dx_", "dy_")) for name in variable_names
+    )
+    assert len(solver.model.Proto().objective.vars) == 0
+
+
+def test_route_solver_successor_constraints_avoid_table_expansion():
+    solver = RouteSolver(
+        areas=[2, 3, 2],
+        next_area_id={0: [1], 1: [2]},
+        feasibility_only=True,
+        max_time_in_seconds=30.0,
+    )
+
+    solver.solve()
+
+    constraints = solver.model.Proto().constraints
+    assert not any(constraint.has_table() for constraint in constraints)
+    assert any(constraint.has_at_most_one() for constraint in constraints)
+
+
+def test_route_solver_defaults_to_one_area_solution():
+    copy_configs, coords = _solve()
+
+    assert len(copy_configs) == 1
+    assert len(coords) == 1
+    _assert_valid_coords(coords)
+
+
 def test_route_solve_optimized_chain_returns_valid_solution():
     next_area_id = {0: [1], 1: [2]}
     copy_configs, coords = _solve(
@@ -80,7 +154,7 @@ def test_route_solve_fixed_io_distance_prefers_nearest_offline_core(io_kw):
     copy_configs, coords = _solve(
         areas=[1],
         next_area_id={},
-        io_target=(0, 0),
+        io_bias_coord=(0, 0),
         feasibility_only=False,
         **{io_kw: [0]},
     )
@@ -92,7 +166,79 @@ def test_route_solve_fixed_io_distance_prefers_nearest_offline_core(io_kw):
 
 def test_route_solve_raises_when_no_shape_can_cover_area():
     with pytest.raises(RuntimeError, match="No shape found"):
-        _solve(areas=[MAX_AREA + 1], next_area_id={})
+        _solve(areas=[len(SINGLE_SCOPE.offline_core_coords) + 1], next_area_id={})
+
+
+def test_route_solve_array_2x2_can_bias_to_second_cpu():
+    scope = get_route_scope("array_2x2")
+    _, coords = _solve(
+        areas=[1],
+        scope=scope,
+        io_bias_coord=scope.cpu_endpoints[1].coord,
+        input_area_ids=[0],
+    )
+
+    _assert_valid_coords(coords, scope)
+    assert _center(coords[0]) == (9, 2)
+
+
+def test_route_solve_derives_io_area_ids(monkeypatch):
+    input_a = object()
+    input_b = object()
+    output_a = object()
+    output_b = object()
+    input_group = InputGroup([input_a, input_b])
+    rg = RoutingGroup([output_a, output_b], [input_a, input_b])
+    output_group = OutputGroup([output_a, output_b])
+
+    input_group.dests[input_a] = rg
+    input_group.dests[input_b] = rg
+    rg.dests[output_a] = output_group
+    rg.dests[output_b] = output_group
+    rg.core_placements = [OfflineCorePlacementV2()]
+    captured = _capture_route_solver_init(monkeypatch)
+
+    route_solver_module.route_solve([rg], {0: []}, [input_group], SINGLE_SCOPE)
+
+    assert captured["areas"] == [1]
+    assert captured["next_area_id"] == {0: []}
+    assert captured["scope"] is SINGLE_SCOPE
+    assert captured["input_area_ids"] == [0]
+    assert captured["output_area_ids"] == [0]
+
+
+def test_route_solve_derives_input_area_through_remap_group(monkeypatch):
+    input_elem = object()
+    input_group = InputGroup([input_elem])
+    rg = RoutingGroup([], [input_elem])
+    remap_group = RemapGroup.__new__(RemapGroup)
+
+    def remap_dest(_elem):
+        return rg
+
+    remap_group.remap_dest = remap_dest
+    input_group.dests[input_elem] = remap_group
+    rg.core_placements = [OfflineCorePlacementV2()]
+    captured = _capture_route_solver_init(monkeypatch)
+
+    route_solver_module.route_solve([rg], {0: []}, [input_group], SINGLE_SCOPE)
+
+    assert captured["input_area_ids"] == [0]
+    assert captured["output_area_ids"] == []
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"next_area_id": {2: []}},
+        {"next_area_id": {0: [2]}},
+        {"input_area_ids": [2]},
+        {"output_area_ids": [2]},
+    ],
+)
+def test_route_solve_rejects_out_of_range_area_ids(kwargs):
+    with pytest.raises(ValueError, match="Area ids out of range"):
+        _solve(areas=[1, 1], **kwargs)
 
 
 @pytest.mark.perf
@@ -110,11 +256,10 @@ def test_route_solver_perf_profile():
     for case_name, areas, next_area_id in cases:
         for feasibility_only in (True, False):
             start = time.perf_counter()
-            _, coords = route_solve(
+            _, coords = _solve(
                 areas=areas,
                 next_area_id=next_area_id,
                 feasibility_only=feasibility_only,
-                max_time_in_seconds=30.0,
             )
             results.append(
                 {

--- a/uv.lock
+++ b/uv.lock
@@ -1449,6 +1449,7 @@ dependencies = [
     { name = "flatbuffers" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "paicorelib" },
     { name = "protobuf", version = "6.31.1", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version < '3.14'" },
     { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "rich" },
@@ -1466,7 +1467,6 @@ spikingjelly = [
 ]
 visualizer = [
     { name = "fastapi" },
-    { name = "paicorelib" },
     { name = "uvicorn" },
 ]
 
@@ -1476,7 +1476,6 @@ dev = [
     { name = "orjson" },
     { name = "ortools", version = "9.14.6206", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version < '3.14'" },
     { name = "ortools", version = "9.15.6755", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "paicorelib" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-md" },
@@ -1496,7 +1495,7 @@ requires-dist = [
     { name = "flatbuffers", specifier = "==25.12.19" },
     { name = "nir", marker = "extra == 'nir'", specifier = ">=1.0.6,<2" },
     { name = "numpy", specifier = ">=2.1.0,<3.0.0" },
-    { name = "paicorelib", marker = "platform_machine != 'armv7l' and extra == 'visualizer'", specifier = ">=2.0.0rc3" },
+    { name = "paicorelib", marker = "platform_machine != 'armv7l'", specifier = ">=2.0.0" },
     { name = "protobuf", specifier = ">=5.27.1,<7" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "snntorch", marker = "extra == 'snntorch'", specifier = ">=0.9.0" },
@@ -1511,7 +1510,6 @@ dev = [
     { name = "orjson", specifier = ">=3.11.6" },
     { name = "ortools", marker = "python_full_version < '3.14'", specifier = "==9.14.6206" },
     { name = "ortools", marker = "python_full_version >= '3.14'", specifier = "==9.15.6755" },
-    { name = "paicorelib", marker = "platform_machine != 'armv7l'", specifier = ">=2.0.0rc3" },
     { name = "pytest", specifier = ">=9.0" },
     { name = "pytest-cov", specifier = ">=7.0" },
     { name = "pytest-md", specifier = ">=0.2" },
@@ -1524,16 +1522,16 @@ dev = [
 
 [[package]]
 name = "paicorelib"
-version = "2.0.0rc3"
+version = "2.0.0"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/fc/34f009e2a438f87df105518b5b0baa0688df7e91126c9a5a43e19a44cc27/paicorelib-2.0.0rc3.tar.gz", hash = "sha256:86fd0131e5c27a2bc90eeefb6a3d479ea9a908c35cffbaa00f3fd56f7e4e582a", size = 77147, upload-time = "2026-06-26T04:07:33.203Z" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/47/ab/dcff284b194ed92b5dcc8d3f9cdb4cc9020fd60bab4934b425abe51b498e/paicorelib-2.0.0.tar.gz", hash = "sha256:9a41a1524025d8ab5955014569fde35ba5f0af7607c608bfd5a7cd3eb2899fe5", size = 80275, upload-time = "2026-07-08T07:26:07.713Z" }
 wheels = [
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/84/b6/a85dcfa93999b1b980782ed64abbd4d5473303ca44a70a411dc1785268d0/paicorelib-2.0.0rc3-py3-none-any.whl", hash = "sha256:8edf170025830395ee25f0690953ddfc53be8ffec17900ffc5da29aab31a8b28", size = 86057, upload-time = "2026-06-26T04:07:31.982Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/50/96/2fb3d8a342957788ec3e1122f80241e43571c102654b2e473f50b9dd61a6/paicorelib-2.0.0-py3-none-any.whl", hash = "sha256:5d200adfe15ffb2b3a92d2f7f4ea24d25cbecaf29a3ffe6ee16e1c6b4a69000e", size = 88102, upload-time = "2026-07-08T07:26:06.506Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add fixed backendv2 route scopes for `single` and `array_2x2` target boards.
- Refactor route solving into a scope-aware OOP CP-SAT solver with IO placement bias and feasibility mode.
- Thread selected `target_board` through mapper routing, pressure unroll, output completion, and global signal setup.