### PR TITLE
feat(paiir): support vector beta snnTorch Leaky deployment

### DIFF
--- a/paibox/backendv2/op_node.py
+++ b/paibox/backendv2/op_node.py
@@ -4,6 +4,7 @@ from typing import Generic, TypeVar
 import torch
 from paicorelib import (
     AddPotentialMode,
+    LeakMultiMode,
     OfflineNeuFullAttrsV2Part2,
     OutputType,
     SNNMode,
@@ -433,7 +434,7 @@ class CoreOpNode(BaseNode["OfflineCoreOp"]):
             lateral_inhibition=neu_attrs.lateral_inhi,
             leak_multi_sequence=neu_attrs.leak_multi_sequence,
             leak_multi_input=neu_attrs.leak_multi_input,
-            leak_multi_mode=neu_attrs.leak_multi_mode,
+            leak_multi_mode=LeakMultiMode(resolved["leak_multi_mode"]),
             leak_add_mode=neu_attrs.leak_add_mode,
             leak_tau=resolved["leak_tau"],
             leak_v=resolved["leak_v"],

--- a/paibox/paiir/ir/calc_params.py
+++ b/paibox/paiir/ir/calc_params.py
@@ -217,6 +217,7 @@ class NeuronParams:
         "reset_v",
         "thres_neg",
         "thres_pos",
+        "leak_multi_mode",
         "leak_tau",
         "leak_v",
         "init_v",
@@ -233,7 +234,7 @@ class NeuronParams:
         LeakMultiComparisonOrder.AFTER_COMPARE
     )
     leak_multi_input: LeakMultiInputMode = LeakMultiInputMode.DISABLE
-    leak_multi_mode: LeakMultiMode = LeakMultiMode.DISABLE
+    leak_multi_mode: LeakMultiMode | Tensor = LeakMultiMode.DISABLE
     leak_add_mode: LeakAddMode = LeakAddMode.FORWARD
     leak_tau: int | Tensor = 0
     leak_v: float | Tensor = 0.0

--- a/paibox/paiir/ir/core_neuron.py
+++ b/paibox/paiir/ir/core_neuron.py
@@ -109,7 +109,7 @@ class CoreNeuronV25(MemoryModule):
         lateral_inhi: LateralInhibitionMode | bool = LateralInhibitionMode.DISABLE,
         leak_multi_sequence: LeakMultiComparisonOrder = LeakMultiComparisonOrder.AFTER_COMPARE,
         leak_multi_input: LeakMultiInputMode | bool = LeakMultiInputMode.DISABLE,
-        leak_multi_mode: LeakMultiMode | bool = LeakMultiMode.DISABLE,
+        leak_multi_mode: LeakMultiMode | bool | Tensor = LeakMultiMode.DISABLE,
         leak_add_mode: LeakAddMode = LeakAddMode.FORWARD,
         tau: float | Tensor = 1,
         leak_v: float | Tensor = 0,
@@ -175,7 +175,7 @@ class CoreNeuronV25(MemoryModule):
         self.lateral_inhi = LateralInhibitionMode(lateral_inhi)
         self.leak_multi_sequence = leak_multi_sequence
         self.leak_multi_input = LeakMultiInputMode(leak_multi_input)
-        self.leak_multi_mode = LeakMultiMode(leak_multi_mode)
+        self.leak_multi_mode = _normalize_leak_multi_mode(leak_multi_mode)
         self.leak_add_mode = leak_add_mode
 
         # tau -> leak_tau (right-shift exponent)
@@ -191,7 +191,7 @@ class CoreNeuronV25(MemoryModule):
         self.init_v = _normalize_numeric_param(init_v, name="init_v")
 
         self._validate_threshold_bounds()
-        self._validate_dynamics_homogeneity()
+        self._validate_vector_dynamics_shapes()
 
         self.surrogate_function = surrogate_function
         self.detach_reset = detach_reset
@@ -250,16 +250,35 @@ class CoreNeuronV25(MemoryModule):
     @property
     def has_if_dynamics(self) -> bool:
         """Return True for spike neurons without leak dynamics."""
-        if not self.is_snn or self.leak_multi_mode != LeakMultiMode.DISABLE:
-            return False
-        if torch.is_tensor(self.leak_tau):
-            return bool(torch.all(self.leak_tau == 0).item())
-        return self.leak_tau == 0
+        return self._classify_dynamics()[0]
 
     @property
     def has_lif_dynamics(self) -> bool:
         """Return True for spike neurons with leak dynamics."""
-        return self.is_snn and not self.has_if_dynamics
+        return self._classify_dynamics()[1]
+
+    @property
+    def has_mixed_dynamics(self) -> bool:
+        """Return True when one neuron contains both IF and LIF dynamics."""
+        return self._classify_dynamics()[2]
+
+    def _classify_dynamics(self) -> tuple[bool, bool, bool]:
+        if not self.is_snn:
+            return False, False, False
+
+        mode_is_disabled = self.leak_multi_mode == LeakMultiMode.DISABLE
+        shift_is_zero = self.leak_tau == 0
+        if torch.is_tensor(mode_is_disabled) and torch.is_tensor(shift_is_zero):
+            shift_is_zero = shift_is_zero.to(mode_is_disabled.device)
+        if_mask = mode_is_disabled & shift_is_zero
+
+        if torch.is_tensor(if_mask):
+            any_if = bool(torch.any(if_mask).item())
+            all_if = bool(torch.all(if_mask).item())
+        else:
+            any_if = all_if = bool(if_mask)
+
+        return all_if, not any_if, any_if and not all_if
 
     @property
     def output_sign(self) -> bool:
@@ -468,23 +487,28 @@ class CoreNeuronV25(MemoryModule):
             return self.v
         return self.v - self._apply_tau_shift(self.v)
 
-    def _validate_dynamics_homogeneity(self) -> None:
-        if not self.is_snn or not torch.is_tensor(self.leak_tau):
-            return
-        if self.leak_multi_mode == LeakMultiMode.ENABLE:
-            return
-
-        zero_shift = self.leak_tau == 0
-        if torch.any(zero_shift).item() and not torch.all(zero_shift).item():
+    def _validate_vector_dynamics_shapes(self) -> None:
+        if (
+            torch.is_tensor(self.leak_multi_mode)
+            and torch.is_tensor(self.leak_tau)
+            and self.leak_multi_mode.shape != self.leak_tau.shape
+        ):
             raise ValueError(
-                "leak_tau mixes IF (zero shift) and LIF (non-zero shift) dynamics "
-                "while leak_multi_mode is DISABLE"
+                "leak_multi_mode and leak_tau_shift tensors must have the same shape, "
+                f"got {tuple(self.leak_multi_mode.shape)} and "
+                f"{tuple(self.leak_tau.shape)}"
             )
 
     def _validate_simulation_params(self) -> None:
         unsupported = [
             name
-            for name in ("reset_v", "thres_neg", "leak_tau", "init_v")
+            for name in (
+                "reset_v",
+                "thres_neg",
+                "leak_multi_mode",
+                "leak_tau",
+                "init_v",
+            )
             if torch.is_tensor(getattr(self, name))
         ]
         if unsupported:
@@ -604,6 +628,35 @@ def _normalize_leak_tau_shift(value: int | Tensor) -> int | Tensor:
     ):
         raise TypeError("leak_tau_shift Tensor must have an integer dtype")
     return _normalize_numeric_param(value, name="leak_tau_shift")  # type: ignore
