### PR TITLE
fix(paiir): preserve stateless standalone potential execution

### DIFF
--- a/paibox/backendv2/mapper.py
+++ b/paibox/backendv2/mapper.py
@@ -458,14 +458,14 @@ class Mapper:
         self.route_scope = get_route_scope(target_board)
         self.timesteps = self._resolve_timesteps(pai_graph, timesteps)
 
-        # determine raw_neus in routing groups, other properties remain unset
-        self.generate_routing_groups(pai_graph)
-
         for node in pai_graph.nodes.values():
             if auto_reset is not None and isinstance(node, OfflineCoreOp):
                 node.core_params.tick_duration = 0 if auto_reset else self.timesteps
                 node.core_params.tick_initial = self.timesteps if auto_reset else 0
                 node.core_params.validate_tick_params()
+
+        # determine raw_neus in routing groups, other properties remain unset
+        self.generate_routing_groups(pai_graph)
 
         all_groups: list[RoutingGroup | InputGroup | OutputGroup | RemapGroup] = []
         all_groups.extend(self.input_groups)

--- a/paibox/paiir/ir/calc_params.py
+++ b/paibox/paiir/ir/calc_params.py
@@ -211,6 +211,9 @@ class NeuronParams:
     Full configuration of an offline-core neuron, corresponding 1:1 to
     :class:`~paibox.paiir.ir.core_neuron.CoreNeuronV25` attributes.  The backend maps
     these to chip-specific register layouts.
