### PR TITLE
feat(backendv2): support compiling independent PAICORE subgraphs

### DIFF
--- a/paibox/backendv2/artifacts/compile_artifacts.py
+++ b/paibox/backendv2/artifacts/compile_artifacts.py
@@ -405,14 +405,9 @@ def _thread_decode_mode(output_groups: Sequence[OutputGroup], timesteps: int) ->
     """Derive STREAM/STEP from the final output LCN timestep capacity."""
     if not output_groups:
         return DECODE_MODE_STREAM
-    if len(output_groups) != 1:
-        raise NotImplementedError(
-            "RuntimeParams export currently supports one OutputGroup per thread."
-        )
-
-    out_grp = output_groups[0]
-    ts_width = 8 - int(out_grp.lcn.value)
-    max_stream_timesteps = 1 << ts_width
+    max_stream_timesteps = min(
+        1 << (8 - out_grp.lcn.value) for out_grp in output_groups
+    )
     return DECODE_MODE_STREAM if max_stream_timesteps >= timesteps else DECODE_MODE_STEP
 
 

--- a/paibox/backendv2/compile_plan.py
+++ b/paibox/backendv2/compile_plan.py
@@ -36,14 +36,11 @@ def build_subgraph_compile_plan(
     for index, source in enumerate(graphs):
         if not isinstance(source, PAIIRGraph):
             raise TypeError(
-                f"subgraphs[{index}] must be a PAIIRGraph, "
-                f"got {type(source).__name__}"
+                f"subgraphs[{index}] must be a PAIIRGraph, got {type(source).__name__}"
             )
         source.lint()
         unsupported = [
-            node.name
-            for node in source.nodes.values()
-            if isinstance(node, CPUOp)
+            node.name for node in source.nodes.values() if isinstance(node, CPUOp)
         ]
         if unsupported:
             raise ValueError(

--- a/paibox/backendv2/compile_plan.py
+++ b/paibox/backendv2/compile_plan.py
@@ -1,0 +1,108 @@
+"""Planning helpers for caller-partitioned pure PAICORE subgraphs."""
+
+from collections.abc import Sequence
+from copy import deepcopy
+from dataclasses import dataclass
+
+from paibox.paiir.ir import CPUOp, InputNode, OfflineCoreOp, PAIIRGraph
+
+
+@dataclass(frozen=True, slots=True)
+class SubgraphCompilePlan:
+    """One namespaced graph and the prefixes assigned to its source graphs."""
+
+    graph: PAIIRGraph
+    prefixes: tuple[str, ...]
+
+
+def build_subgraph_compile_plan(
+    subgraphs: Sequence[PAIIRGraph], timesteps: int, auto_reset: bool
+) -> SubgraphCompilePlan:
+    """Combine independent pure PAICORE graphs without mutating their nodes.
+
+    Graph order defines execution order. Each source graph is deep-copied and
+    receives a ``gN/`` name prefix so its I/O and core metadata remain distinct
+    in the exported artifact.
+    """
+    graphs = tuple(subgraphs)
+    if not graphs:
+        raise ValueError("'subgraphs' must contain at least one graph")
+    if timesteps <= 0:
+        raise ValueError(f"'timesteps' must be positive, got {timesteps}")
+
+    combined = PAIIRGraph("subgraphs")
+    prefixes: list[str] = []
+    base_tick = 0
+    for index, source in enumerate(graphs):
+        if not isinstance(source, PAIIRGraph):
+            raise TypeError(
+                f"subgraphs[{index}] must be a PAIIRGraph, "
+                f"got {type(source).__name__}"
+            )
+        source.lint()
+        unsupported = [
+            node.name
+            for node in source.nodes.values()
+            if isinstance(node, CPUOp)
+        ]
+        if unsupported:
+            raise ValueError(
+                f"subgraphs[{index}] must be pure PAICORE; found {unsupported}"
+            )
+
+        prefix = f"g{index}/"
+        prefixes.append(prefix)
+        names = {name: f"{prefix}{name}" for name in source.nodes}
+        for name, node in source.nodes.items():
+            copied = deepcopy(node)
+            copied.name = names[name]
+            combined.add_node(copied)
+        for edge in source.edges:
+            combined.add_edge(
+                names[edge.src],
+                names[edge.dst],
+                src_port=edge.src_port,
+                dst_port=edge.dst_port,
+            )
+
+        base_tick = _assign_timing(
+            combined,
+            tuple(names.values()),
+            base_tick,
+            timesteps,
+            auto_reset,
+        )
+
+    return SubgraphCompilePlan(combined, tuple(prefixes))
+
+
+def _assign_timing(
+    graph: PAIIRGraph,
+    names: tuple[str, ...],
+    base_tick: int,
+    timesteps: int,
+    auto_reset: bool,
+) -> int:
+    name_set = set(names)
+    depth: dict[str, int] = {}
+    max_tick = base_tick
+    for name in graph.topo_sort():
+        if name not in name_set:
+            continue
+        node = graph.nodes[name]
+        if isinstance(node, InputNode):
+            depth[name] = base_tick
+            continue
+        pred_depth = max(
+            (depth.get(pred, base_tick) for pred in graph.predecessors(name)),
+            default=base_tick,
+        )
+        node_depth = pred_depth + node.__tick_depth__
+        depth[name] = node_depth
+        if isinstance(node, OfflineCoreOp):
+            node.core_params.tick_start = node_depth
+            node.core_params.tick_duration = 0 if auto_reset else timesteps
+            node.core_params.tick_initial = timesteps if auto_reset else 0
+            node.core_params.validate_tick_params()
+            max_tick = max(max_tick, node_depth)
+    return max_tick

--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal
 
@@ -20,6 +21,7 @@ from .artifacts.utils import (
     make_frame_records,
     resolve_platform_exports,
 )
+from .compile_plan import build_subgraph_compile_plan
 from .coreplacement import (
     CorePlacement,
     EmptyOfflineCorePlacementV2,
@@ -111,6 +113,18 @@ class Mapper:
                 )
 
         return resolved
+
+    def _reset_compile_state(self) -> None:
+        """Discard placement state so one Mapper can compile another graph."""
+        self.groups = []
+        self.routing_groups = []
+        self.next_rg_group = {}
+        self.nodes = []
+        self.output_groups = []
+        self.input_groups = []
+        self.coreplacements = []
+        self.global_starts = {}
+        self.output_completion_plan = None
 
     def generate_routing_groups(self, pai_graph: PAIIRGraph) -> None:
         self.nodes = build_nodes(pai_graph)
@@ -360,6 +374,7 @@ class Mapper:
         literal_format: LiteralFormat = "bin",
         *,
         timesteps: int | None = None,
+        auto_reset: bool | None = None,
         target_board: TargetBoard = "single",
         target_platform: TargetPlatform = "all",
         word_order: WordOrder = "high_first",
@@ -439,11 +454,18 @@ class Mapper:
                 ``"fanin_margin"`` is a conservative fallback that reserves one
                 fanin slot during tiling and avoids generating the boundary case.
         """
+        self._reset_compile_state()
         self.route_scope = get_route_scope(target_board)
         self.timesteps = self._resolve_timesteps(pai_graph, timesteps)
 
         # determine raw_neus in routing groups, other properties remain unset
         self.generate_routing_groups(pai_graph)
+
+        for node in pai_graph.nodes.values():
+            if auto_reset is not None and isinstance(node, OfflineCoreOp):
+                node.core_params.tick_duration = 0 if auto_reset else self.timesteps
+                node.core_params.tick_initial = self.timesteps if auto_reset else 0
+                node.core_params.validate_tick_params()
 
         all_groups: list[RoutingGroup | InputGroup | OutputGroup | RemapGroup] = []
         all_groups.extend(self.input_groups)
@@ -545,4 +567,64 @@ class Mapper:
             export_merged_frames,
             export_proto_python,
             debug,
+        )
+
+    def compile_subgraphs(
+        self,
+        subgraphs: Sequence[PAIIRGraph],
+        output_path: str | Path | None = None,
+        literal_format: LiteralFormat = "bin",
+        *,
+        timesteps: int | None = None,
+        auto_reset: bool = True,
+        target_board: TargetBoard = "single",
+        target_platform: TargetPlatform = "all",
+        word_order: WordOrder = "high_first",
+        export_merged_frames: bool = True,
+        export_proto_python: bool = True,
+        debug: bool = False,
+        unrolling: bool = False,
+        unroll_max_try: int = 4,
+        unroll_max_factor: int | None = 2,
+        unroll_core_selection: Literal["peak_ratio", "quantile"] = "peak_ratio",
+        unroll_peak_ratio: float = 0.8,
+        unroll_quantile: float = 0.5,
+        allow_empty_online_relay_core: bool = False,
+        csc_tail_overflow_fix: Literal[
+            "weight_indice_padding", "fanin_margin"
+        ] = "weight_indice_padding",
+    ) -> None:
+        """Compile caller-partitioned pure PAICORE graphs as one artifact set."""
+        graphs = tuple(subgraphs)
+        if not graphs:
+            raise ValueError("'subgraphs' must contain at least one graph")
+        if timesteps is None:
+            inferred = {self._resolve_timesteps(graph, None) for graph in graphs}
+            if len(inferred) != 1:
+                raise ValueError(
+                    "subgraphs must use one common timestep count; "
+                    f"found {sorted(inferred)}"
+                )
+            timesteps = inferred.pop()
+        plan = build_subgraph_compile_plan(graphs, timesteps, auto_reset)
+        self.compile(
+            plan.graph,
+            output_path,
+            literal_format,
+            timesteps=timesteps,
+            auto_reset=auto_reset,
+            target_board=target_board,
+            target_platform=target_platform,
+            word_order=word_order,
+            export_merged_frames=export_merged_frames,
+            export_proto_python=export_proto_python,
+            debug=debug,
+            unrolling=unrolling,
+            unroll_max_try=unroll_max_try,
+            unroll_max_factor=unroll_max_factor,
+            unroll_core_selection=unroll_core_selection,
+            unroll_peak_ratio=unroll_peak_ratio,
+            unroll_quantile=unroll_quantile,
+            allow_empty_online_relay_core=allow_empty_online_relay_core,
+            csc_tail_overflow_fix=csc_tail_overflow_fix,
         )

--- a/tests/backendv2/test_subgraph_compile.py
+++ b/tests/backendv2/test_subgraph_compile.py
@@ -38,7 +38,9 @@ def test_subgraph_plan_namespaces_without_mutating_sources() -> None:
     assert plan.prefixes == ("g0/", "g1/")
     assert all(name.startswith(("g0/", "g1/")) for name in plan.graph.nodes)
 
-    core_nodes = [node for node in plan.graph.nodes.values() if hasattr(node, "core_params")]
+    core_nodes = [
+        node for node in plan.graph.nodes.values() if hasattr(node, "core_params")
+    ]
     assert [node.core_params.tick_start for node in core_nodes] == [1, 2]
     assert all(node.core_params.tick_duration == 0 for node in core_nodes)
     assert all(node.core_params.tick_initial == 2 for node in core_nodes)

--- a/tests/backendv2/test_subgraph_compile.py
+++ b/tests/backendv2/test_subgraph_compile.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+from paibox.backendv2 import Mapper
+from paibox.backendv2.compile_plan import build_subgraph_compile_plan
+from paibox.backendv2.generated.proto.compile_artifacts_pb2 import CompileArtifacts
+from paibox.paiir import LIFNodeV25, PAIIRGraph, compile_to_paiir
+from paibox.paiir.ir import CPUOp, InputNode, OutputNode
+
+
+class _LinearLIF(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(3, 2)
+        self.neuron = LIFNodeV25(tau=2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.neuron(self.linear(x))
+
+
+def _graph() -> PAIIRGraph:
+    return compile_to_paiir(_LinearLIF().eval(), torch.zeros(1, 3), timesteps=2)
+
+
+def test_subgraph_plan_namespaces_without_mutating_sources() -> None:
+    first = _graph()
+    second = _graph()
+    first_names = tuple(first.nodes)
+    second_names = tuple(second.nodes)
+
+    plan = build_subgraph_compile_plan((first, second), timesteps=2, auto_reset=True)
+
+    assert tuple(first.nodes) == first_names
+    assert tuple(second.nodes) == second_names
+    assert plan.prefixes == ("g0/", "g1/")
+    assert all(name.startswith(("g0/", "g1/")) for name in plan.graph.nodes)
+
+    core_nodes = [node for node in plan.graph.nodes.values() if hasattr(node, "core_params")]
+    assert [node.core_params.tick_start for node in core_nodes] == [1, 2]
+    assert all(node.core_params.tick_duration == 0 for node in core_nodes)
+    assert all(node.core_params.tick_initial == 2 for node in core_nodes)
+
+
+def test_subgraph_plan_rejects_cpu_nodes() -> None:
+    graph = PAIIRGraph("cpu")
+    input_node = InputNode(torch.Size([1]))
+    cpu_node = CPUOp()
+    output_node = OutputNode(torch.Size([1]))
+    graph.add_node(input_node)
+    graph.add_node(cpu_node)
+    graph.add_node(output_node)
+    graph.add_edge(input_node.name, cpu_node.name)
+    graph.add_edge(cpu_node.name, output_node.name)
+
+    with pytest.raises(ValueError, match="pure PAICORE"):
+        build_subgraph_compile_plan((graph,), timesteps=1, auto_reset=True)
+
+
+def test_mapper_exports_multiple_namespaced_subgraphs(tmp_path: Path) -> None:
+    Mapper().compile_subgraphs(
+        (_graph(), _graph()),
+        tmp_path,
+        target_platform="x86",
+        export_merged_frames=False,
+        export_proto_python=False,
+    )
+
+    artifacts = CompileArtifacts()
+    artifacts.ParseFromString((tmp_path / "proto" / "config.pb").read_bytes())
+    thread = artifacts.io_mapping.threads[0]
+    input_names = {item.name for item in thread.input_mappings.items}
+    assert len(input_names) == 2
+    assert {name.split("/", 1)[0] for name in input_names} == {"g0", "g1"}
+    assert thread.runtime.timesteps == 2
+    assert thread.runtime.tick_depth == 2


### PR DESCRIPTION
## Summary

- Add planning support for combining caller-partitioned pure PAICORE subgraphs.
- Namespace each subgraph to prevent node and I/O mapping collisions.
- Add `Mapper.compile_subgraphs()` with sequential tick assignment and shared artifact export.
- Support multiple output groups when deriving runtime decode mode.
- Add tests covering source graph isolation, CPU node rejection, and protobuf export.