+
+
+def _normalize_leak_multi_mode(
+    value: LeakMultiMode | bool | Tensor,
+) -> LeakMultiMode | Tensor:
+    if isinstance(value, LeakMultiMode):
+        return value
+    if isinstance(value, bool):
+        return LeakMultiMode(value)
+    if not torch.is_tensor(value):
+        raise TypeError(
+            "leak_multi_mode must be a LeakMultiMode, bool, or integer/bool Tensor"
+        )
+    if value.numel() == 0:
+        raise ValueError("leak_multi_mode must not be empty")
+    if value.dtype not in (
+        torch.bool,
+        torch.uint8,
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+    ):
+        raise TypeError("leak_multi_mode Tensor must have an integer or bool dtype")
+    if torch.any((value != 0) & (value != 1)).item():
+        raise ValueError("leak_multi_mode Tensor values must be 0 or 1")
+    if value.ndim == 0:
+        return LeakMultiMode(value.item())
+    return value.detach().clone()
 
 
 def _resolve_reset(v_reset: float | Tensor | None) -> tuple[float | Tensor, RM]:

--- a/paibox/paiir/lowering/converter.py
+++ b/paibox/paiir/lowering/converter.py
@@ -1246,6 +1246,11 @@ def _apply_module_lowering_rule(
         if not source_resolution.supported:
             description = registry.describe_source_error(source_resolution)
             raise UnsupportedOpError(node.name, description)
+        context_error = registry.describe_source_context_error(
+            source_resolution, get_output_shape(node)
+        )
+        if context_error is not None:
+            raise UnsupportedOpError(node.name, context_error)
 
         ir_node = registry.lower_source_resolution(source_resolution)
         _register_ir_node(

--- a/paibox/paiir/lowering/frontends/registry.py
+++ b/paibox/paiir/lowering/frontends/registry.py
@@ -14,6 +14,7 @@ __all__ = [
     "build_frontend_module_map",
     "collect_erase_types",
     "describe_source_error",
+    "describe_source_context_error",
     "describe_unsupported_module",
     "lower_source_resolution",
     "owned_by_frontend",
@@ -83,6 +84,23 @@ def describe_source_error(resolution: SourceResolution) -> str:
         frontend=resolution.schema.frontend,
         op=resolution.schema.op,
         result=resolution.error,
+    )
+
+
+def describe_source_context_error(
+    resolution: SourceResolution, output_shape
+) -> str | None:
+    """Return a frontend error that depends on propagated FX output shape."""
+    if resolution.schema.frontend != snntorch.name:
+        return None
+    result = snntorch.validate_source_context(resolution.source_op, output_shape)
+    if result is None:
+        return None
+    return format_constraint_error(
+        stage="source",
+        frontend=resolution.schema.frontend,
+        op=resolution.schema.op,
+        result=result,
     )
 
 

--- a/paibox/paiir/lowering/frontends/snntorch.py
+++ b/paibox/paiir/lowering/frontends/snntorch.py
@@ -1,11 +1,16 @@
 """snnTorch lowering frontend."""
 
+import math
+import warnings
+
 import torch
-from paicorelib import RM
+from paicorelib import RM, LeakMultiMode
 from torch import nn
 
-from ...ir.core_neuron import CoreNeuronV25, IFNodeV25
+from ....exceptions import AutoOptimizationWarning
+from ...ir.core_neuron import CoreNeuronV25, IFNodeV25, LeakyBeta0NodeV25
 from ..support import (
+    Constraint,
     ConstraintResult,
     ModuleMapper,
     SourceOp,
@@ -13,9 +18,9 @@ from ..support import (
     eq,
     is_false,
     one_of,
+    predicate,
     reader,
     scalar,
-    scalar_value,
     source_op_schema,
 )
 
@@ -56,20 +61,212 @@ def describe_unsupported(module: nn.Module) -> ConstraintResult | None:
     return None
 
 
-def _threshold(source_op: SourceOp) -> float:
-    return scalar_value(source_op.attributes.raw("threshold"))
+def validate_source_context(
+    source_op: SourceOp, output_shape: torch.Size
+) -> ConstraintResult | None:
+    """Restrict 1D Leaky parameters to unambiguous per-feature outputs."""
+    for field in ("beta", "threshold"):
+        value = source_op.attributes.raw(field)
+        if torch.is_tensor(value) and value.ndim == 1 and len(output_shape) != 2:
+            return ConstraintResult.fail(
+                constraint=f"{field} 1D layout",
+                field=field,
+                value=f"Tensor(shape={tuple(value.shape)})",
+                reason=(
+                    f"1D {field} is supported only for rank-2 Linear/per-feature "
+                    "outputs; Conv tensor broadcasting is not supported"
+                ),
+            )
+    return None
 
 
-def _map_linear_reset(source_op: SourceOp) -> IFNodeV25:
-    return IFNodeV25(v_threshold=_threshold(source_op), v_reset=None)
+def _scalar_or_1d_numeric(field: str) -> Constraint:
+    return predicate(
+        f"{field} is scalar or 1D numeric tensor",
+        field,
+        lambda attrs: _is_scalar_or_1d_numeric(attrs.raw(field)),
+        f"{field} must be a scalar or non-empty 1D real-valued Tensor",
+    )
 
 
-def _map_zero_reset(source_op: SourceOp) -> IFNodeV25:
-    return IFNodeV25(v_threshold=_threshold(source_op))
+def _closed_interval(field: str, lower: float, upper: float) -> Constraint:
+    return predicate(
+        f"{field} is in [{lower}, {upper}]",
+        field,
+        lambda attrs: _is_in_closed_interval(attrs.raw(field), lower, upper),
+        f"{field} values must be in [{lower}, {upper}]",
+    )
 
 
-def _map_nonreset(source_op: SourceOp) -> CoreNeuronV25:
-    return CoreNeuronV25(reset_mode=RM.MODE_NONRESET, thres_pos=_threshold(source_op))
+def _is_scalar_or_1d_numeric(value: object) -> bool:
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return True
+    return bool(
+        torch.is_tensor(value)
+        and value.ndim <= 1
+        and value.numel() > 0
+        and not value.is_complex()
+        and value.dtype != torch.bool
+    )
+
+
+def _is_in_closed_interval(value: object, lower: float, upper: float) -> bool:
+    if torch.is_tensor(value):
+        return bool(torch.all((value >= lower) & (value <= upper)).item())
+    return lower <= float(value) <= upper
+
+
+def _snapshot_numeric(value: object) -> int | float | torch.Tensor:
+    """Read the current numeric value without preserving training metadata."""
+    if torch.is_tensor(value):
+        snapshot = value.detach().clone()
+        return snapshot.item() if snapshot.ndim == 0 else snapshot
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value
+    raise TypeError(f"expected numeric value, got {type(value).__name__}")
+
+
+def _deployment_threshold(source_op: SourceOp) -> tuple[int | torch.Tensor, float]:
+    """Convert snnTorch's strict firing threshold to PAICORE's inclusive one.
+
+    snnTorch fires when ``V > T``, while PAICORE compares integer potentials
+    using ``V >= T_hw``. Therefore ``T_hw = floor(T) + 1`` preserves the firing
+    boundary. The second return value is the maximum ``T_hw - T`` adjustment,
+    used to report the extra subtraction introduced by subtract reset.
+    """
+    value = _snapshot_numeric(source_op.attributes.raw("threshold"))
+    if torch.is_tensor(value):
+        deployed = torch.floor(value).to(torch.int64) + 1
+        return deployed, float(torch.max(deployed - value).item())
+    deployed = math.floor(value) + 1
+    return deployed, float(deployed - value)
+
+
+def _beta_to_hardware(
+    source_op: SourceOp,
+) -> tuple[
+    LeakMultiMode | torch.Tensor, int | torch.Tensor, int | torch.Tensor, int, float
+]:
+    """Encode snnTorch beta values as PAICORE leak mode and shift fields.
+
+    ``beta=0`` maps exactly to complete leakage (multi-leak enabled, shift 0),
+    and ``beta=1`` maps exactly to IF behavior (multi-leak disabled, shift 0).
+    Each ``0 < beta < 1`` is approximated by the nearest hardware value
+    ``1 - 2**-k`` for ``k`` in ``[1, 32]``; ties select the smaller ``k`` and
+    therefore the stronger leak. The return value contains mode, signed shift,
+    equivalent tau, the number of approximated elements, and maximum absolute
+    beta error.
+    """
+    raw_value = _snapshot_numeric(source_op.attributes.raw("beta"))
+    beta = torch.as_tensor(raw_value, dtype=torch.float64)
+
+    # Endpoint defaults encode beta=1; beta=0 switches to complete leakage.
+    modes = torch.full(beta.shape, int(LeakMultiMode.DISABLE), dtype=torch.int64)
+    shifts = torch.zeros(beta.shape, dtype=torch.int64)
+    interior = (beta > 0) & (beta < 1)
+    modes[beta == 0] = int(LeakMultiMode.ENABLE)
+
+    approximated_count = 0
+    max_error = 0.0
+    if torch.any(interior).item():
+        grid = 1.0 - torch.pow(
+            torch.tensor(2, dtype=torch.float64),
+            -torch.arange(1, 33, dtype=torch.float64),
+        )
+        distances = torch.abs(beta[interior, None] - grid[None, :])
+        # argmin returns the first match, so midpoint ties select smaller k.
+        grid_indices = torch.argmin(distances, dim=1)
+        exponents = grid_indices + 1
+        shifts[interior] = -exponents
+        errors = distances.gather(1, grid_indices[:, None]).squeeze(1)
+        approximated_count = int(torch.count_nonzero(errors).item())
+        max_error = float(errors.max().item())
+
+    # Preserve equivalent tau metadata alongside the exact hardware shift.
+    tau = torch.bitwise_left_shift(torch.ones_like(shifts, dtype=torch.int64), -shifts)
+    if beta.ndim == 0:
+        return (
+            LeakMultiMode(int(modes.item())),
+            int(shifts.item()),
+            int(tau.item()),
+            approximated_count,
+            max_error,
+        )
+    return modes, shifts, tau, approximated_count, max_error
+
+
+def _all_equal(value: int | torch.Tensor, expected: int) -> bool:
+    if torch.is_tensor(value):
+        return bool(torch.all(value == expected).item())
+    return value == expected
+
+
+def _warn_adjustments(
+    *,
+    reset_mechanism: str,
+    approximated_count: int,
+    max_error: float,
+    max_threshold_adjustment: float,
+) -> None:
+    """Emit one summary warning for beta approximation and threshold changes."""
+    details: list[str] = []
+    if approximated_count:
+        details.append(
+            f"approximated {approximated_count} beta value(s) "
+            f"(max absolute error {max_error:.6g})"
+        )
+    if reset_mechanism == "subtract":
+        details.append(
+            "raised threshold to floor(threshold)+1 to preserve strict spike "
+            "comparison; subtract reset uses the adjusted threshold "
+            f"(maximum extra reset {max_threshold_adjustment:.6g})"
+        )
+    if details:
+        warnings.warn(
+            "snnTorch Leaky deployment: " + "; ".join(details),
+            AutoOptimizationWarning,
+            stacklevel=3,
+        )
+
+
+def _map_leaky(source_op: SourceOp) -> CoreNeuronV25:
+    """Lower a validated snnTorch Leaky op to a deployable PAIIR neuron."""
+    reset_mechanism = str(source_op.attributes.raw("reset_mechanism"))
+    threshold, max_threshold_adjustment = _deployment_threshold(source_op)
+    mode, shift, tau, approximated_count, max_error = _beta_to_hardware(source_op)
+    _warn_adjustments(
+        reset_mechanism=reset_mechanism,
+        approximated_count=approximated_count,
+        max_error=max_error,
+        max_threshold_adjustment=max_threshold_adjustment,
+    )
+
+    all_if = _all_equal(mode, int(LeakMultiMode.DISABLE)) and _all_equal(shift, 0)
+    if all_if and reset_mechanism == "subtract":
+        return IFNodeV25(threshold, None)
+    if all_if and reset_mechanism == "zero":
+        return IFNodeV25(threshold)
+
+    all_beta_zero = _all_equal(mode, int(LeakMultiMode.ENABLE)) and _all_equal(shift, 0)
+    if all_beta_zero:
+        return LeakyBeta0NodeV25(
+            threshold, None if reset_mechanism == "subtract" else 0
+        )
+
+    reset_mode = {
+        "subtract": RM.MODE_LINEAR,
+        "zero": RM.MODE_NORMAL,
+        "none": RM.MODE_NONRESET,
+    }[reset_mechanism]
+    return CoreNeuronV25(
+        reset_mode=reset_mode,
+        thres_pos=threshold,
+        tau=tau,
+        leak_tau_shift=shift,
+        leak_multi_mode=mode,
+    )
 
 
 def _reset_mechanism(module: nn.Module) -> str:
@@ -101,20 +298,9 @@ source_schemas = (
     .attribute("state_quant", attr("state_quant", default=False))
     .attribute("graded_spikes_factor", attr("graded_spikes_factor", default=1.0))
     .attribute("reset_mechanism", reader(_reset_mechanism))
-    .generic(scalar("beta", reason="learnable or non-scalar beta is not equivalent"))
-    .generic(
-        eq(
-            "beta",
-            1,
-            reason=(
-                "beta != 1 leaks only old membrane state in snnTorch and needs "
-                "IR support"
-            ),
-        )
-    )
-    .generic(
-        scalar("threshold", reason="learnable or non-scalar threshold is not supported")
-    )
+    .generic(_scalar_or_1d_numeric("beta"))
+    .generic(_closed_interval("beta", 0, 1))
+    .generic(_scalar_or_1d_numeric("threshold"))
     .generic(
         is_false(
             "output", reason="explicit membrane output is not represented in PAIIR"
@@ -158,12 +344,12 @@ source_schemas = (
             reason="reset_delay=True is not equivalent for subtract reset",
         )
     )
-    .canonicalize_to(_map_linear_reset)
+    .canonicalize_to(_map_leaky)
     .case("zero_reset")
     .when(eq("reset_mechanism", "zero"))
-    .canonicalize_to(_map_zero_reset)
+    .canonicalize_to(_map_leaky)
     .case("non_reset")
     .when(eq("reset_mechanism", "none"))
-    .canonicalize_to(_map_nonreset)
+    .canonicalize_to(_map_leaky)
     .build(),
 )

--- a/paibox/paiir/nir_exchange.py
+++ b/paibox/paiir/nir_exchange.py
@@ -847,7 +847,22 @@ def _check_snn_act_export(name: str, owner: PAIIRNode, act: CoreNeuronV25) -> No
             value=type(act).__name__,
             reason="ANN/LUT neurons are not representable as NIR IF/LIF",
         )
-    for field in ("reset_v", "thres_neg", "leak_tau", "init_v", "tau"):
+    if act.has_mixed_dynamics:
+        _unsupported_export(
+            name,
+            owner,
+            field="act",
+            value=type(act).__name__,
+            reason="mixed IF/LIF neuron dynamics are not representable in NIR",
+        )
+    for field in (
+        "reset_v",
+        "thres_neg",
+        "leak_multi_mode",
+        "leak_tau",
+        "init_v",
+        "tau",
+    ):
         value = getattr(act, field)
         if torch.is_tensor(value):
             _unsupported_export(

--- a/paibox/paiir/pipeline/avgpool/utils.py
+++ b/paibox/paiir/pipeline/avgpool/utils.py
@@ -34,9 +34,21 @@ _INT32_MIN = torch.iinfo(torch.int32).min
 
 def require_scalar_avgpool_neuron_params(act: CoreNeuronV25) -> None:
     """Reject vector fields not supported by AvgPool deployment rewrites."""
+    if act.has_mixed_dynamics:
+        raise ValueError(
+            "AvgPool deployment does not support mixed IF/LIF neuron dynamics"
+        )
+
     vector_fields = [
         name
-        for name in ("reset_v", "thres_neg", "leak_tau", "init_v", "tau")
+        for name in (
+            "reset_v",
+            "thres_neg",
+            "leak_multi_mode",
+            "leak_tau",
+            "init_v",
+            "tau",
+        )
         if torch.is_tensor(getattr(act, name))
     ]
     if vector_fields:

--- a/paibox/paiir/pipeline/neuron_param_materialization.py
+++ b/paibox/paiir/pipeline/neuron_param_materialization.py
@@ -4,7 +4,7 @@ from dataclasses import replace
 from math import prod
 
 import torch
-from paicorelib import LeakAddMode
+from paicorelib import LeakAddMode, LeakMultiMode
 from torch import Tensor
 
 from ..ir.calc_params import NeuronParams
@@ -63,6 +63,7 @@ def _materialize_params(
         )
         for field in params.__vectorized_attrs__
     }
+    _validate_leak_multi_mode(node_name, values["leak_multi_mode"])
     _validate_leak_tau(node_name, values["leak_tau"])
     _validate_threshold_bounds(node_name, values["thres_pos"], values["thres_neg"])
 
@@ -76,6 +77,43 @@ def _materialize_params(
         values["leak_v"] = values["leak_v"] + bias_flat
 
     return replace(params, **values)
+
+
+def _validate_leak_multi_mode(
+    node_name: str,
+    leak_multi_mode: LeakMultiMode | bool | int | Tensor,
+) -> None:
+    if torch.is_tensor(leak_multi_mode):
+        if leak_multi_mode.dtype not in {
+            torch.bool,
+            torch.uint8,
+            torch.int8,
+            torch.int16,
+            torch.int32,
+            torch.int64,
+        }:
+            raise TypeError(
+                f"OfflineCoreOp '{node_name}' leak_multi_mode must have integer "
+                "or bool dtype"
+            )
+        invalid = torch.any((leak_multi_mode != 0) & (leak_multi_mode != 1))
+        if invalid.item():
+            raise ValueError(
+                f"OfflineCoreOp '{node_name}' leak_multi_mode values must be 0 or 1"
+            )
+        return
+
+    if isinstance(leak_multi_mode, bool):
+        return
+    if not isinstance(leak_multi_mode, (LeakMultiMode, int)):
+        raise TypeError(
+            f"OfflineCoreOp '{node_name}' leak_multi_mode must be a LeakMultiMode, "
+            "bool, or integer/bool Tensor"
+        )
+    if int(leak_multi_mode) not in (0, 1):
+        raise ValueError(
+            f"OfflineCoreOp '{node_name}' leak_multi_mode values must be 0 or 1"
+        )
 
 
 def _validate_leak_tau(node_name: str, leak_tau: int | float | Tensor) -> None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2937,14 +2937,14 @@ reference = "tsinghua"
 name = "snntorch"
 version = "1.0.0"
 description = "Deep learning with spiking neural networks."
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"snntorch\""
+groups = ["main", "dev"]
 files = [
     {file = "snntorch-1.0.0-py2.py3-none-any.whl", hash = "sha256:b5a85f6f44c6d27c8a1dcea16cb18a630d00b8d2f3cfec85b7e580cb177e606b"},
     {file = "snntorch-1.0.0.tar.gz", hash = "sha256:93c33506a5975c1d0d2387a130def02382789197314cefb2c70511b05a03536e"},
 ]
+markers = {main = "extra == \"snntorch\""}
 
 [package.source]
 type = "legacy"
@@ -3426,4 +3426,4 @@ visualizer = ["fastapi", "uvicorn"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "6b10c91172143a31703021e81ec774fd4a73de761931db0f585e82cdf3cd919d"
+content-hash = "fcc79c9bc691dc65ef9374877e6c36e66c2e3b1a73b39f3316024c59a80dd278"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ paiviz = "paibox.visualizer.cli:main"
 
 [project.optional-dependencies]
 visualizer = ["fastapi>=0.128.0,<1", "uvicorn>=0.38.0,<1"]
-snntorch = ["snntorch>=0.9.0"]
-spikingjelly = ["spikingjelly>=0.0.0.0.12"]
+snntorch = ["snntorch>=0.9.4,<2"]
+spikingjelly = ["spikingjelly>=0.0.0.0.12,<1"]
 nir = ["nir>=1.0.6,<2"]
 
 [project.urls]
@@ -61,7 +61,8 @@ dev = [
     "orjson>=3.11.6",
     "torch>=2.0.0,<2.2.0 ; python_full_version < '3.12'",
     "torch>=2.2.0 ; python_full_version >= '3.12'",
-    "spikingjelly>=0.0.0.0.12",
+    "spikingjelly>=0.0.0.0.12,<1",
+    "snntorch>=0.9.4,<2",
     "tabulate>=0.9.0",
     "ortools==9.14.6206 ; python_full_version < '3.14'",
     "ortools==9.15.6755 ; python_full_version >= '3.14'",

--- a/tests/backendv2/test_mapper.py
+++ b/tests/backendv2/test_mapper.py
@@ -403,6 +403,40 @@ def test_mapper_compiles_flat_vector_neuron_parameters(tmp_path, ann):
     assert [p.neu_attrs_part2.leak_v for p in placements] == [8, 9, 10, 11]
 
 
+def test_mapper_vector_mode_controls_part2_and_half_reuse(tmp_path):
+    linear = nn.Linear(3, 4, bias=False)
+    with torch.no_grad():
+        linear.weight.fill_(1)
+    act = CoreNeuronV25(
+        leak_multi_mode=torch.tensor([0, 0, 1, 1]),
+        leak_tau_shift=torch.tensor([0, 0, 0, 0]),
+    )
+    graph = compile_to_paiir(
+        nn.Sequential(linear, act).eval(),
+        torch.zeros(1, 3),
+        input_formats={"InputNode_0": (DataSign.SIGNED, DataWidth.WIDTH_8BIT)},
+        strict=True,
+    )
+    mapper = Mapper()
+    mapper.compile(graph, tmp_path, target_platform="x86", debug=False)
+
+    placements = sorted(
+        _shared_sparse_linear_neuron_placements(mapper),
+        key=lambda placement: placement.raw_neus[0].index.idx,
+    )
+
+    assert [placement.neuron_type for placement in placements] == [
+        NeuronType.FULL,
+        NeuronType.HALF,
+        NeuronType.FULL,
+        NeuronType.HALF,
+    ]
+    assert placements[0].neu_attrs_part2.leak_multi_mode == LeakMultiMode.DISABLE
+    assert placements[1].neu_attrs_part2 is None
+    assert placements[2].neu_attrs_part2.leak_multi_mode == LeakMultiMode.ENABLE
+    assert placements[3].neu_attrs_part2 is None
+
+
 def test_mapper_builds_output_completion_plan_without_full_compile(monkeypatch):
     mapper = Mapper()
     producer_coords = [CoordXY(4, 2), CoordXY(2, 4)]
@@ -705,6 +739,51 @@ def test_mapper_does_not_fold_neurons_with_different_part2_attrs(tmp_path):
         121,
         122,
         123,
+    ]
+
+
+def test_mapper_does_not_fold_neurons_with_different_leak_modes(tmp_path):
+    model = nn.Sequential(
+        nn.Linear(4, 4, bias=False),
+        CoreNeuronV25(
+            leak_multi_mode=torch.tensor([0, 1, 0, 1]),
+            leak_tau_shift=torch.full((4,), -1),
+        ),
+        nn.Linear(4, 2, bias=False),
+    )
+    with torch.no_grad():
+        model[0].weight.copy_(torch.tensor([1, -1, 1, -1]).repeat(4, 1))
+        model[2].weight.copy_(torch.tensor([[1, 1, -1, -1], [-1, 1, -1, 1]]))
+
+    graph = compile_to_paiir(
+        model.eval(),
+        torch.zeros(1, 4),
+        input_formats={"InputNode_0": (DataSign.SIGNED, DataWidth.WIDTH_8BIT)},
+        timesteps=1,
+        auto_reset=True,
+        strict=True,
+    )
+    mapper = Mapper()
+    mapper.compile(graph, tmp_path, target_platform="x86", debug=False)
+
+    placements = _shared_sparse_linear_neuron_placements(mapper)
+    first_layer = sorted(
+        (
+            placement
+            for placement in placements
+            if len(placement.raw_neus) == 1
+            and placement.raw_neus[0].target.name == "SequentialOp_0"
+        ),
+        key=lambda placement: placement.raw_neus[0].index.idx,
+    )
+
+    assert len(first_layer) == 4
+    assert all(placement.folded_neu_attrs_part1 is None for placement in first_layer)
+    assert [placement.neu_attrs_part2.leak_multi_mode for placement in first_layer] == [
+        LeakMultiMode.DISABLE,
+        LeakMultiMode.ENABLE,
+        LeakMultiMode.DISABLE,
+        LeakMultiMode.ENABLE,
     ]
 
 

--- a/tests/backendv2/test_op_node.py
+++ b/tests/backendv2/test_op_node.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+from paicorelib import LeakMultiMode
 
 from paibox.backendv2.op_node import CoreOpNode
 from paibox.paiir import IFNodeV25
@@ -33,6 +34,7 @@ def test_attrs_part2_resolves_all_flat_neuron_params():
             reset_v=torch.tensor([1.0, 2.0, 3.0, 4.0]),
             thres_neg=torch.tensor([-1.0, -2.0, -3.0, -4.0]),
             thres_pos=torch.tensor([5.0, 6.0, 7.0, 8.0]),
+            leak_multi_mode=torch.tensor([0, 0, 1, 1]),
             leak_tau=torch.tensor([0, -1, -2, -3]),
             leak_v=torch.tensor([9.0, 10.0, 11.0, 12.0]),
             init_v=torch.tensor([13.0, 14.0, 15.0, 16.0]),
@@ -44,6 +46,7 @@ def test_attrs_part2_resolves_all_flat_neuron_params():
     assert attrs.reset_v == 3
     assert attrs.threshold_neg == -3
     assert attrs.threshold_pos == 7
+    assert attrs.leak_multi_mode == LeakMultiMode.ENABLE
     assert attrs.leak_tau == -2
     assert attrs.leak_v == 11
     assert attrs.vjt_initial == 15

--- a/tests/paiir/ir/test_core_neuron.py
+++ b/tests/paiir/ir/test_core_neuron.py
@@ -38,6 +38,7 @@ class TestIFNodeV25:
             "reset_v",
             "thres_neg",
             "thres_pos",
+            "leak_multi_mode",
             "leak_tau",
             "leak_v",
             "init_v",
@@ -230,12 +231,108 @@ class TestVectorNeuronParameters:
 
         assert node.has_lif_dynamics
 
-    def test_disabled_leak_rejects_mixed_if_lif_shifts(self):
-        with pytest.raises(ValueError, match="mixes IF .* and LIF"):
+    @pytest.mark.parametrize(
+        ("mode", "expected"),
+        [
+            (LeakMultiMode.ENABLE, LeakMultiMode.ENABLE),
+            (False, LeakMultiMode.DISABLE),
+            (torch.tensor(1), LeakMultiMode.ENABLE),
+            (torch.tensor(False), LeakMultiMode.DISABLE),
+        ],
+    )
+    def test_leak_mode_normalizes_scalar_values(self, mode, expected):
+        node = CoreNeuronV25(leak_multi_mode=mode)
+
+        assert node.leak_multi_mode == expected
+
+    def test_vector_leak_mode_is_detached_and_cloned(self):
+        mode = torch.tensor([0, 1], dtype=torch.int16)
+        node = CoreNeuronV25(leak_multi_mode=mode)
+
+        assert torch.equal(node.leak_multi_mode, mode)
+        assert node.leak_multi_mode is not mode
+        mode[0] = 1
+        assert torch.equal(node.leak_multi_mode, torch.tensor([0, 1], dtype=mode.dtype))
+
+    @pytest.mark.parametrize(
+        ("mode", "error", "message"),
+        [
+            (0, TypeError, "LeakMultiMode, bool"),
+            (torch.tensor([]), ValueError, "must not be empty"),
+            (torch.tensor([0.0, 1.0]), TypeError, "integer or bool dtype"),
+            (torch.tensor([0, 2]), ValueError, "values must be 0 or 1"),
+        ],
+    )
+    def test_leak_mode_rejects_invalid_values(self, mode, error, message):
+        with pytest.raises(error, match=message):
+            CoreNeuronV25(leak_multi_mode=mode)
+
+    def test_vector_mode_and_shift_require_the_same_shape(self):
+        with pytest.raises(ValueError, match="must have the same shape"):
             CoreNeuronV25(
-                leak_multi_mode=LeakMultiMode.DISABLE,
-                leak_tau_shift=torch.tensor([0, -1]),
+                leak_multi_mode=torch.tensor([0, 1]),
+                leak_tau_shift=torch.tensor([[0, -1]]),
             )
+
+    @pytest.mark.parametrize(
+        ("mode", "shift"),
+        [
+            (LeakMultiMode.DISABLE, torch.tensor([0, -1])),
+            (torch.tensor([0, 1]), 0),
+        ],
+    )
+    def test_scalar_mode_or_shift_allows_broadcasting(self, mode, shift):
+        CoreNeuronV25(leak_multi_mode=mode, leak_tau_shift=shift)
+
+    @pytest.mark.parametrize(
+        ("mode", "shift", "dynamics"),
+        [
+            (
+                torch.tensor([0, 0]),
+                torch.tensor([0, 0]),
+                (True, False, False),
+            ),
+            (
+                torch.tensor([1, 0]),
+                torch.tensor([0, -1]),
+                (False, True, False),
+            ),
+            (
+                torch.tensor([0, 0]),
+                torch.tensor([0, -1]),
+                (False, False, True),
+            ),
+            (
+                torch.tensor([1, 0]),
+                torch.tensor([0, 0]),
+                (False, False, True),
+            ),
+        ],
+        ids=("if", "lif", "mixed-shift", "mixed-mode"),
+    )
+    def test_vector_mode_and_shift_define_mutually_exclusive_dynamics(
+        self, mode, shift, dynamics
+    ):
+        node = CoreNeuronV25(
+            leak_multi_mode=mode,
+            leak_tau_shift=shift,
+        )
+
+        assert (
+            node.has_if_dynamics,
+            node.has_lif_dynamics,
+            node.has_mixed_dynamics,
+        ) == dynamics
+
+    def test_vector_leak_mode_is_compile_only(self):
+        node = CoreNeuronV25(leak_multi_mode=torch.tensor([0, 1]))
+
+        with pytest.raises(NotImplementedError, match="leak_multi_mode"):
+            node(torch.tensor([[1, 1]]))
+
+    @pytest.mark.parametrize("node", [IFNodeV25(), LIFNodeV25(), LeakyBeta0NodeV25()])
+    def test_convenience_nodes_keep_scalar_leak_mode(self, node):
+        assert isinstance(node.leak_multi_mode, LeakMultiMode)
 
     @pytest.mark.parametrize(
         "field",

--- a/tests/paiir/lowering/test_snntorch_leaky.py
+++ b/tests/paiir/lowering/test_snntorch_leaky.py
@@ -1,12 +1,14 @@
+import numpy as np
 import pytest
 import torch
-from paicorelib import RM
+from paicorelib import RM, DataSign, DataWidth, LeakMultiMode
 from torch import nn
 
-from paibox.backendv2.op_node import CoreOpNode
+from paibox.backendv2 import Mapper
+from paibox.exceptions import AutoOptimizationWarning
 from paibox.paiir import compile_to_paiir, torch_to_paiir
 from paibox.paiir.exceptions import UnsupportedOpError
-from paibox.paiir.ir.core_neuron import CoreNeuronV25, IFNodeV25
+from paibox.paiir.ir.core_neuron import CoreNeuronV25, IFNodeV25, LeakyBeta0NodeV25
 from paibox.paiir.ir.op_node import OfflineCoreOp, StandaloneActOp, StandaloneCompOp
 from tests.paiir.conftest import find_nodes, make_vec_8d
 
@@ -31,7 +33,6 @@ def _lowered_leaky_act(module: nn.Module) -> CoreNeuronV25:
     act_nodes = find_nodes(graph, StandaloneActOp)
     assert len(act_nodes) == 1
     act = act_nodes[0].act
-    assert isinstance(act, CoreNeuronV25)
     return act
 
 
@@ -55,14 +56,13 @@ def test_supported_reset_mechanisms_lower_to_expected_neuron(
     assert type(act) is expected_type
     assert act.reset_mode == reset_mode
     assert act.reset_v == 0
-    assert act.thres_pos == 2.0
+    assert act.thres_pos == 3
     assert act.leak_tau == 0
 
 
 @pytest.mark.parametrize(
     ("reset_mechanism", "reset_delay"),
     [
-        ("subtract", False),
         ("zero", False),
         ("zero", True),
         ("none", False),
@@ -77,9 +77,7 @@ def test_supported_subset_matches_snntorch_spikes(reset_mechanism, reset_delay):
         _leaky(reset_mechanism=reset_mechanism, reset_delay=reset_delay, threshold=1.0)
     )
     act.eval()
-    inputs = torch.tensor(
-        [[0.4, 0.8, 1.2, -0.3], [0.7, 0.15, 0.1, 1.5], [0.6, 0.6, 0.6, 0.2]]
-    )
+    inputs = torch.tensor([[0, 1, 2, -1], [1, 0, 0, 3], [2, 2, 0, 0]])
 
     snntorch_spikes = [leaky(x.unsqueeze(0)).to(torch.int8) for x in inputs]
     paiir_spikes = [act(x.unsqueeze(0)).to(torch.int8) for x in inputs]
@@ -105,7 +103,86 @@ def test_two_linear_leaky_blocks_lower_all_supported_frontend_ops():
         RM.MODE_NORMAL,
         RM.MODE_NONRESET,
     ]
-    assert [node.act.thres_pos for node in act_nodes] == [2.0, 3.0]
+    assert [node.act.thres_pos for node in act_nodes] == [3, 4]
+
+
+def test_subtract_reset_prioritizes_strict_spike_boundary():
+    leaky = _leaky(reset_mechanism="subtract", threshold=1.0)
+    with pytest.warns(AutoOptimizationWarning, match="maximum extra reset 1"):
+        act = _lowered_leaky_act(_leaky(reset_mechanism="subtract", threshold=1.0))
+
+    source_spike = leaky(torch.tensor([[1.0, 2.0]])).to(torch.int8)
+    target_spike = act(torch.tensor([[1.0, 2.0]])).to(torch.int8)
+
+    assert torch.equal(source_spike, target_spike)
+    assert act.thres_pos == 2
+    assert torch.equal(leaky.mem, torch.tensor([[1.0, 1.0]]))
+    assert torch.equal(act.v, torch.tensor([[1.0, 0.0]]))
+
+
+def test_vector_beta_lowers_to_per_neuron_mode_and_shift():
+    beta = torch.tensor([0.0, 0.5, 0.75, 1.0] * 2)
+    threshold = torch.arange(1.0, 9.0)
+
+    with pytest.warns(AutoOptimizationWarning, match="subtract reset"):
+        act = _lowered_leaky_act(_leaky(beta=beta, threshold=threshold))
+
+    assert type(act) is CoreNeuronV25
+    assert torch.equal(act.leak_multi_mode, torch.tensor([1, 0, 0, 0, 1, 0, 0, 0]))
+    assert torch.equal(act.leak_tau, torch.tensor([0, -1, -2, 0] * 2))
+    assert torch.equal(act.thres_pos, torch.arange(2, 10))
+    assert act.has_mixed_dynamics
+
+
+def test_all_beta_zero_uses_beta_zero_node():
+    act = _lowered_leaky_act(_leaky(beta=torch.zeros(8), reset_mechanism="zero"))
+
+    assert type(act) is LeakyBeta0NodeV25
+    assert act.has_lif_dynamics
+
+
+def test_all_beta_zero_nonreset_uses_equivalent_beta_zero_node():
+    act = _lowered_leaky_act(_leaky(beta=torch.zeros(8), reset_mechanism="none"))
+
+    assert type(act) is LeakyBeta0NodeV25
+    assert act.has_lif_dynamics
+
+
+def test_non_grid_beta_uses_nearest_positive_hardware_beta():
+    with pytest.warns(AutoOptimizationWarning, match="max absolute error"):
+        act = _lowered_leaky_act(
+            _leaky(beta=torch.full((8,), 0.1), reset_mechanism="zero")
+        )
+
+    assert torch.equal(act.leak_multi_mode, torch.zeros(8, dtype=torch.int64))
+    assert torch.equal(act.leak_tau, torch.full((8,), -1, dtype=torch.int64))
+
+
+def test_learning_metadata_does_not_affect_current_parameter_values():
+    module = _leaky(
+        beta=torch.full((8,), 0.5),
+        threshold=torch.arange(1.0, 9.0),
+        learn_beta=True,
+        learn_threshold=True,
+        reset_mechanism="zero",
+    )
+
+    act = _lowered_leaky_act(module)
+
+    assert torch.equal(act.leak_tau, torch.full((8,), -1, dtype=torch.int64))
+    assert torch.equal(act.thres_pos, torch.arange(2, 10))
+
+
+@pytest.mark.parametrize("field", ["beta", "threshold"])
+def test_conv_output_rejects_ambiguous_1d_leaky_parameters(field):
+    kwargs = {field: torch.tensor([0.5, 0.75])}
+    model = nn.Sequential(
+        nn.Conv2d(1, 2, kernel_size=3, bias=False),
+        _leaky(reset_mechanism="zero", **kwargs),
+    )
+
+    with pytest.raises(UnsupportedOpError, match="rank-2 Linear/per-feature"):
+        torch_to_paiir(model, torch.zeros(1, 1, 4, 4), strict=True)
 
 
 def test_state_quant_none_is_supported():
@@ -214,27 +291,33 @@ def test_unsupported_snntorch_neurons_are_frontend_hard_errors(module):
             "not equivalent for subtract reset",
             id="reset_delay",
         ),
-        pytest.param(_leaky(beta=0.5), "beta", "0.5", "beta != 1", id="beta_value"),
         pytest.param(
-            _leaky(beta=1.0, learn_beta=True),
+            _leaky(beta=torch.ones(2, 2)),
             "beta",
-            "Parameter",
-            "learnable or non-scalar",
-            id="learn_beta",
+            "shape=(2, 2)",
+            "scalar or 1D",
+            id="beta_rank",
         ),
         pytest.param(
-            _leaky(threshold=torch.ones(2)),
-            "threshold",
-            "Tensor",
-            "learnable or non-scalar",
-            id="threshold_tensor",
+            _leaky(beta=-0.1),
+            "beta",
+            "-0.1",
+            "values must be in [0, 1]",
+            id="beta_below_range",
         ),
         pytest.param(
-            _leaky(threshold=1.0, learn_threshold=True),
+            _leaky(beta=1.1),
+            "beta",
+            "1.1",
+            "values must be in [0, 1]",
+            id="beta_above_range",
+        ),
+        pytest.param(
+            _leaky(threshold=torch.ones(2, 2)),
             "threshold",
-            "Parameter",
-            "learnable or non-scalar",
-            id="learn_threshold",
+            "shape=(2, 2)",
+            "scalar or 1D",
+            id="threshold_rank",
         ),
         pytest.param(
             _leaky(output=True),
@@ -288,13 +371,21 @@ def test_unsupported_leaky_configs_report_field_value_and_reason(
     assert reason in message
 
 
-def test_linear_leaky_compile_preserves_neuron_attrs_for_backendv2():
+def test_linear_leaky_compiles_and_exports_with_vector_neuron_attrs(tmp_path):
+    beta = torch.tensor([0.0, 0.5, 0.75, 1.0])
+    threshold = torch.tensor([1.0, 2.0, 3.0, 4.0])
     model = nn.Sequential(
         nn.Linear(8, 4, bias=False),
-        _leaky(reset_mechanism="subtract", threshold=2.0),
+        _leaky(reset_mechanism="subtract", threshold=threshold, beta=beta),
     )
 
-    graph = compile_to_paiir(model, make_vec_8d(), strict=True)
+    with pytest.warns(AutoOptimizationWarning, match="subtract reset"):
+        graph = compile_to_paiir(
+            model,
+            make_vec_8d(),
+            input_formats={"InputNode_0": (DataSign.SIGNED, DataWidth.WIDTH_8BIT)},
+            strict=True,
+        )
     cores = find_nodes(graph, OfflineCoreOp)
     sequentials = [
         node
@@ -303,9 +394,28 @@ def test_linear_leaky_compile_preserves_neuron_attrs_for_backendv2():
     ]
     assert len(sequentials) == 1
 
-    attrs = CoreOpNode(
-        "snntorch_leaky", sequentials[0], torch.Size((1, 4))
-    ).attrs_part2()
-    assert RM(attrs.reset_mode) == RM.MODE_LINEAR
-    assert attrs.threshold_pos == 2
-    assert attrs.leak_tau == 0
+    mapper = Mapper()
+    mapper.compile(graph, tmp_path, target_platform="x86", debug=False)
+    placements = sorted(
+        (
+            placement
+            for core in mapper.coreplacements
+            for placement in core.neus
+            if len(placement.raw_neus) == 1
+            and placement.raw_neus[0].target.name == sequentials[0].name
+        ),
+        key=lambda placement: placement.raw_neus[0].index.idx,
+    )
+    attrs = [placement.neu_attrs_part2 for placement in placements]
+    assert len(attrs) == 4
+    assert [RM(item.reset_mode) for item in attrs] == [RM.MODE_LINEAR] * 4
+    assert [item.threshold_pos for item in attrs] == [2, 3, 4, 5]
+    assert [item.leak_multi_mode for item in attrs] == [
+        LeakMultiMode.ENABLE,
+        LeakMultiMode.DISABLE,
+        LeakMultiMode.DISABLE,
+        LeakMultiMode.DISABLE,
+    ]
+    assert [item.leak_tau for item in attrs] == [0, -1, -2, 0]
+
+    assert np.load(tmp_path / "cfg_frames.npy").size > 0

--- a/tests/paiir/pipeline/avgpool/test_utils.py
+++ b/tests/paiir/pipeline/avgpool/test_utils.py
@@ -1,15 +1,40 @@
+import pytest
 import torch
 from torch import nn
 
+from paibox.paiir import CoreNeuronV25
 from paibox.paiir.nn import SumPool1d, SumPool2d
 from paibox.paiir.pipeline.avgpool.utils import (
     build_sum_pool,
     get_avgpool_divisor,
     get_pool_window_size,
+    require_scalar_avgpool_neuron_params,
 )
 
 
 class TestAvgPoolUtils:
+    @pytest.mark.parametrize(
+        ("act", "match"),
+        [
+            pytest.param(
+                CoreNeuronV25(leak_multi_mode=torch.tensor([1, 1]), leak_tau_shift=0),
+                "leak_multi_mode",
+                id="vector-mode",
+            ),
+            pytest.param(
+                CoreNeuronV25(
+                    leak_multi_mode=torch.tensor([0, 1]),
+                    leak_tau_shift=torch.tensor([0, -1]),
+                ),
+                "mixed IF/LIF",
+                id="mixed-dynamics",
+            ),
+        ],
+    )
+    def test_rejects_vector_or_mixed_neuron_dynamics(self, act, match):
+        with pytest.raises(ValueError, match=match):
+            require_scalar_avgpool_neuron_params(act)
+
     def test_avgpool_divisor_can_differ_from_window_size(self):
         pool = nn.AvgPool2d(2, divisor_override=1)
         assert get_pool_window_size(pool) == 4

--- a/tests/paiir/pipeline/test_neuron_param_materialization.py
+++ b/tests/paiir/pipeline/test_neuron_param_materialization.py
@@ -124,6 +124,53 @@ def test_rejects_non_integer_leak_tau(value):
         materialize_neuron_params(_graph_with(node))
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(
+            torch.tensor([False, True]),
+            torch.tensor([False, False, True, True]),
+            id="bool-per-channel",
+        ),
+        pytest.param(
+            torch.tensor([0, 1], dtype=torch.int32),
+            torch.tensor([0, 0, 1, 1], dtype=torch.int32),
+            id="integer-per-channel",
+        ),
+        pytest.param(torch.tensor(1), 1, id="zero-dimensional"),
+    ],
+)
+def test_materializes_leak_multi_mode(value, expected):
+    node = _ParamOp(NeuronParams(leak_multi_mode=value))
+    _set_output_shape(node, (1, 2, 2))
+
+    materialize_neuron_params(_graph_with(node))
+
+    actual = node.neu_params.leak_multi_mode
+    if torch.is_tensor(expected):
+        assert torch.equal(actual, expected)
+        assert actual.shape == (4,)
+    else:
+        assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "error", "match"),
+    [
+        pytest.param(
+            torch.tensor([0.0, 1.0]), TypeError, "integer or bool", id="float"
+        ),
+        pytest.param(torch.tensor([0, 2]), ValueError, "0 or 1", id="out-of-range"),
+    ],
+)
+def test_rejects_invalid_leak_multi_mode(value, error, match):
+    node = _ParamOp(NeuronParams(leak_multi_mode=value))
+    _set_output_shape(node, (1, 2))
+
+    with pytest.raises(error, match=match):
+        materialize_neuron_params(_graph_with(node))
+
+
 def test_rank_one_output_materializes_one_logical_neuron():
     node = _ParamOp(NeuronParams(thres_pos=torch.tensor([7])))
     _set_output_shape(node, (1,))

--- a/tests/paiir/test_nir_exchange.py
+++ b/tests/paiir/test_nir_exchange.py
@@ -5,6 +5,7 @@ from torch import nn
 
 from paibox.paiir.exceptions import UnsupportedNIRNodeError
 from paibox.paiir.ir import (
+    CoreNeuronV25,
     IFNodeV25,
     InputNode,
     LeakyBeta0NodeV25,
@@ -469,11 +470,29 @@ def test_export_nir_rejects_soft_reset():
         export_to_nir(_manual_linear_if_paiir_graph(soft_reset=True), dt=1e-4)
 
 
-def test_export_nir_rejects_vector_neuron_parameters():
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        pytest.param("reset_v", torch.tensor([0.0, 0.0]), id="reset-v"),
+        pytest.param("leak_multi_mode", torch.tensor([1, 1]), id="leak-mode"),
+    ],
+)
+def test_export_nir_rejects_vector_neuron_parameters(field, value):
     graph = _manual_linear_if_paiir_graph()
-    graph.nodes["if"].act.reset_v = torch.tensor([0.0, 0.0])
+    setattr(graph.nodes["if"].act, field, value)
 
     with pytest.raises(UnsupportedNIRNodeError, match="vector neuron parameters"):
+        export_to_nir(graph, dt=1e-4)
+
+
+def test_export_nir_rejects_mixed_neuron_dynamics():
+    graph = _manual_linear_if_paiir_graph()
+    graph.nodes["if"].act = CoreNeuronV25(
+        leak_multi_mode=torch.tensor([0, 1]),
+        leak_tau_shift=torch.tensor([0, -1]),
+    )
+
+    with pytest.raises(UnsupportedNIRNodeError, match="mixed IF/LIF"):
         export_to_nir(graph, dt=1e-4)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1480,6 +1480,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-md" },
     { name = "pytest-xdist" },
+    { name = "snntorch" },
     { name = "spikingjelly" },
     { name = "tabulate" },
     { name = "torch", version = "2.1.2", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version < '3.12' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform == 'darwin')" },
@@ -1498,8 +1499,8 @@ requires-dist = [
     { name = "paicorelib", marker = "platform_machine != 'armv7l'", specifier = ">=2.0.0" },
     { name = "protobuf", specifier = ">=5.27.1,<7" },
     { name = "rich", specifier = ">=14.0.0" },
-    { name = "snntorch", marker = "extra == 'snntorch'", specifier = ">=0.9.0" },
-    { name = "spikingjelly", marker = "extra == 'spikingjelly'", specifier = ">=0.0.0.0.12" },
+    { name = "snntorch", marker = "extra == 'snntorch'", specifier = ">=0.9.4,<2" },
+    { name = "spikingjelly", marker = "extra == 'spikingjelly'", specifier = ">=0.0.0.0.12,<1" },
     { name = "uvicorn", marker = "extra == 'visualizer'", specifier = ">=0.38.0,<1" },
 ]
 provides-extras = ["visualizer", "snntorch", "spikingjelly", "nir"]
@@ -1514,7 +1515,8 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0" },
     { name = "pytest-md", specifier = ">=0.2" },
     { name = "pytest-xdist", specifier = ">=3.7.0" },
-    { name = "spikingjelly", specifier = ">=0.0.0.0.12" },
+    { name = "snntorch", specifier = ">=0.9.4,<2" },
+    { name = "spikingjelly", specifier = ">=0.0.0.0.12,<1" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "torch", marker = "python_full_version < '3.12'", specifier = ">=2.0.0,<2.2.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torch", marker = "python_full_version >= '3.12'", specifier = ">=2.2.0", index = "https://download.pytorch.org/whl/cpu" },
@@ -2249,11 +2251,11 @@ wheels = [
 
 [[package]]
 name = "snntorch"
-version = "0.9.4"
+version = "1.0.0"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
-sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/53/a7/ce6eec2007d505612bc2bfc297d05daf9e507748d7d4a2406cae0d2a5e32/snntorch-0.9.4.tar.gz", hash = "sha256:eaa0dd46675c471bf0b616068ee777564377bcb46b2104840a4ff4332de01909", size = 95103, upload-time = "2025-02-16T21:26:01.332Z" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/05/84564a9468c09f6501213eeb4a5c76f35eb82a5c3e1981005e5dba79cd13/snntorch-1.0.0.tar.gz", hash = "sha256:93c33506a5975c1d0d2387a130def02382789197314cefb2c70511b05a03536e", size = 101429, upload-time = "2026-06-29T13:30:14.765Z" }
 wheels = [
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e0/a6/c9ca7a9a335a302694f0a86d5235fcba797283f94d5cd835e1dc8efdc905/snntorch-0.9.4-py2.py3-none-any.whl", hash = "sha256:34805e8d9d3d50fa8d28eb8ee715d9196a4db115cefe497e026b3ce1b7884388", size = 125619, upload-time = "2025-02-16T21:25:59.057Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/82/bc/38ad8a5fc17dfbfc62cbf896c11e71f20376b4cd57e204325e6c1578dcbb/snntorch-1.0.0-py2.py3-none-any.whl", hash = "sha256:b5a85f6f44c6d27c8a1dcea16cb18a630d00b8d2f3cfec85b7e580cb177e606b", size = 133558, upload-time = "2026-06-29T13:30:13.384Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Vectorize `leak_multi_mode` to represent mixed IF, LIF, and complete-leak dynamics in one neuron node.
- Lower scalar and vector `snnTorch.Leaky` beta and threshold parameters into deployable PAICORE neuron parameters.
- Support snnTorch versions from 0.9.4 through 1.x.