+
+    Default dynamics model a stateless compute-only core. The owning IR node
+    selects the output type; explicit neuron operators provide all dynamics.
     """
 
     __vectorized_attrs__: ClassVar[tuple[str, ...]] = (
@@ -225,9 +228,9 @@ class NeuronParams:
 
     reset_mode: RM = RM.MODE_NORMAL
     reset_v: float | Tensor = 0.0
-    thres_neg_mode: ThresholdNegMode = ThresholdNegMode.FLOOR
+    thres_neg_mode: ThresholdNegMode = ThresholdNegMode.FIRE
     thres_pos_mode: ThresholdPosMode = ThresholdPosMode.FIRE
-    thres_neg: float | Tensor = DEFAULT_NEG_THRESHOLD
+    thres_neg: float | Tensor = 0.0
     thres_pos: float | Tensor = 0.0
     lateral_inhi: LateralInhibitionMode = LateralInhibitionMode.DISABLE
     leak_multi_sequence: LeakMultiComparisonOrder = (

--- a/tests/backendv2/test_mapper.py
+++ b/tests/backendv2/test_mapper.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 from paicorelib import (
     LCN_EX,
+    RM,
     CoordXY,
     CoordZXYOffset,
     CSCAccelerateMode,
@@ -14,6 +15,8 @@ from paicorelib import (
     LeakMultiMode,
     NeuronType,
     OfflineNeuRegLimV2,
+    ThresholdNegMode,
+    ThresholdPosMode,
     WeightCompressType,
     find_coordxy_shortest_path,
 )
@@ -401,6 +404,51 @@ def test_mapper_compiles_flat_vector_neuron_parameters(tmp_path, ann):
     assert [p.neu_attrs_part2.threshold_pos for p in placements] == [4, 5, 6, 7]
     assert [p.neu_attrs_part2.leak_tau for p in placements] == [0, -1, -2, -3]
     assert [p.neu_attrs_part2.leak_v for p in placements] == [8, 9, 10, 11]
+
+
+def test_mapper_applies_auto_reset_before_core_placement(tmp_path):
+    linear = nn.Linear(3, 2)
+    graph = compile_to_paiir(
+        linear.eval(),
+        torch.zeros(1, 3),
+        input_formats={"InputNode_0": (DataSign.SIGNED, DataWidth.WIDTH_8BIT)},
+        timesteps=3,
+        auto_reset=True,
+    )
+    mapper = Mapper()
+    mapper.compile(
+        graph,
+        tmp_path,
+        target_platform="x86",
+        auto_reset=False,
+        debug=False,
+    )
+
+    core = mapper.coreplacements[0]
+
+    assert mapper.timesteps == 3
+    assert core.frontend_core_config.tick_duration == 3
+    assert core.frontend_core_config.tick_initial == 0
+
+
+def test_mapper_preserves_standalone_potential_reset_config(tmp_path):
+    graph = compile_to_paiir(
+        nn.Linear(3, 2).eval(),
+        torch.zeros(1, 3),
+        input_formats={"InputNode_0": (DataSign.SIGNED, DataWidth.WIDTH_8BIT)},
+    )
+    mapper = Mapper()
+    mapper.compile(graph, tmp_path, target_platform="x86", debug=False)
+
+    attrs = mapper.coreplacements[0].neus[0].neu_attrs_part2
+
+    assert attrs is not None
+    assert attrs.reset_mode == RM.MODE_NORMAL.value
+    assert attrs.reset_v == 0
+    assert attrs.threshold_neg_mode == ThresholdNegMode.FIRE.value
+    assert attrs.threshold_pos_mode == ThresholdPosMode.FIRE.value
+    assert attrs.threshold_neg == 0
+    assert attrs.threshold_pos == 0
 
 
 def test_mapper_vector_mode_controls_part2_and_half_reuse(tmp_path):

--- a/tests/paiir/ir/test_op_node.py
+++ b/tests/paiir/ir/test_op_node.py
@@ -45,6 +45,16 @@ from paibox.paiir.pipeline.passes import _infer_node_weight_format
 
 
 class TestNodeCapabilities:
+    def test_neuron_params_default_to_stateless_potential(self):
+        params = NeuronParams()
+
+        assert params.reset_mode == RM.MODE_NORMAL
+        assert params.reset_v == 0
+        assert params.thres_neg_mode == ThresholdNegMode.FIRE
+        assert params.thres_pos_mode == ThresholdPosMode.FIRE
+        assert params.thres_neg == 0
+        assert params.thres_pos == 0
+
     def test_routing_nodes_declare_format_flow_and_zero_tick_depth(self):
         routing_nodes = [TransformOp(), PadOp((1, 1)), SplitOp(sections=2, dim=1)]
 
@@ -259,6 +269,17 @@ class TestWeights:
 
         op.signal_semantics.output_domain = SignalDomain.POTENTIAL
         assert op.src_params()[0].output_type == OutputType.POTENTIAL
+
+    @pytest.mark.parametrize("comp", [nn.Linear(4, 2), nn.Conv2d(1, 2, 1)])
+    def test_standalone_comp_potential_defaults_reset_every_tick(self, comp):
+        params, _ = StandaloneCompOp(comp).src_params()
+
+        assert params.reset_mode == RM.MODE_NORMAL
+        assert params.reset_v == 0
+        assert params.thres_neg_mode == ThresholdNegMode.FIRE
+        assert params.thres_pos_mode == ThresholdPosMode.FIRE
+        assert params.thres_neg == 0
+        assert params.thres_pos == 0
 
     def test_add_op_returns_none(self):
         op = PotentialAddOp(op_signs=(1, -1))

--- a/tests/paiir/pipeline/test_compile.py
+++ b/tests/paiir/pipeline/test_compile.py
@@ -4,7 +4,13 @@ from collections.abc import Callable
 import pytest
 import torch
 import torch.nn.functional as F
-from paicorelib import DataSign, DataWidth
+from paicorelib import (
+    RM,
+    DataSign,
+    DataWidth,
+    ThresholdNegMode,
+    ThresholdPosMode,
+)
 from spikingjelly.activation_based import layer as sj_layer
 from spikingjelly.activation_based import neuron as sj
 from torch import Tensor, nn
@@ -13,6 +19,7 @@ import paibox.paiir.pipeline.avgpool.fusion as avgpool_fusion
 import paibox.paiir.pipeline.compile as compile_mod
 from paibox.paiir import (
     CompileConfig,
+    CoreNeuronV25,
     LIFNodeV25,
     compile_to_paiir,
     register_module,
@@ -793,6 +800,47 @@ class TestTickParams:
         for node in offline_nodes(graph):
             assert node.core_params.tick_duration == expected_duration
             assert node.core_params.tick_initial == expected_initial
+
+    @pytest.mark.parametrize(
+        ("auto_reset", "expected_duration"),
+        [(True, 0), (False, 3)],
+    )
+    def test_standalone_potential_resets_every_tick(
+        self, auto_reset, expected_duration
+    ):
+        linear = nn.Linear(3, 2)
+        graph = compile_to_paiir(
+            linear.eval(),
+            torch.zeros(1, 3),
+            input_formats={"InputNode_0": (DataSign.SIGNED, DataWidth.WIDTH_8BIT)},
+            timesteps=3,
+            auto_reset=auto_reset,
+        )
+        node = next(
+            node for node in graph.nodes.values() if isinstance(node, StandaloneCompOp)
+        )
+
+        assert node.core_params.tick_duration == expected_duration
+        assert node.core_params.tick_initial == (3 if auto_reset else 0)
+        assert node.neu_params.reset_mode == RM.MODE_NORMAL
+        assert node.neu_params.reset_v == 0
+        assert node.neu_params.thres_neg_mode == ThresholdNegMode.FIRE
+        assert node.neu_params.thres_pos_mode == ThresholdPosMode.FIRE
+        assert node.neu_params.thres_neg == 0
+        assert node.neu_params.thres_pos == 0
+
+        neuron = CoreNeuronV25(
+            reset_mode=node.neu_params.reset_mode,
+            reset_v=node.neu_params.reset_v,
+            thres_neg_mode=node.neu_params.thres_neg_mode,
+            thres_pos_mode=node.neu_params.thres_pos_mode,
+            thres_neg=node.neu_params.thres_neg,
+            thres_pos=node.neu_params.thres_pos,
+        ).eval()
+        neuron(torch.tensor([[5.0, -5.0]]))
+        assert torch.equal(neuron.v, torch.zeros(1, 2))
+        neuron(torch.tensor([[-2.0, 2.0]]))
+        assert torch.equal(neuron.v, torch.zeros(1, 2))
 
     @pytest.mark.parametrize("timesteps", [0, -1], ids=["zero", "negative"])
     def test_invalid_timesteps_raises(self, timesteps):


### PR DESCRIPTION
## Summary
* Make default PAICORE potential dynamics stateless for compute-only operators, while preserving explicit IF/LIF/LUT parameters. Apply Mapper auto_reset before core placement so exported timing matches the requested lifecycle.